### PR TITLE
fix: use git pull --ff-only in deploy workflow

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -137,7 +137,7 @@ jobs:
           gcloud compute ssh Usuario@polymarket-vm \
             --zone=us-east1-b \
             --ssh-flag="-o ServerAliveInterval=30" \
-            --command="echo '${{ secrets.GITHUB_TOKEN }}' | docker login ghcr.io -u github-actions --password-stdin && cd /home/Usuario/polymarket-trader && git pull origin main && docker compose -f docker-compose.gcp.yml pull data-collector dashboard-api && docker compose -f docker-compose.gcp.yml up -d --remove-orphans"
+            --command="echo '${{ secrets.GITHUB_TOKEN }}' | docker login ghcr.io -u github-actions --password-stdin && cd /home/Usuario/polymarket-trader && git pull --ff-only origin main && docker compose -f docker-compose.gcp.yml pull data-collector dashboard-api && docker compose -f docker-compose.gcp.yml up -d --remove-orphans"
 
       - name: Health check
         run: |


### PR DESCRIPTION
## Summary

- Change `git pull origin main` → `git pull --ff-only origin main` in `.github/workflows/deploy-gcp.yml:140`
- Prevents `fatal: Need to specify how to reconcile divergent branches` failure when VM has untracked files

## Root Cause

Today (2026-04-15) CI deploy failed 2x. VM had untracked files (`docker-compose.override.yml`, `review-history.json`) and no local commits — so the VM was simply behind origin. However, the bare `git pull` command requires `pull.rebase` or `pull.ff` config to be set; neither is configured on the VM, and Git treats the presence of untracked files ambiguously.

`--ff-only` is the correct semantic: deploy never expects local commits on the VM, only fast-forward to origin/main.

## Test plan

- [x] Edit verified: grep shows `--ff-only` in deploy-gcp.yml
- [ ] Next merge triggers deploy → should succeed even with untracked files on VM

🤖 Generated with [Claude Code](https://claude.com/claude-code)