### PR TITLE
fix: cleanup stale SSH keys before each deploy

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -132,6 +132,24 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Cleanup stale SSH keys in project metadata
+        # Each `gcloud compute ssh` regenerates and uploads a key. Without
+        # cleanup, project metadata grows unbounded (we hit 165KB / 284 keys
+        # on 2026-04-15, which delayed key propagation and broke deploys with
+        # `Permission denied (publickey)`). Keep the latest key per user only.
+        run: |
+          set -euo pipefail
+          tmp=$(mktemp)
+          gcloud compute project-info describe \
+            --format="value(commonInstanceMetadata.items[].value)" \
+            | awk -F: '{ lines[$1]=$0 } END { for (k in lines) if (k != "") print lines[k] }' \
+            > "$tmp"
+          if [ -s "$tmp" ]; then
+            gcloud compute project-info add-metadata \
+              --metadata-from-file=ssh-keys="$tmp"
+          fi
+          rm -f "$tmp"
+
       - name: Deploy to VM
         run: |
           gcloud compute ssh Usuario@polymarket-vm \

--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -141,7 +141,9 @@ jobs:
           set -euo pipefail
           tmp=$(mktemp)
           gcloud compute project-info describe \
-            --format="value(commonInstanceMetadata.items[].value)" \
+            --flatten="commonInstanceMetadata.items[]" \
+            --filter="commonInstanceMetadata.items.key=ssh-keys" \
+            --format="value(commonInstanceMetadata.items.value)" \
             | awk -F: '{ lines[$1]=$0 } END { for (k in lines) if (k != "") print lines[k] }' \
             > "$tmp"
           if [ -s "$tmp" ]; then

--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -141,9 +141,8 @@ jobs:
           set -euo pipefail
           tmp=$(mktemp)
           gcloud compute project-info describe \
-            --flatten="commonInstanceMetadata.items[]" \
-            --filter="commonInstanceMetadata.items.key=ssh-keys" \
-            --format="value(commonInstanceMetadata.items.value)" \
+            --format=json \
+            | jq -r '.commonInstanceMetadata.items[]? | select(.key == "ssh-keys") | .value' \
             | awk -F: '{ lines[$1]=$0 } END { for (k in lines) if (k != "") print lines[k] }' \
             > "$tmp"
           if [ -s "$tmp" ]; then


### PR DESCRIPTION
## Summary

Adds a workflow step that prunes `project ssh-keys` metadata to one entry per user before each deploy. Prevents recurring `Permission denied (publickey)` on the SSH step.

## Root Cause

Every `gcloud compute ssh` invocation regenerates the runner's RSA key and uploads it to project metadata. Nothing removes old entries, so the metadata grew to **165KB / 284 keys** (250 Usuario from local SSH, 33 runner from CI, 1 other) by 2026-04-15. At that size GCP delays propagation of new keys to the VM enough that the runner's 15s wait expires before sshd accepts the fresh key — every CI deploy today failed with `Permission denied`.

Manual cleanup (kept latest key per user → 1.7KB) immediately restored CI auth. This step automates that.

## Test plan

- [x] awk dedupe verified locally (165KB → 1.7KB, 3 entries from 284)
- [x] SA `github-deploy@` already has `compute.instanceAdmin.v1` (covers `add-metadata`)
- [ ] After merge: this PR's own deploy should run cleanup successfully and SSH normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow to improve SSH key management during the pre-deployment phase. This optimizes how authentication credentials are handled during infrastructure updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->