### PR TITLE
fix: harden DB risk fail-safe and daily review triage

### DIFF
--- a/.claude/skills/daily-autoreview-analysis/SKILL.md
+++ b/.claude/skills/daily-autoreview-analysis/SKILL.md
@@ -63,6 +63,7 @@ Present to user concisely (NOT as a GitHub issue):
 - Persistent issues flagged across multiple reviews without fix
 - Gradual degradation trends (compare with recent issues)
 - Whether previous fixes actually worked
+- Whether today's PRs prioritized mitigation over the actual infra/control root cause
 
 **Real PnL check** (mandatory):
 Run this query to separate real from phantom PnL:
@@ -120,13 +121,14 @@ gcloud compute ssh polymarket-vm --zone=us-east1-b -- "docker stats --no-stream 
 |-----------|------|-----|
 | Root cause | SQL evidence, code line refs | "likely", "may be", "suggests" |
 | Severity | Context-aware, distinguishes resets from bugs | Everything is CRITICAL |
-| PR quality | Tests, boundary cases, CI green | No tests, untested edge cases |
+| PR quality | Tests, boundary cases, CI green, temporary containment labeled honestly | No tests, untested edge cases, symptom patch sold as root fix |
 | Persistence tracking | References prior issues, tracks trends | Each review is isolated |
 | Fix verification | Checks if yesterday's fix worked | Never looks back |
 
 ## Common Auto-Review Failure Patterns
 
 - **Symptom patching**: Creates PR for symptom without finding root cause
+- **Root-cause inversion**: Infra/control failure exists but the review prioritizes thresholds or tunables
 - **Trending blind spot**: Doesn't compare metrics across consecutive reviews
 - **Persistent issue slide**: Flags same P1 issue for days without escalating
 - **No fix verification**: Never checks if merged PRs actually resolved the problem

--- a/.github/workflows/daily-trade-review-claude.yml
+++ b/.github/workflows/daily-trade-review-claude.yml
@@ -133,6 +133,8 @@ jobs:
             echo "==========================="
             echo ""
             echo "IMPORTANT: Create the GitHub Issue and implement fixes as PRs (deploy to VM to verify each, then rollback to main). Do NOT send email or Slack — the workflow handles notifications automatically."
+            echo "IMPORTANT: Prioritize root-cause infra/control failures over tactical mitigations. Prefer 0 PRs over speculative symptom patches."
+            echo "IMPORTANT: If a PR is only containment (thresholds, memory knobs, cooldown tuning), label it clearly as temporary containment in the issue and PR."
             echo "When done, output a single line: REVIEW_COMPLETE"
           } | claude --model claude-sonnet-4-6 \
             --print \
@@ -294,6 +296,10 @@ jobs:
           for branch in $PR_BRANCHES; do
             PR_NUM=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number' 2>/dev/null || true)
             [ -z "$PR_NUM" ] && echo "[$branch] No open PR — skipping" && continue
+
+            # Claude occasionally omits the label even though the branch belongs to this workflow.
+            # Normalize metadata here so valid small fixes are not blocked on PR labeling.
+            gh pr edit "$PR_NUM" --add-label "daily-review" >/dev/null 2>&1 || true
 
             PR_DATA=$(gh pr view "$PR_NUM" --json files,additions,deletions,changedFiles,labels)
             FILE_COUNT=$(echo "$PR_DATA" | jq '.changedFiles')

--- a/packages/dashboard/src/api/routes.ts
+++ b/packages/dashboard/src/api/routes.ts
@@ -7,7 +7,7 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import type { DashboardContext } from './server.js';
 import type { JournalFilter, ApiResponse, PaginatedResponse } from '../types/index.js';
