### PR TITLE
fix: CI/CD auto-deploy + remove broken Optuna optimizer URL

### DIFF
--- a/.github/workflows/daily-trade-review-claude.yml
+++ b/.github/workflows/daily-trade-review-claude.yml
@@ -254,7 +254,10 @@ jobs:
       - name: Auto-merge small daily-review PRs
         if: always() && steps.gather.outputs.data_collected == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Use a PAT instead of github.token so the merge push triggers
+          # downstream workflows (deploy). GitHub's security policy blocks
+          # GITHUB_TOKEN-originated pushes from firing on:push workflows.
+          GH_TOKEN: ${{ secrets.MERGE_PAT }}
         run: |
           [ ! -f claude-output.log ] && echo "No Claude output — skipping" && exit 0
           PR_BRANCHES=$(grep -oP 'fix/daily-review-[a-z0-9-]+' claude-output.log | sort -u || true)

--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -118,7 +118,8 @@ services:
       SIGNAL_INTERVAL_MS: "300000"
       MAX_SIGNAL_MARKETS: "35"
       ENABLE_OPTIMIZATION: "true"
-      OPTIMIZER_URL: https://polymarket-optimizer-server.onrender.com
+      # OPTIMIZER_URL removed: Render service can't reach TimescaleDB (localhost-only port).
+      # Without it, OptimizationScheduler falls back to local grid search.
       POLYMARKET_API_URL: https://clob.polymarket.com
       INITIAL_CAPITAL: "10000"
       FEE_RATE: "0.001"


### PR DESCRIPTION
## Summary
- CI/CD deploy workflow not triggering for bot-merged PRs since 2026-03-24
- Optuna optimizer producing 20x 500 errors/day, never successfully ran

## CI/CD Fix
**Root cause:** `GH_TOKEN: ${{ github.token }}` in the auto-merge step. GitHub blocks GITHUB_TOKEN pushes from triggering `on: push` workflows.

**Fix:** Changed to `${{ secrets.MERGE_PAT }}`. Secret already configured.

## Optuna Fix
**Root cause:** Render optimizer can't reach TimescaleDB — Docker exposes port 5432 only on `127.0.0.1`. `ping()` succeeds (no DB) so grid-search fallback never activates.

**Fix:** Removed `OPTIMIZER_URL` from docker-compose.gcp.yml. Without it, `OptimizationScheduler` uses local grid-search fallback (line 161).

## Test plan
- [ ] Next daily review auto-merge should trigger deploy workflow
- [ ] Dashboard logs should show "Grid-search fallback mode" instead of Optuna 500 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication method for automated merge operations
  * Simplified deployment configuration; system now uses local processing instead of an external service dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->