### PR TITLE
fix: acumular realized_pnl en cierre parcial manual

### DIFF
--- a/packages/dashboard/src/api/routes.ts
+++ b/packages/dashboard/src/api/routes.ts
@@ -1227,7 +1227,7 @@ export async function registerRoutes(
         // Reduce position size in place
         await query(
           `UPDATE paper_positions SET
-            size = $1, current_price = $2, realized_pnl = $3,
+            size = $1, current_price = $2, realized_pnl = COALESCE(realized_pnl, 0) + $3,
             unrealized_pnl = 0, updated_at = NOW()
           WHERE id = $4 AND closed_at IS NULL`,
           [currentSize - size, price, pnl, existingPosition.id]


### PR DESCRIPTION
## Resumen

`routes.ts:1230` usaba `realized_pnl = $3` (sobrescritura) en lugar de `COALESCE(realized_pnl, 0) + $3` (acumulación) en la ruta de cierre parcial del endpoint manual `/api/paper/trade`.

## Causa raíz

El mismo patrón de bug corregido en:
- **PR #43**: `PositionClosingService.ts` — `realized_pnl = $1` → `COALESCE(realized_pnl, 0) + $1`
- **PR #52**: test helper `closePosition()` — misma corrección

Pero la instancia en `routes.ts` (cierre parcial manual) fue omitida en ambos PRs.

**Impacto**: Si un usuario ejecuta dos cierres parciales consecutivos en la misma posición vía el endpoint manual, el segundo sobrescribe el `realized_pnl` del primero en lugar de acumularlo. El `total_realized_pnl` a nivel cuenta es correcto (se acumula en línea 1218), pero el campo `realized_pnl` de la posición pierde el historial.

## Cambio

```diff
- realized_pnl = $3,
+ realized_pnl = COALESCE(realized_pnl, 0) + $3,
```

## Tests

- 513 tests unitarios pasan (0 fallos)

## Contexto

Encontrado durante la auditoría del issue #51. Este es el patrón documentado en CLAUDE.md como "Historical Bug Patterns: Services bypassing PositionClosingService with direct SQL".

Relacionado con #51

https://claude.ai/code/session_01HrHktrc7X99vc4PQ8JwLKp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed realized profit/loss calculation for partial position closes in paper trading. Previously, closing part of a position would overwrite accumulated PnL; now it correctly adds to existing values, ensuring accurate profit/loss tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->