-import { healthCheck as dbHealthCheck, isDatabaseConfigured } from '../database/index.js';
+import { getQueryStats as getDbQueryStats, healthCheck as dbHealthCheck, isDatabaseConfigured } from '../database/index.js';
 import {
   signalPredictionsRepo,
   signalWeightsRepo,
@@ -746,6 +746,7 @@ export async function registerRoutes(
           external: Math.round(memUsage.external / 1024 / 1024),
         },
         database: dbMetrics,
+        databaseResilience: getDbQueryStats(),
         trading: tradingMetrics,
         optimization: optimizationMetrics,
       },

--- a/packages/dashboard/src/database/index.test.ts
+++ b/packages/dashboard/src/database/index.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('dashboard database query resilience', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete process.env.DATABASE_URL;
+    delete process.env.DB_POOL_MAX;
+    delete process.env.DB_IDLE_TIMEOUT_MS;
+  });
+
+  it('recreates the pool and retries once on transient connection timeout', async () => {
+    process.env.DATABASE_URL = 'postgres://example';
+
+    const firstPool = {
+      query: vi.fn().mockRejectedValue(new Error('Connection terminated due to connection timeout')),
+      connect: vi.fn(),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn(),
+    };
+    const secondPool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ ok: 1 }], rowCount: 1 }),
+      connect: vi.fn(),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn(),
+    };
+
+    let instanceCount = 0;
+    const Pool = vi.fn(class MockPool {
+      constructor() {
+        instanceCount += 1;
+        return instanceCount === 1 ? firstPool : secondPool;
+      }
+    } as any);
+
+    vi.doMock('pg', () => ({
+      default: { Pool },
+      Pool,
+    }));
+
+    const db = await import('./index.js');
+
+    const result = await db.query('SELECT 1');
+
+    expect(result.rows).toEqual([{ ok: 1 }]);
+    expect(firstPool.query).toHaveBeenCalledTimes(1);
+    expect(firstPool.end).toHaveBeenCalledTimes(1);
+    expect(secondPool.query).toHaveBeenCalledTimes(1);
+    expect(Pool).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry non-transient query errors', async () => {
+    process.env.DATABASE_URL = 'postgres://example';
+
+    const pool = {
+      query: vi.fn().mockRejectedValue(new Error('relation "paper_account" does not exist')),
+      connect: vi.fn(),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn(),
+    };
+
+    const Pool = vi.fn(class MockPool {
+      constructor() {
+        return pool;
+      }
+    } as any);
+
+    vi.doMock('pg', () => ({
+      default: { Pool },
+      Pool,
+    }));
+
+    const db = await import('./index.js');
+
+    await expect(db.query('SELECT * FROM paper_account')).rejects.toThrow(
+      'relation "paper_account" does not exist',
+    );
+
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    expect(pool.end).not.toHaveBeenCalled();
+    expect(Pool).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks retry and pool reset stats for transient failures', async () => {
+    process.env.DATABASE_URL = 'postgres://example';
+
+    const firstPool = {
+      query: vi.fn().mockRejectedValue(new Error('server closed the connection unexpectedly')),
+      connect: vi.fn(),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn(),
+    };
+    const secondPool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ ok: 1 }], rowCount: 1 }),
+      connect: vi.fn(),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn(),
+    };
+
+    let instanceCount = 0;
+    const Pool = vi.fn(class MockPool {
+      constructor() {
+        instanceCount += 1;
+        return instanceCount === 1 ? firstPool : secondPool;
+      }
+    } as any);
+
+    vi.doMock('pg', () => ({
+      default: { Pool },
+      Pool,
+    }));
+
+    const db = await import('./index.js');
+
+    await db.query('SELECT 1');
+
+    expect(db.getQueryStats()).toMatchObject({
+      totalQueries: 2,
+      retries: 1,
+      poolResets: 1,
+      consecutiveConnectionFailures: 0,
+      lastError: 'server closed the connection unexpectedly',
+    });
+  });
+});

--- a/packages/dashboard/src/database/index.ts
+++ b/packages/dashboard/src/database/index.ts
@@ -12,6 +12,19 @@ export type PoolClient = pg.PoolClient;
 
 // Connection pool singleton
 let pool: pg.Pool | null = null;
