### PR TITLE
fix: gate optimizer apply on min markets evaluated

### DIFF
--- a/packages/backtest/src/types/index.ts
+++ b/packages/backtest/src/types/index.ts
@@ -247,6 +247,10 @@ export interface BacktestResult {
   equityCurve: PortfolioSnapshot[];
   metrics: PerformanceMetrics;
   predictionMetrics: PredictionMarketMetrics;
+  /** Number of distinct markets backed by data during this run.
+   *  Used by OptimizationScheduler to gate parameter apply against
+   *  statistically tiny universes. Optional for back-compat. */
+  marketsEvaluated?: number;
 }
 
 export interface BacktestSummary {

--- a/packages/dashboard/src/services/BacktestService.ts
+++ b/packages/dashboard/src/services/BacktestService.ts
@@ -194,6 +194,7 @@ export class BacktestService extends EventEmitter {
         ...result,
         metrics,
         predictionMetrics: predMetrics,
+        marketsEvaluated: marketData.length,
       };
       storedBacktest.status = 'completed';
 

--- a/packages/dashboard/src/services/OptimizationScheduler.oos.test.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.oos.test.ts
@@ -31,9 +31,12 @@ function shouldDeploy(
   drawdownOOS: number,
   tradesOOS: number,
   decayFactor: number,
+  marketsEvaluated = 100,
+  minMarkets = 8,
 ): { passed: boolean; reason?: string } {
   // Safety floor
   if (isScore <= 0) return { passed: false, reason: 'IS Sharpe <= 0' };
+  if (marketsEvaluated < minMarkets) return { passed: false, reason: `Markets ${marketsEvaluated} < ${minMarkets} (universe too small to apply)` };
   if (tradesOOS < 20) return { passed: false, reason: `Trades ${tradesOOS} < 20` };
   if (oosScore < -1.0) return { passed: false, reason: `OOS Sharpe ${oosScore} < -1.0` };
   if (Math.abs(drawdownOOS) > 0.50) return { passed: false, reason: `Drawdown ${drawdownOOS} > 50%` };
@@ -125,6 +128,25 @@ describe('shouldDeploy (adaptive OOS gate)', () => {
 
   it('works with negative decay factor', () => {
     const result = shouldDeploy(1.0, -0.3, 0.1, 50, -0.5);
+    expect(result.passed).toBe(true);
+  });
+
+  it('rejects when marketsEvaluated below minMarkets (2026-04-14 incident)', () => {
+    // Reproduces the 6-market event_financial scenario that produced
+    // direction_multiplier=+1.0208 and 13.5% drawdown.
+    const result = shouldDeploy(1.0, 0.5, 0.1, 50, 0.3, 6, 8);
+    expect(result.passed).toBe(false);
+    expect(result.reason).toContain('Markets 6 < 8');
+  });
+
+  it('passes when marketsEvaluated meets threshold', () => {
+    const result = shouldDeploy(1.0, 0.4, 0.1, 50, 0.3, 8, 8);
+    expect(result.passed).toBe(true);
+  });
+
+  it('uses default 100 markets when threshold not specified (back-compat)', () => {
+    // Old call signature (no markets arg) should still pass for valid scores
+    const result = shouldDeploy(1.0, 0.4, 0.1, 50, 0.3);
     expect(result.passed).toBe(true);
   });
 });

--- a/packages/dashboard/src/services/OptimizationScheduler.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.ts
@@ -99,6 +99,11 @@ const OOS_SAFETY_FLOOR = {
   maxDrawdown: 0.50,
   /** Minimum trades in OOS for statistical signal */
   minTrades: 20,
+  /** Minimum distinct markets evaluated — prevents apply on tiny universes
+   *  where local maxima are statistically meaningless. Triggered by the
+   *  2026-04-14 incident where 6 event_financial markets produced
+   *  direction_multiplier=+1.0208 (causing 13.5% drawdown). */
+  minMarkets: parseInt(process.env.OPTIMIZER_MIN_MARKETS_FOR_APPLY || '8', 10),
 };
 
 // Decay factor cold start: used when fewer than 10 runs have OOS data
@@ -121,6 +126,7 @@ interface OOSValidationResult {
   drawdownOOS: number;
   tradesOOS: number;
   winRateOOS: number;
+  marketsEvaluated: number;
   reason?: string;
 }
 
@@ -607,7 +613,7 @@ export class OptimizationScheduler {
   private async validateOnOOS(params: Record<string, any>, isScore: number): Promise<OOSValidationResult> {
     // Gate: don't validate negative in-sample
     if (isScore <= 0) {
-      return { passed: false, sharpeOOS: 0, drawdownOOS: 0, tradesOOS: 0, winRateOOS: 0, reason: 'IS Sharpe <= 0, nothing to validate' };
+      return { passed: false, sharpeOOS: 0, drawdownOOS: 0, tradesOOS: 0, winRateOOS: 0, marketsEvaluated: 0, reason: 'IS Sharpe <= 0, nothing to validate' };
     }
 
     const now = new Date();
@@ -634,23 +640,27 @@ export class OptimizationScheduler {
       const backtest = await this.backtestService.runBacktest(request);
 
       if (!backtest.result || !backtest.result.metrics) {
-        return { passed: false, sharpeOOS: 0, drawdownOOS: 1, tradesOOS: 0, winRateOOS: 0, reason: 'Backtest failed to produce results' };
+        return { passed: false, sharpeOOS: 0, drawdownOOS: 1, tradesOOS: 0, winRateOOS: 0, marketsEvaluated: 0, reason: 'Backtest failed to produce results' };
       }
 
       const metrics = backtest.result.metrics;
       const trades = backtest.result.trades?.length || 0;
       const oosScore = metrics.sharpeRatio || 0;
       const drawdown = Math.abs(metrics.maxDrawdown || 0);
+      const marketsEvaluated = backtest.result.marketsEvaluated ?? 0;
 
       // Safety floor checks
+      if (marketsEvaluated < OOS_SAFETY_FLOOR.minMarkets) {
+        return { passed: false, sharpeOOS: oosScore, drawdownOOS: metrics.maxDrawdown, tradesOOS: trades, winRateOOS: metrics.winRate, marketsEvaluated, reason: `Markets ${marketsEvaluated} < ${OOS_SAFETY_FLOOR.minMarkets} (universe too small to apply)` };
+      }
       if (trades < OOS_SAFETY_FLOOR.minTrades) {
-        return { passed: false, sharpeOOS: oosScore, drawdownOOS: metrics.maxDrawdown, tradesOOS: trades, winRateOOS: metrics.winRate, reason: `Trades ${trades} < ${OOS_SAFETY_FLOOR.minTrades}` };
+        return { passed: false, sharpeOOS: oosScore, drawdownOOS: metrics.maxDrawdown, tradesOOS: trades, winRateOOS: metrics.winRate, marketsEvaluated, reason: `Trades ${trades} < ${OOS_SAFETY_FLOOR.minTrades}` };
       }
       if (oosScore < OOS_SAFETY_FLOOR.minSharpe) {
-        return { passed: false, sharpeOOS: oosScore, drawdownOOS: metrics.maxDrawdown, tradesOOS: trades, winRateOOS: metrics.winRate, reason: `OOS Sharpe ${oosScore.toFixed(3)} < ${OOS_SAFETY_FLOOR.minSharpe}` };
+        return { passed: false, sharpeOOS: oosScore, drawdownOOS: metrics.maxDrawdown, tradesOOS: trades, winRateOOS: metrics.winRate, marketsEvaluated, reason: `OOS Sharpe ${oosScore.toFixed(3)} < ${OOS_SAFETY_FLOOR.minSharpe}` };
       }
       if (drawdown > OOS_SAFETY_FLOOR.maxDrawdown) {
-        return { passed: false, sharpeOOS: oosScore, drawdownOOS: metrics.maxDrawdown, tradesOOS: trades, winRateOOS: metrics.winRate, reason: `Drawdown ${(drawdown * 100).toFixed(1)}% > ${OOS_SAFETY_FLOOR.maxDrawdown * 100}%` };
+        return { passed: false, sharpeOOS: oosScore, drawdownOOS: metrics.maxDrawdown, tradesOOS: trades, winRateOOS: metrics.winRate, marketsEvaluated, reason: `Drawdown ${(drawdown * 100).toFixed(1)}% > ${OOS_SAFETY_FLOOR.maxDrawdown * 100}%` };
       }
 
       // Adaptive consistency gate
@@ -663,12 +673,12 @@ export class OptimizationScheduler {
         reason = `OOS ${oosScore.toFixed(3)} < IS ${isScore.toFixed(3)} * decay ${decayFactor.toFixed(3)} = ${threshold.toFixed(3)}`;
       }
 
-      console.log(`[OptimizationScheduler] OOS validation: Sharpe=${oosScore.toFixed(3)}, decay=${decayFactor.toFixed(3)}, threshold=${threshold.toFixed(3)}, ${passed ? 'PASSED' : 'FAILED'}`);
+      console.log(`[OptimizationScheduler] OOS validation: Sharpe=${oosScore.toFixed(3)}, markets=${marketsEvaluated}, decay=${decayFactor.toFixed(3)}, threshold=${threshold.toFixed(3)}, ${passed ? 'PASSED' : 'FAILED'}`);
 
-      return { passed, sharpeOOS: oosScore, drawdownOOS: metrics.maxDrawdown, tradesOOS: trades, winRateOOS: metrics.winRate, reason };
+      return { passed, sharpeOOS: oosScore, drawdownOOS: metrics.maxDrawdown, tradesOOS: trades, winRateOOS: metrics.winRate, marketsEvaluated, reason };
     } catch (error) {
       console.error('[OptimizationScheduler] OOS validation failed:', error);
-      return { passed: false, sharpeOOS: 0, drawdownOOS: 1, tradesOOS: 0, winRateOOS: 0, reason: `Validation error: ${error instanceof Error ? error.message : String(error)}` };
+      return { passed: false, sharpeOOS: 0, drawdownOOS: 1, tradesOOS: 0, winRateOOS: 0, marketsEvaluated: 0, reason: `Validation error: ${error instanceof Error ? error.message : String(error)}` };
     }
   }
 


### PR DESCRIPTION
## Summary

- Add `marketsEvaluated` to `BacktestResult` (optional, populated from `marketData.length` in BacktestService)
- New OOS safety floor `minMarkets = 8` (env: `OPTIMIZER_MIN_MARKETS_FOR_APPLY`)
- `validateOnOOS` rejects when `marketsEvaluated < minMarkets`
- Tests added on the standalone `shouldDeploy` helper

## Root Cause

On 2026-04-14 23:49 the optimizer evaluated only 6 `event_financial` markets (narrow `ALLOWED_MARKET_TYPES` slice), found a local maximum at `direction_multiplier = +1.0208`, and applied it — flipping the system from contrarian to trend-following. Result: win rate collapsed to 13.2%, drawdown 13.5% (1.5% from circuit breaker).

PR #97 already constrained the parameter range. This PR addresses the deeper issue: **any** parameter being applied from a statistically tiny sample. With `minMarkets = 8` and `minTrades = 20`, the optimizer needs roughly the same evidence base as the validated Apr 2026 contrarian baseline (188 trades across many markets ≈ 25 trades/market).

## Test plan

- [x] 16 unit tests pass (3 new on the gate)
- [x] Type-check clean across backtest + dashboard packages
- [ ] After deploy: monitor `[OptimizationScheduler] OOS validation: ... markets=N` log; runs with `markets < 8` should report `Markets N < 8 (universe too small to apply)` and not write to `signal_weights`

## Follow-ups (out of scope)

- Persist `marketsEvaluated` to `optimization_runs.market_count` (column already exists in schema)
- Consider per-type minMarkets thresholds (e.g., relax for crypto where universe is naturally smaller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backtests now capture and display the count of distinct markets evaluated during each run.
  * Added automatic validation to prevent optimization strategy deployment when backtests are evaluated against insufficient market data (configurable minimum, default: 8 markets).

* **Tests**
  * Added comprehensive test coverage for market threshold validation and backward compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->