### PR TITLE
fix: prioritize tradeable markets in classifier + NULL fallback

### DIFF
--- a/packages/dashboard/src/services/MarketClassifier.test.ts
+++ b/packages/dashboard/src/services/MarketClassifier.test.ts
@@ -42,5 +42,22 @@ describe('MarketClassifier', () => {
         classifier.classifyWithRegex('MegaETH market cap (FDV) >$3B one day after launch?', shortEndDate)
       ).toBe('event_short');
     });
+
+    it('classifies S&P 500 markets as event_financial', () => {
+      expect(
+        classifier.classifyWithRegex('S&P 500 (SPX) Opens Up or Down on April 7?', shortEndDate)
+      ).toBe('event_financial');
+    });
+
+    it('classifies sports markets as event_short (never NULL)', () => {
+      expect(
+        classifier.classifyWithRegex('Counter-Strike: FOKUS vs BC.Game Esports (BO3)', shortEndDate)
+      ).toBe('event_short');
+    });
+
+    it('returns event_short as last-resort default (never NULL)', () => {
+      // Question with no keywords at all, no end date → still returns a type
+      expect(classifier.classifyWithRegex('Opaque question with no hints', null)).toBe('event_short');
+    });
   });
 });

--- a/packages/dashboard/src/services/MarketClassifier.ts
+++ b/packages/dashboard/src/services/MarketClassifier.ts
@@ -67,6 +67,12 @@ export class MarketClassifier {
   async classifyPendingMarkets(): Promise<number> {
     if (!isDatabaseConfigured()) return 0;
 
+    // Prioritize tradeable markets (high volume) over zombie long-tail to ensure
+    // classifications reach the signal engine before markets go stale.
+    // Accept is_resolved NULL as "not yet resolved" — older rows may predate
+    // the column default.
+    const limit = parseInt(process.env.MARKET_CLASSIFIER_BATCH || '200', 10);
+
     const result = await query<{
       id: string;
       question: string;
@@ -76,29 +82,40 @@ export class MarketClassifier {
       FROM markets
       WHERE market_type IS NULL
         AND is_active = true
-        AND is_resolved = false
-      LIMIT 50
-    `);
+        AND COALESCE(is_resolved, false) = false
+      ORDER BY COALESCE(volume_24h, 0) DESC, updated_at DESC
+      LIMIT $1
+    `, [limit]);
 
     if (result.rows.length === 0) return 0;
 
     let classified = 0;
+    let failed = 0;
     for (const market of result.rows) {
+      let marketType: MarketType;
       try {
-        const marketType = await this.classifyMarket(market.question, market.end_date);
+        marketType = await this.classifyMarket(market.question, market.end_date);
+      } catch (error) {
+        // classifyMarket should never throw (regex fallback is pure), but if
+        // something unexpected happens, use pure regex as last resort so the
+        // market never stays NULL.
+        console.warn(`[MarketClassifier] classifyMarket threw for ${market.id}, using hard fallback:`, error);
+        marketType = this.classifyWithRegex(market.question, market.end_date);
+      }
+
+      try {
         await query(
           'UPDATE markets SET market_type = $1, updated_at = NOW() WHERE id = $2',
           [marketType, market.id]
         );
         classified++;
       } catch (error) {
-        console.error(`[MarketClassifier] Failed to classify ${market.id}:`, error);
+        failed++;
+        console.error(`[MarketClassifier] UPDATE failed for ${market.id}:`, error);
       }
     }
 
-    if (classified > 0) {
-      console.log(`[MarketClassifier] Classified ${classified}/${result.rows.length} markets`);
-    }
+    console.log(`[MarketClassifier] Classified ${classified}/${result.rows.length} markets (failed=${failed})`);
 
     return classified;
   }


### PR DESCRIPTION
## Summary

- `MarketClassifier.classifyPendingMarkets` now orders by `volume_24h DESC` so tradeable markets classify first
- Batch size raised from 50 → 200 (env override `MARKET_CLASSIFIER_BATCH`) to drain the 19k-row backlog
- `COALESCE(is_resolved, false)` includes legacy NULL rows
- Split try/catch: classify and UPDATE handled separately; classifyMarket exception falls back to `classifyWithRegex` so `market_type` never stays NULL from a transient error

## Root Cause

19,174 active markets with `market_type IS NULL` vs throughput ~2,400/day (LIMIT 50 × 48 ticks). Tradeable markets like S&P 500 (volume >\$5k) waited behind zombie long-tail. Today's review found 1,276 tradeable markets (volume >\$1k) unclassified — they fall through the signal engine's `market_type` gate.

## Test plan

- [x] 9 unit tests pass (added S&P 500, sports, hard-default cases)
- [x] Type-check clean
- [ ] After deploy: monitor log `[MarketClassifier] Classified X/Y markets (failed=0)` and verify NULL count drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)