+const RETRYABLE_CONNECTION_ERRORS = [
+  'connection terminated due to connection timeout',
+  'timeout exceeded when trying to connect',
+  'terminating connection due to administrator command',
+  'server closed the connection unexpectedly',
+];
+const queryStats = {
+  totalQueries: 0,
+  retries: 0,
+  poolResets: 0,
+  consecutiveConnectionFailures: 0,
+  lastError: null as string | null,
+};
 
 export interface DatabaseConfig {
   connectionString?: string;
@@ -96,6 +109,25 @@ export function getPool(): pg.Pool {
   return pool;
 }
 
+async function resetPool(): Promise<void> {
+  if (!pool) return;
+
+  const stalePool = pool;
+  pool = null;
+  queryStats.poolResets += 1;
+
+  try {
+    await stalePool.end();
+  } catch (error) {
+    console.warn('Database pool reset failed during end():', error);
+  }
+}
+
+function isRetryableConnectionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return RETRYABLE_CONNECTION_ERRORS.some(pattern => message.includes(pattern));
+}
+
 /**
  * Execute a query
  */
@@ -103,22 +135,43 @@ export async function query<T extends QueryResultRow = QueryResultRow>(
   text: string,
   params?: unknown[]
 ): Promise<pg.QueryResult<T>> {
-  const client = getPool();
-  const start = Date.now();
+  for (let attempt = 0; attempt < 2; attempt++) {
+    queryStats.totalQueries += 1;
+    const client = getPool();
+    const start = Date.now();
 
-  try {
-    const result = await client.query<T>(text, params);
-    const duration = Date.now() - start;
+    try {
+      const result = await client.query<T>(text, params);
+      const duration = Date.now() - start;
+      queryStats.consecutiveConnectionFailures = 0;
 
-    if (duration > 1000) {
-      // console.warn(`Slow query (${duration}ms):`, text.substring(0, 100));
+      if (duration > 1000) {
+        // console.warn(`Slow query (${duration}ms):`, text.substring(0, 100));
+      }
+
+      return result;
+    } catch (error) {
+      const retryable = attempt === 0 && isRetryableConnectionError(error);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      queryStats.lastError = errorMessage;
+      console.error('Query error:', error);
+
+      if (!retryable) {
+        throw error;
+      }
+
+      queryStats.retries += 1;
+      queryStats.consecutiveConnectionFailures += 1;
+      console.warn('Retrying query after resetting database pool');
+      await resetPool();
     }
-
-    return result;
-  } catch (error) {
-    console.error('Query error:', error);
-    throw error;
   }
+
+  throw new Error('Query retry loop exited unexpectedly');
+}
+
+export function getQueryStats(): typeof queryStats {
+  return { ...queryStats };
 }
 
 /**

--- a/packages/dashboard/src/services/RiskManager.test.ts
+++ b/packages/dashboard/src/services/RiskManager.test.ts
@@ -72,4 +72,50 @@ describe('RiskManager — canOpenPosition fail-closed', () => {
     const result = await rm.canOpenPosition(100);
     expect(result.allowed).toBe(true);
   });
+
+  it('halts trading after repeated risk check database failures', async () => {
+    rm = new RiskManager({
+      enabled: true,
+      consecutiveFailureHaltThreshold: 2,
+    } as any);
+
+    vi.mocked(query).mockRejectedValue(new Error('connection timeout'));
+
+    const firstStatus = await rm.checkRisk();
+    expect(firstStatus.isHalted).toBe(false);
+
+    const secondStatus = await rm.checkRisk();
+    expect(secondStatus.isHalted).toBe(true);
+    expect(secondStatus.haltReason).toBe('system');
+    expect((secondStatus as any).consecutiveCheckFailures).toBe(2);
+    expect((secondStatus as any).lastCheckError).toContain('connection timeout');
+  });
+
+  it('resets the failure counter after a successful risk check', async () => {
+    rm = new RiskManager({
+      enabled: true,
+      consecutiveFailureHaltThreshold: 3,
+    } as any);
+
+    vi.mocked(query)
+      .mockRejectedValueOnce(new Error('connection timeout'))
+      .mockResolvedValueOnce({
+        rows: [{ initial_capital: '10000', current_capital: '10000', peak_equity: '10000' }],
+      } as any)
+      .mockResolvedValueOnce({
+        rows: [{ current_capital: '10000' }],
+      } as any)
+      .mockResolvedValueOnce({
+        rows: [],
+      } as any);
+
+    vi.mocked(paperPositionsRepo.getAll).mockResolvedValue([]);
+
+    await rm.checkRisk();
+    const status = await rm.checkRisk();
+
+    expect(status.isHalted).toBe(false);
+    expect((status as any).consecutiveCheckFailures).toBe(0);
+    expect((status as any).lastCheckError).toBeNull();
+  });
 });

--- a/packages/dashboard/src/services/RiskManager.ts
+++ b/packages/dashboard/src/services/RiskManager.ts
@@ -17,7 +17,7 @@ import {
 
 export type { RiskConfig } from '@polymarket-trader/backtest';
 
-export type RiskViolation = 'drawdown' | 'daily_loss' | 'position_size' | 'total_exposure' | 'manual';
+export type RiskViolation = 'drawdown' | 'daily_loss' | 'position_size' | 'total_exposure' | 'manual' | 'system';
 
 interface RiskStatus {
   isHalted: boolean;
@@ -29,6 +29,8 @@ interface RiskStatus {
   largestPositionPct: number;
   adaptiveMultiplier: number;
   profileType: string;
+  consecutiveCheckFailures: number;
+  lastCheckError: string | null;
 }
 
 /**
@@ -50,14 +52,18 @@ export class RiskManager extends EventEmitter {
   private lastDayReset: Date;
   private adaptiveMultiplier = 1.0;
   private isResuming = false; // Prevent infinite recursion
+  private consecutiveCheckFailures = 0;
+  private lastCheckError: string | null = null;
+  private consecutiveFailureHaltThreshold: number;
 
-  constructor(config?: Partial<RiskConfig>) {
+  constructor(config?: (Partial<RiskConfig> & { consecutiveFailureHaltThreshold?: number })) {
     super();
 
     // Use AGGRESSIVE profile as default
     this.config = config
       ? mergeRiskConfig('AGGRESSIVE', config)
       : getDefaultRiskProfile();
+    this.consecutiveFailureHaltThreshold = config?.consecutiveFailureHaltThreshold ?? 3;
 
     this.lastDayReset = new Date();
     this.lastDayReset.setHours(0, 0, 0, 0);
@@ -286,6 +292,9 @@ export class RiskManager extends EventEmitter {
         }
       }
 
+      this.consecutiveCheckFailures = 0;
+      this.lastCheckError = null;
+
       const status: RiskStatus = {
         isHalted: this.isHalted,
         haltReason: this.haltReason,
@@ -296,6 +305,8 @@ export class RiskManager extends EventEmitter {
         largestPositionPct,
         adaptiveMultiplier: this.adaptiveMultiplier,
         profileType: this.config.profileType,
+        consecutiveCheckFailures: this.consecutiveCheckFailures,
+        lastCheckError: this.lastCheckError,
       };
 
       this.emit('risk:checked', status);
@@ -303,6 +314,16 @@ export class RiskManager extends EventEmitter {
 
     } catch (error) {
       console.error('[RiskManager] Risk check failed:', error);
+      this.consecutiveCheckFailures += 1;
+      this.lastCheckError = error instanceof Error ? error.message : String(error);
+
+      if (!this.isHalted && this.consecutiveCheckFailures >= this.consecutiveFailureHaltThreshold) {
+        await this.haltTrading(
+          'system',
+          `Risk checks failed ${this.consecutiveCheckFailures} consecutive times: ${this.lastCheckError}`
+        );
+      }
+
       this.emit('risk:error', error);
       return this.getStatus();
     }
@@ -503,6 +524,8 @@ export class RiskManager extends EventEmitter {
       largestPositionPct: 0,
       adaptiveMultiplier: this.adaptiveMultiplier,
       profileType: this.config.profileType,
+      consecutiveCheckFailures: this.consecutiveCheckFailures,
+      lastCheckError: this.lastCheckError,
     };
   }
 

--- a/packages/data-collector/src/database/connection.test.ts
+++ b/packages/data-collector/src/database/connection.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('data-collector database query resilience', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete process.env.DATABASE_URL;
+    delete process.env.DB_POOL_MAX;
+    delete process.env.DB_IDLE_TIMEOUT_MS;
+  });
+
+  it('recreates the pool and retries once on transient connection timeout', async () => {
+    process.env.DATABASE_URL = 'postgres://example';
+
+    const firstPool = {
+      query: vi.fn().mockRejectedValue(new Error('Connection terminated due to connection timeout')),
+      connect: vi.fn(),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn(),
+    };
+    const secondPool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ ok: 1 }], rowCount: 1 }),
+      connect: vi.fn(),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn(),
+    };
+
+    let instanceCount = 0;
+    const Pool = vi.fn(class MockPool {
+      constructor() {
+        instanceCount += 1;
+        return instanceCount === 1 ? firstPool : secondPool;
+      }
+    } as any);
+
+    vi.doMock('pg', () => ({
+      Pool,
+    }));
+
+    const db = await import('./connection.js');
+
+    const result = await db.query('SELECT 1');
+
+    expect(result.rows).toEqual([{ ok: 1 }]);
+    expect(firstPool.query).toHaveBeenCalledTimes(1);
+    expect(firstPool.end).toHaveBeenCalledTimes(1);
+    expect(secondPool.query).toHaveBeenCalledTimes(1);
+    expect(Pool).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry non-transient query errors', async () => {
+    process.env.DATABASE_URL = 'postgres://example';
+
+    const pool = {
+      query: vi.fn().mockRejectedValue(new Error('syntax error at or near "FROM"')),
+      connect: vi.fn(),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn(),
+    };
+
+    const Pool = vi.fn(class MockPool {
+      constructor() {
+        return pool;
+      }
+    } as any);
+
+    vi.doMock('pg', () => ({
+      Pool,
+    }));
+
+    const db = await import('./connection.js');
+
+    await expect(db.query('SELECT FROM')).rejects.toThrow('syntax error at or near "FROM"');
+
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    expect(pool.end).not.toHaveBeenCalled();
+    expect(Pool).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks retry and pool reset stats for transient failures', async () => {
+    process.env.DATABASE_URL = 'postgres://example';
+
+    const firstPool = {
+      query: vi.fn().mockRejectedValue(new Error('timeout exceeded when trying to connect')),
+      connect: vi.fn(),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn(),
+    };
+    const secondPool = {
+      query: vi.fn().mockResolvedValue({ rows: [{ ok: 1 }], rowCount: 1 }),
+      connect: vi.fn(),
+      end: vi.fn().mockResolvedValue(undefined),
+      on: vi.fn(),
+    };
+
+    let instanceCount = 0;
+    const Pool = vi.fn(class MockPool {
+      constructor() {
+        instanceCount += 1;
+        return instanceCount === 1 ? firstPool : secondPool;
+      }
+    } as any);
+
+    vi.doMock('pg', () => ({
+      Pool,
+    }));
+
+    const db = await import('./connection.js');
+
+    await db.query('SELECT 1');
+
+    expect(db.getQueryStats()).toMatchObject({
+      totalQueries: 2,
+      retries: 1,
+      poolResets: 1,
+      consecutiveConnectionFailures: 0,
+      lastError: 'timeout exceeded when trying to connect',
+    });
+  });
+});

--- a/packages/data-collector/src/database/connection.ts
+++ b/packages/data-collector/src/database/connection.ts
@@ -4,6 +4,19 @@ import { pino } from 'pino';
 const logger = pino({ name: 'database' });
 
 let pool: Pool | null = null;
+const RETRYABLE_CONNECTION_ERRORS = [
+  'connection terminated due to connection timeout',
+  'timeout exceeded when trying to connect',
+  'terminating connection due to administrator command',
+  'server closed the connection unexpectedly',
+];
+const queryStats = {
+  totalQueries: 0,
+  retries: 0,
+  poolResets: 0,
+  consecutiveConnectionFailures: 0,
+  lastError: null as string | null,
+};
 
 export function getPool(): Pool {
   if (!pool) {
@@ -40,26 +53,66 @@ export function getPool(): Pool {
   return pool;
 }
 
+async function resetPool(): Promise<void> {
+  if (!pool) return;
+
+  const stalePool = pool;
+  pool = null;
+  queryStats.poolResets += 1;
+
+  try {
+    await stalePool.end();
+  } catch (error) {
+    logger.warn({ err: error }, 'Database pool reset failed during end()');
+  }
+}
+
+function isRetryableConnectionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return RETRYABLE_CONNECTION_ERRORS.some(pattern => message.includes(pattern));
+}
+
 export async function query<T extends QueryResultRow = QueryResultRow>(
   text: string,
   params?: any[]
 ): Promise<QueryResult<T>> {
-  const pool = getPool();
-  const start = Date.now();
+  for (let attempt = 0; attempt < 2; attempt++) {
+    queryStats.totalQueries += 1;
+    const pool = getPool();
+    const start = Date.now();
 
-  try {
-    const result = await pool.query<T>(text, params);
-    const duration = Date.now() - start;
+    try {
+      const result = await pool.query<T>(text, params);
+      const duration = Date.now() - start;
+      queryStats.consecutiveConnectionFailures = 0;
 
-    if (duration > 1000) {
-      logger.warn({ duration, query: text.slice(0, 100) }, 'Slow query detected');
+      if (duration > 1000) {
+        logger.warn({ duration, query: text.slice(0, 100) }, 'Slow query detected');
+      }
+
+      return result;
+    } catch (error: any) {
+      const retryable = attempt === 0 && isRetryableConnectionError(error);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      queryStats.lastError = errorMessage;
+      logger.error({ err: error.message || String(error), query: text.slice(0, 100) }, 'Query error');
+
+      if (!retryable) {
+        throw error;
+      }
+
+      queryStats.retries += 1;
+      queryStats.consecutiveConnectionFailures += 1;
+      logger.warn({ query: text.slice(0, 100) }, 'Retrying query after resetting database pool');
+      await resetPool();
     }
-
-    return result;
-  } catch (error: any) {
-    logger.error({ err: error.message || String(error), query: text.slice(0, 100) }, 'Query error');
-    throw error;
   }
+
+  throw new Error('Query retry loop exited unexpectedly');
+}
+
+export function getQueryStats(): typeof queryStats {
+  return { ...queryStats };
 }
 
 export async function getClient(): Promise<PoolClient> {

--- a/scripts/daily-review-prompt.md
+++ b/scripts/daily-review-prompt.md
@@ -141,11 +141,21 @@ For each PR merged in the last 48h:
 
 If a fix is **ineffective**, flag as HIGH and investigate why.
 
+Also check the 3 oldest open `daily-review` issues. If one is still relevant today, add a `Persistent Open Issues` section to the new issue and explain whether today worsens, improves, or merely repeats that problem.
+
 ## Step 1: Read the Data
 
 Read `review-data.json` in the current directory. It contains ~22 sections of trading data gathered from the VM, including per-market-type breakdowns (`trades_by_type`, `category_performance`, `shadow_summary`).
 
 ## Step 2: Analyze
+
+Before proposing any fix, rank causes in this order:
+1. Control-plane / infra failures (DB timeouts, stale ingestion, unhealthy containers, broken schedulers, failed risk checks)
+2. Data integrity failures
+3. Execution / accounting bugs
+4. Strategy tuning or threshold issues
+
+If categories 1-2 are active, do not present category 4 as the main fix.
 
 For each section, don't just report numbers — explain what they MEAN and investigate when things don't add up:
 
@@ -238,6 +248,7 @@ The issue should have:
 - **Key Metrics** table: capital, PnL, drawdown, win rate, open positions
 - **Alerts** if any thresholds exceeded — use judgment (see alert guidance below)
 - **Analysis** sections — including any investigation you performed (queries run, code read, findings)
+- **Persistent Open Issues** — unresolved prior issues still relevant today, if any
 - **Recommendations** ranked by impact
 - **Risk Assessment**: what could go wrong in the next 24h
 
@@ -257,6 +268,7 @@ Do NOT send email or Slack notifications yourself. The workflow handles that aut
 - **Test the invariants** after your fix — don't just check "containers healthy"
 - **Do NOT merge PRs yourself** — leave them open for human review. The auto-merge step in the workflow will handle small PRs that meet the criteria.
 - **Do NOT use `Fixes #N` or `Closes #N`** in commit messages or PR bodies — the daily review issue must stay open for tracking. Use `Related to #N` instead.
+- **Do NOT submit mitigation-only PRs as if they were root fixes.** If the change merely reduces blast radius (thresholds, memory knobs, cooldown tuning), label it clearly as `temporary containment` in the PR body.
 
 ### 4a. Create branch and implement
 


### PR DESCRIPTION
## Summary

- add one-shot DB pool retry/reset resilience to dashboard and data-collector query wrappers
- halt trading after repeated DB-backed risk-check failures instead of only logging them
- expose DB resilience counters in `/api/metrics`
- harden the daily review prompt/workflow/skill to prioritize infra-control root causes over mitigation-only PRs

## Root Cause

Issue #105 identified the real safety problem correctly: transient DB connection timeouts were breaking `SignalEngine`, `CircuitBreaker`, and `RiskManager` at the same time. Before this change:

- the DB wrappers failed queries immediately and provided no counters to distinguish a rare transient from a chronic control-plane failure
- `RiskManager.checkRisk()` logged DB failures but returned a non-halted status, so repeated failures could leave the system trading while the risk path was blind
- the daily review system still had room to prioritize tactical containment PRs (`#106`, `#107`) over the underlying infra/control failure

## Changes

1. DB resilience
- add retry-once behavior for transient connection errors in:
  - `packages/dashboard/src/database/index.ts`
  - `packages/data-collector/src/database/connection.ts`
- reset the pool before retrying
- track `totalQueries`, `retries`, `poolResets`, `consecutiveConnectionFailures`, and `lastError`

2. Risk fail-safe
- extend `RiskManager` status with `consecutiveCheckFailures` and `lastCheckError`
- add `consecutiveFailureHaltThreshold`
- automatically halt trading with reason `system` after repeated risk-check DB failures

3. Observability
- expose `databaseResilience` from `/api/metrics`

4. Daily review quality
- strengthen `scripts/daily-review-prompt.md`
- strengthen `.github/workflows/daily-trade-review-claude.yml`
- update `.claude/skills/daily-autoreview-analysis/SKILL.md`
- require persistent-open-issue tracking and honest labeling of mitigation-only PRs as temporary containment

## Test Plan

- `npm run test -- packages/dashboard/src/database/index.test.ts packages/data-collector/src/database/connection.test.ts packages/dashboard/src/services/RiskManager.test.ts packages/dashboard/src/services/CircuitBreakerService.test.ts packages/dashboard/src/services/SignalEngine.test.ts`

## References

- Related to #105
- Related to #103
- Related to #94


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database connections now automatically retry on transient failures
  * Added `databaseResilience` metrics to API responses
  * Risk management system detects and halts trading after consecutive system check failures with diagnostic tracking

* **Documentation**
  * Updated daily review process guidance on persistent issue assessment and PR discipline standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->