### PR TITLE
feat: sync market resolution status so shadow trades can score

### DIFF
--- a/packages/data-collector/src/collectors/GammaCollector.ts
+++ b/packages/data-collector/src/collectors/GammaCollector.ts
@@ -158,6 +158,114 @@ export class GammaCollector {
   }
 
   /**
+   * Sync resolution status for markets that have closed on Polymarket.
+   * Only UPDATES existing rows (never INSERTs) — we don't need resolved
+   * markets we never tracked. Populates `is_resolved`, `resolution_outcome`,
+   * and `resolved_at` so that `resolveShadowTrades` (daily cron) can score
+   * shadow trades against actual outcomes.
+   */
+  async syncResolvedMarketsToDb(): Promise<{ resolved: number; scanned: number }> {
+    let resolved = 0;
+    let scanned = 0;
+    let offset = 0;
+    let pageCount = 0;
+    const limit = 100;
+
+    logger.info('Syncing resolved markets');
+
+    while (true) {
+      await this.rateLimiter.acquire('gamma_markets');
+
+      let markets: any[] = [];
+      try {
+        const response = await this.client.get<any[]>('/markets', {
+          params: {
+            limit: limit.toString(),
+            offset: offset.toString(),
+            closed: 'true',
+            // Newest resolutions first — sort desc by updatedAt if supported; Gamma
+            // doesn't reject unknown params, so this is a best-effort hint.
+            order: 'updatedAt',
+            ascending: 'false',
+          },
+        });
+        markets = response.data || [];
+      } catch (error: any) {
+        logger.error({ err: error.message || String(error), offset }, 'Error fetching closed markets page');
+        break;
+      }
+
+      if (markets.length === 0) break;
+
+      // Build batched UPDATE by id. Only rows that are NOT already resolved are
+      // touched (WHERE is_resolved = false), so re-runs are idempotent and cheap.
+      for (const market of markets) {
+        scanned++;
+        if (!market.id || !market.closed) continue;
+
+        // Schema: `markets.resolution_outcome` is VARCHAR(10) with values
+        // 'yes' | 'no' | 'invalid'. MarketPerformanceTracker interprets any
+        // non-'yes' value as 0.0 in PnL, so invalid markets are skipped here to
+        // avoid polluting shadow resolution.
+        let resolutionOutcome: 'yes' | 'no' | null = null;
+        try {
+          const prices = JSON.parse(market.outcomePrices || '[]');
+          const yesPrice = prices[0] ? parseFloat(prices[0]) : null;
+          if (yesPrice !== null && !isNaN(yesPrice)) {
+            if (yesPrice >= 0.99) resolutionOutcome = 'yes';
+            else if (yesPrice <= 0.01) resolutionOutcome = 'no';
+            // Else market resolved partially (invalid/50-50) — skip.
+          }
+        } catch {
+          // Leave null — we won't mark it resolved.
+        }
+
+        if (resolutionOutcome === null) continue;
+
+        // Prefer the API's closedTime; fall back to now for rows missing it.
+        const resolvedAt = market.closedTime
+          ? new Date(market.closedTime.replace(' ', 'T').replace('+00', 'Z'))
+          : new Date();
+
+        try {
+          const result = await query(
+            `
+            UPDATE markets
+            SET is_resolved = true,
+                resolution_outcome = $1,
+                resolved_at = $2,
+                is_active = false,
+                updated_at = NOW()
+            WHERE id = $3
+              AND COALESCE(is_resolved, false) = false
+            `,
+            [resolutionOutcome, resolvedAt, market.id]
+          );
+          if (result.rowCount && result.rowCount > 0) {
+            resolved++;
+          }
+        } catch (err: any) {
+          logger.warn({ err: err.message || String(err), marketId: market.id }, 'Failed to mark market resolved');
+        }
+      }
+
+      pageCount++;
+      logger.debug({ offset, batchSize: markets.length, resolved, scanned }, 'Processed closed markets batch');
+
+      if (markets.length < limit) break;
+      if (pageCount >= MAX_SYNC_PAGES) {
+        logger.info(`[GammaCollector] Reached MAX_SYNC_PAGES (${MAX_SYNC_PAGES}), stopping resolved-market sync`);
+        break;
+      }
+
+      offset += limit;
+    }
+
+    logger.info({ resolved, scanned }, 'Finished syncing resolved markets');
+    return { resolved, scanned };
+  }
+
+  /**
    * Sync all events to database (streaming to avoid memory issues)
    */
   async syncEventsToDb(): Promise<{ inserted: number; updated: number }> {

--- a/packages/data-collector/src/services/Scheduler.ts
+++ b/packages/data-collector/src/services/Scheduler.ts
@@ -41,6 +41,7 @@ export class Scheduler {
     this.newsCollector = new NewsCollector();
     // Define all scheduled jobs
     this.defineJob('sync-markets', '17 * * * *', this.syncMarkets.bind(this));      // Hourly at :17
+    this.defineJob('sync-resolved-markets', '33 * * * *', this.syncResolvedMarkets.bind(this));  // Hourly at :33
     this.defineJob('sync-events', '47 */2 * * *', this.syncEvents.bind(this));     // Every 2h at :47
     this.defineJob('sync-prices', '*/5 * * * *', this.syncPrices.bind(this));  // Every 5min (only for market selection, not trading)
     // DISABLED: CLOB /prices-history returns complementary (No) prices for Yes tokens.
@@ -170,6 +171,9 @@ export class Scheduler {
         case 'sync-prices':
           await this.syncPrices();
           break;
+        case 'sync-resolved-markets':
+          await this.syncResolvedMarkets();
+          break;
         case 'sync-price-history':
           // DISABLED: see job registration comment
           // await this.syncPriceHistory();
@@ -298,6 +302,16 @@ export class Scheduler {
     const collector = getGammaCollector();
     const result = await collector.syncEventsToDb();
     logger.info({ inserted: result.inserted, updated: result.updated }, 'Events synced');
+  }
+
+  /**
+   * Pull resolution status for closed markets so the daily shadow-trade
+   * resolver can score theoretical PnL. Only touches rows we already track.
+   */
+  private async syncResolvedMarkets(): Promise<void> {
+    const collector = getGammaCollector();
+    const result = await collector.syncResolvedMarketsToDb();
+    logger.info({ resolved: result.resolved, scanned: result.scanned }, 'Resolved markets synced');
   }
 
   /**


### PR DESCRIPTION
## Summary

- Adds `GammaCollector.syncResolvedMarketsToDb()` — queries `/markets?closed=true` and populates `markets.is_resolved`, `resolution_outcome`, `resolved_at` for existing rows
- New Scheduler job `sync-resolved-markets` hourly at `:33`

## Root Cause

`shadow_trades` accumulated 6,878 rows in 48h, **0 resolved**. The daily `compute-market-priors` job (02:45 UTC) calls `resolveShadowTrades()`, which depends on `markets.is_resolved = true` and `resolution_outcome` being populated. Nothing was writing them: `syncMarketsToDb` only queries `closed=false`, and its `ON CONFLICT DO UPDATE` clause doesn't even list the resolution columns. Result: shadow trading generated signals but never scored itself.

## Design notes

- `resolution_outcome` column is `VARCHAR(10)` in schema (`'yes'|'no'|'invalid'`) — mapped from `outcomePrices[0]` (Polymarket resolves to "1"/"0"/"0.5")
- Markets with partial/invalid resolution (0.01 < price < 0.99) are skipped to avoid polluting PnL via the `MarketPerformanceTracker` `CASE WHEN LOWER(outcome)='yes' THEN 1.0 ELSE 0.0` rule
- UPDATE gated on `COALESCE(is_resolved, false) = false` so re-runs are idempotent and don't overwrite `resolved_at`
- Only UPDATES existing rows (no INSERT) — we don't backfill markets we never tracked

## Test plan

- [x] Type-check clean
- [x] Schema verified on VM (`is_resolved boolean`, `resolution_outcome varchar(10)`, `resolved_at timestamptz`)
- [ ] After deploy: monitor `Resolved markets synced` log; within 24h, some of the 6,878 shadow_trades should have `resolved_at` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)