### PR TITLE
fix: add fallback notification step to daily review workflow

### DIFF
--- a/.github/workflows/daily-trade-review-claude.yml
+++ b/.github/workflows/daily-trade-review-claude.yml
@@ -149,6 +149,9 @@ jobs:
           GMAIL_TO_ADDRESS: ${{ secrets.GMAIL_TO_ADDRESS }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
+          # Restore notifier scripts from the triggering commit before exposing secrets.
+          git restore --source "${GITHUB_SHA}" -- scripts/format-review.js scripts/send-review-email.js
+
           # Generate email.html and slack.json from review data
           node scripts/format-review.js review-data.json
 
@@ -163,7 +166,7 @@ jobs:
 
           # Send Slack alert if critical alerts detected
           if [ -f slack.json ] && [ -n "${SLACK_WEBHOOK_URL:-}" ]; then
-            curl -sf -X POST -H "Content-Type: application/json" \
+            curl -sf --connect-timeout 10 --max-time 30 -X POST -H "Content-Type: application/json" \
               -d @slack.json "$SLACK_WEBHOOK_URL" && echo "Slack alert sent" || echo "::warning::Slack send failed"
           fi
 

--- a/scripts/daily-review-prompt.md
+++ b/scripts/daily-review-prompt.md
@@ -17,7 +17,7 @@ Analyze the trading system's health, investigate anomalies, and implement well-u
    - Read source code to understand how a broken metric is computed
    - Cross-reference data sections (if buys >> sells, why? if PnL doesn't match capital, where did the money go?)
 6. **Implement fixes** only after you understand the root cause
-7. **Create outputs** — issue, email, Slack (if critical)
+7. **Create outputs** — GitHub issue (notifications are sent by workflow)
 
 **You have full access to investigate.** You can SSH to the VM, run SQL, read code, check git history. Use these tools when the dashboard data raises questions. Do NOT just report "unexplained $X gap" — find where the money went.
 
@@ -172,7 +172,7 @@ ORDER BY market_score DESC LIMIT 20;
 
 ### 3a. GitHub Issue
 
-Create a GitHub Issue with label "daily-review". **Do NOT close it afterwards.**
+Create a GitHub Issue with label "daily-review". Do NOT close it afterward:
 
 ```bash
 gh issue create --title "TITLE" --body-file report.md --label "daily-review"
@@ -188,7 +188,7 @@ The issue should have:
 
 ### 3b. Email and Slack
 
-You do NOT need to send email or Slack notifications — the workflow handles this automatically after your step using `format-review.js` and `send-review-email.js`. Just focus on creating the issue and implementing fixes.
+Do NOT send email or Slack notifications yourself. The workflow handles that automatically after your step using `format-review.js` and `send-review-email.js`. Focus on creating the issue and implementing fixes.
 
 ## Step 4: Implement Fixes as PRs
 


### PR DESCRIPTION
Claude's analysis step sometimes skips email/Slack notifications.
Add a dedicated workflow step that generates and sends notifications
from review-data.json independently, ensuring email always arrives
even when Claude omits the notification steps.

https://claude.ai/code/session_017HXUHWzpLx9ByfJjankYr5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automated notifications by decoupling delivery from AI analysis; notifications are now sent by the workflow and only when review data exists.
  * Added conditional handling and clearer failure warnings for email and Slack sends.

* **Chores**
  * Strengthened operational rules so the automated agent will create a persistently open daily-review issue, will not send notifications, merge PRs, or close issues automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->