### PR TITLE
feat: direction multiplier exploration (widen learner + epsilon-greedy)

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -153,6 +153,14 @@ services:
       ALLOWED_MARKET_TYPES: "crypto_intraday,crypto_daily,event_financial"
       # Market Classifier (Haiku)
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      # Direction Exploration
+      ENABLE_DIRECTION_EXPLORATION: "true"
+      DIRECTION_EXPLORATION_EPSILON: "0.10"
+      DIRECTION_EXPLORATION_MIN: "0.0"
+      DIRECTION_EXPLORATION_MAX: "1.0"
+      DIRECTION_EXPLORATION_BREAKER_MIN_TRADES: "20"
+      DIRECTION_EXPLORATION_BREAKER_WINDOW_DAYS: "7"
+      DIRECTION_EXPLORATION_BREAKER_MAX_CUM_LOSS: "-150"
     ports:
       - "3001:3001"
     healthcheck:

--- a/docs/plans/2026-04-20-direction-multiplier-exploration-design.md
+++ b/docs/plans/2026-04-20-direction-multiplier-exploration-design.md
@@ -81,6 +81,7 @@ type ResolveReason = 'segment' | 'global' | 'exploration' | 'breaker_tripped';
 
 interface DirectionResolution {
   multiplier: number;
+  contextKey: string;          // preserved from pure resolveDirectionMultiplier for combiner.setDirectionMultiplier(multiplier, contextKey)
   segmentId: string | null;
   wasExploration: boolean;
   reason: ResolveReason;
@@ -187,21 +188,23 @@ No other learner logic changes. Promotion thresholds (`minSegmentTrades=24`, `mi
 Location: `packages/dashboard/src/services/SignalEngine.ts`
 
 - Inject `DirectionResolver` via constructor.
-- Replace existing direct call to `resolveDirectionMultiplier` with `directionResolver.resolve(context)`.
-- After `combiner.combine()` returns, enrich the output:
+- Replace synchronous `resolveDirectionMultiplier(policy, ctx)` at line 449 with `await this.directionResolver.resolve(ctx)`.
+- Existing `combiner.setDirectionMultiplier(resolution.multiplier, resolution.contextKey)` call at line 455 stays intact (resolver preserves `contextKey`).
+- **Consolidate metadata.** Current code at lines 478-483 writes three separate keys (`metadata.directionMultiplier`, `metadata.directionContextKey`, `metadata.directionPolicySegmentId`). Those become top-level on the output (`appliedDirectionMultiplier`, `wasExploration`) plus a single grouped `metadata.direction` for diagnostics. No external consumers read the old keys (grep verified), so this is an internal consolidation:
 
 ```ts
-return {
-  ...combined,
-  wasExploration: resolution.wasExploration,
-  metadata: {
-    ...combined.metadata,
-    direction: {
-      segmentId: resolution.segmentId,
-      reason: resolution.reason,
-    },
+// After combiner.combine() returns into `combined`:
+combined.appliedDirectionMultiplier = resolution.multiplier;
+combined.wasExploration = resolution.wasExploration;
+combined.metadata = {
+  ...(combined.metadata ?? {}),
+  direction: {
+    contextKey: resolution.contextKey,
+    segmentId: resolution.segmentId ?? 'global',
+    reason: resolution.reason,
   },
 };
+// REMOVED: directionMultiplier, directionContextKey, directionPolicySegmentId (superseded by the above)
 ```
 
 ### 4. `WeightedAverageCombiner` (modify)
@@ -224,30 +227,41 @@ Combiner does **not** know about exploration. `wasExploration` is attached upstr
 
 Location: `packages/dashboard/src/services/AutoSignalExecutor.ts`
 
-- On position open, pass two new fields to repo:
+- On position open, extend the `PaperPosition` object passed into `openPositionAtomically`:
 ```ts
-await paperPositionsRepo.open({
-  // ... existing
-  appliedDirectionMultiplier: signal.appliedDirectionMultiplier,
-  wasExploration: signal.wasExploration ?? false,
-});
+await paperPositionsRepo.openPositionAtomically({
+  // ... existing fields
+  applied_direction_multiplier: signal.appliedDirectionMultiplier,
+  was_exploration: signal.wasExploration ?? false,
+}, cost, fee);
 ```
 
-### 6. `paperPositionsRepo.open()` (modify)
+### 6. `paperPositionsRepo` + `PaperPosition` interface (modify)
 
-Location: `packages/dashboard/src/repos/paperPositionsRepo.ts` (or equivalent).
+Location: `packages/dashboard/src/database/repositories.ts`
 
-- Extend parameter type with two new fields (both optional in the signature for manual-script callers; defaults `NULL` and `false`).
-- Extend the INSERT SQL:
-```sql
-INSERT INTO paper_positions (
-  ..., applied_direction_multiplier, was_exploration
-) VALUES (..., $N, $N+1)
+- Extend `PaperPosition` interface (currently around line 310-335):
+```ts
+interface PaperPosition {
+  // ... existing fields
+  applied_direction_multiplier?: number | null;   // nullable: legacy inserts without direction context
+  was_exploration?: boolean;                      // default false when omitted
+}
 ```
 
-### 7. DB migration (startup DDL)
+- **Two INSERT sites must be updated** (confirmed by grep):
+  1. `paperPositionsRepo.insert()` at line 341 (also reached via deprecated `upsert()` used by `routes.ts` and `PaperTradingService`)
+  2. `paperPositionsRepo.openPositionAtomically()` at line 421 (canonical path from `AutoSignalExecutor`)
+- Both INSERT column lists + VALUES clauses get `applied_direction_multiplier, was_exploration` appended.
+- Both sites pass `position.applied_direction_multiplier ?? null` and `position.was_exploration ?? false` — backward-compatible for existing callers.
 
-Location: `packages/dashboard/src/server.ts` — alongside existing `trading_config` CREATE TABLE IF NOT EXISTS block.
+Consumers that must compile without change (don't need to populate the new fields): `routes.ts`, `PaperTradingService`, test fixtures. `AutoSignalExecutor` is the only site that supplies real values.
+
+### 7. DB migration (dual path — fresh deployments + existing VM)
+
+**Fresh deployments** — new migration file following the existing numbered pattern:
+
+Location: `packages/data-collector/src/database/init/017_direction_multiplier_exploration_columns.sql`
 
 ```sql
 ALTER TABLE paper_positions
@@ -255,8 +269,17 @@ ALTER TABLE paper_positions
   ADD COLUMN IF NOT EXISTS was_exploration BOOLEAN NOT NULL DEFAULT false;
 ```
 
-- `applied_direction_multiplier`: NULLABLE (pre-migration rows remain NULL — distinguishes "unknown legacy" from explicit `0`).
-- `was_exploration`: NOT NULL DEFAULT false (semantic default for all historical rows and non-signal inserts).
+These files run once on first volume init (per project convention) — they won't execute on the existing VM whose volume was initialized months ago.
+
+**Existing deployments** — startup DDL in `dashboard-api`:
+
+Location: `packages/dashboard/src/server.ts` — alongside existing `trading_config` CREATE TABLE IF NOT EXISTS block.
+
+Same SQL as above. `IF NOT EXISTS` guards make the statement idempotent so fresh and legacy deployments converge to the same schema.
+
+**Column semantics:**
+- `applied_direction_multiplier`: NULLABLE (pre-migration rows remain NULL — distinguishes "unknown legacy" from an explicit `0`).
+- `was_exploration`: NOT NULL DEFAULT false (semantic default for historical rows and non-signal inserts).
 
 ## Configuration
 
@@ -312,16 +335,16 @@ Kill switch: set `ENABLE_DIRECTION_EXPLORATION=false` and restart `dashboard-api
 ## Implementation sequence
 
 Single PR; tasks will be detailed in the implementation plan:
-1. DB migration DDL in `server.ts` startup (must run before any service that inserts into `paper_positions`)
-2. `paperPositionsRepo.open()` signature + INSERT extension
-3. `WeightedAverageCombiner` output extension (typed field + tests)
-4. `DirectionResolver` module + unit tests (deterministic RNG, mocked repo, breaker state transitions)
+1. DB migration — create init file `017_direction_multiplier_exploration_columns.sql` **and** add matching startup DDL in `server.ts` (must run before any service that inserts into `paper_positions`)
+2. Extend `PaperPosition` interface + BOTH INSERT sites (`insert` and `openPositionAtomically`) in `repositories.ts`
+3. `WeightedAverageCombiner` output extension (top-level `appliedDirectionMultiplier`, typed field + tests)
+4. `DirectionResolver` module + unit tests (deterministic RNG, mocked policy provider, mocked repo for breaker state transitions)
 5. `DirectionMultiplierLearningService` updates:
    - `DEFAULT_CONFIG` range + `maxPositiveMultiplier`
    - `bucketDirectionMultiplier` new buckets
-   - Learner SQL query: prefer `pp.applied_direction_multiplier` via COALESCE
-6. `SignalEngine` integration: inject resolver, replace sync `resolveDirectionMultiplier` with `await resolver.resolve()`, enrich output with `wasExploration` + `metadata.direction`
-7. `AutoSignalExecutor` propagates `appliedDirectionMultiplier` and `wasExploration` to repo
+   - Learner SQL: prefer `pp.applied_direction_multiplier` via COALESCE
+6. `SignalEngine` integration: inject resolver, replace sync `resolveDirectionMultiplier(policy, ctx)` call with `await resolver.resolve(ctx)`, set `appliedDirectionMultiplier` + `wasExploration` top-level on output, consolidate metadata into `metadata.direction`
+7. `AutoSignalExecutor` propagates new fields into the `PaperPosition` object passed to `openPositionAtomically`
 8. Env vars in `docker-compose.gcp.yml`
-9. Audit of non-signal callers of `paperPositionsRepo.open()` (`start-paper-trading.js`, any test harness); leave legacy defaults where present
+9. Audit of non-signal INSERT callers (`routes.ts` POST handlers, `PaperTradingService`, `scripts/start-paper-trading.js`); leave them using backward-compatible defaults (`null` / `false`)
 10. Integration test: end-to-end signal flow with mocked RNG hitting exploration branch, and a breaker-trip scenario that falls back to global

--- a/docs/plans/2026-04-20-direction-multiplier-exploration-design.md
+++ b/docs/plans/2026-04-20-direction-multiplier-exploration-design.md
@@ -1,0 +1,294 @@
+# Direction Multiplier Exploration — Design
+
+**Date:** 2026-04-20
+**Status:** Approved (awaiting implementation plan)
+**Scope:** Single PR — widen learner range + add epsilon-greedy exploration
+
+## Context & Motivation
+
+The `directionMultiplier` in `WeightedAverageCombiner` flips the combined signal direction (`strength * multiplier`). Currently pinned to `-1.0` globally (PR #104, 2026-04-18), with per-segment overrides via `DirectionMultiplierLearningService` (learner) bounded to `[-1.25, +0.1]`.
+
+### Empirical evidence (329 trades, 2026-04-07 → 2026-04-19)
+
+| Category | Trades | WR actual (flipped) | WR counterfactual (un-flipped) |
+|----------|--------|---------------------|-------------------------------|
+| event_short | 28 | 3.6% | **89.3%** |
+| event_long | 228 | 11.8% | **86.0%** |
+| crypto_daily | 4 | 0.0% | 100% |
+| event_financial | 68 | 20.6% | 79.4% |
+| crypto_intraday | 1 | 100% | 0% |
+| **Total** | **329** | **13.1%** | **86.9%** |
+
+The original justification for `-1.0` (commit `f7ea78d`, 2026-04-07) cited "91.5% WR if all 188 trades inverted". The current counterfactual for 329 trades shows the same asymmetry now favours un-flip. Post-reset PnL: −$1,125; counterfactual ≈ +$1,125.
+
+### Cold-start problem
+
+The learner (`deriveDirectionMultiplierPolicy`) compares candidate multiplier buckets **within a segment**. With global pinned `-1.0`, all trades fall in `strong_negative` bucket → single candidate → `best === baseline` → no promotion possible. The existing `event_financial-20to40-medium → -1.25` segment only promoted because its history contained trades at both `-1.0` and `-1.25` (ratchet effect). Widening the range without generating multi-bucket data yields a **structurally inert** learner.
+
+### Chosen approach
+
+Epsilon-greedy exploration: the resolver applies a random multiplier from `[0.0, 1.0]` (continuous uniform) to a small fraction of trades, generating the multi-bucket observations the learner requires.
+
+## Non-goals
+
+- **Not despinning the global multiplier.** Global stays pinned at `-1.0` in this PR. Despin is a separate follow-up PR once exploration produces evidence.
+- **Not modifying optimizer parameter space.** `direction_multiplier` stays out of Optuna (preserves PR #104 intent).
+- **Not adding Thompson sampling / bandit logic.** Future iteration if uniform sampling proves insufficient.
+- **Not resetting the paper account.** The learner's 30-day lookback window absorbs the transition naturally.
+- **Not changing signal generators or combiner math.** Only the multiplier resolution layer.
+
+## Design overview
+
+```
+SignalEngine
+    │
+    ▼
+DirectionResolver.resolve(context)
+    │
+    ├─ Segment match via resolveDirectionMultiplier(context, policy)
+    │     └─ segmentId found? → exploit (use segment multiplier)
+    │
+    ├─ No match + exploration disabled → exploit (use global -1.0)
+    │
+    └─ No match + exploration enabled (roll < epsilon)
+          └─ sample U(min, max) → explore (random multiplier)
+    │
+    ▼
+{ multiplier, segmentId, wasExploration, reason }
+    │
+    ▼
+WeightedAverageCombiner.setDirectionMultiplier(multiplier, ctxKey)
+WeightedAverageCombiner.combine() → output.appliedDirectionMultiplier
+    │
+    ▼
+SignalEngine enriches: { ...output, wasExploration, metadata.direction }
+    │
+    ▼
+AutoSignalExecutor → paperPositionsRepo.open(..., appliedDirectionMultiplier, wasExploration)
+    │
+    ▼
+INSERT INTO paper_positions (..., applied_direction_multiplier, was_exploration)
+```
+
+## Components
+
+### 1. `DirectionResolver` (new module)
+
+Location: `packages/dashboard/src/services/DirectionResolver.ts`
+
+```ts
+type ResolveReason = 'segment' | 'global' | 'exploration' | 'breaker_tripped';
+
+interface DirectionResolution {
+  multiplier: number;
+  segmentId: string | null;
+  wasExploration: boolean;
+  reason: ResolveReason;
+}
+
+interface DirectionResolverDeps {
+  policyProvider: () => Promise<DirectionMultiplierPolicy>;
+  explorationConfig: ExplorationConfig;
+  rng?: () => number;              // default Math.random — injectable for tests
+  paperPositionsRepo: PaperPositionsRepo;  // for circuit breaker state
+  logger: Logger;
+}
+
+interface ExplorationConfig {
+  enabled: boolean;        // env: ENABLE_DIRECTION_EXPLORATION (default true)
+  epsilon: number;         // env: DIRECTION_EXPLORATION_EPSILON (default 0.10)
+  min: number;             // env: DIRECTION_EXPLORATION_MIN (default 0.0)
+  max: number;             // env: DIRECTION_EXPLORATION_MAX (default 1.0)
+  breakerMinTrades: number;      // default 20
+  breakerWindowDays: number;     // default 7
+  breakerMaxCumLoss: number;     // default -150
+  breakerCacheTtlMs: number;     // default 300_000 (5 min)
+}
+
+class DirectionResolver {
+  async resolve(context: DirectionContext): Promise<DirectionResolution>;
+  private async isBreakerTripped(): Promise<boolean>;
+}
+```
+
+**Resolution order inside `resolve()`:**
+
+1. Load active policy (via `policyProvider` — `trading_config.direction_multiplier_policy`).
+2. Call pure `resolveDirectionMultiplier(context, policy)` → `{ multiplier, segmentId }`. If `segmentId !== null`, return `{ multiplier, segmentId, wasExploration: false, reason: 'segment' }`.
+3. Check `explorationConfig.enabled`. If false → return `{ multiplier: policy.global, ..., reason: 'global' }`.
+4. Check circuit breaker (`isBreakerTripped`, cached). If tripped → return global with `reason: 'breaker_tripped'`.
+5. Roll `rng() < epsilon`. If miss → return global with `reason: 'global'`.
+6. Hit: `sampled = min + rng() * (max - min)` → return `{ multiplier: sampled, segmentId: null, wasExploration: true, reason: 'exploration' }`.
+
+**Circuit breaker logic (`isBreakerTripped`):**
+
+```sql
+SELECT COUNT(*) AS explore_count,
+       COALESCE(SUM(realized_pnl), 0) AS explore_pnl
+FROM paper_positions
+WHERE was_exploration = true
+  AND closed_at >= NOW() - INTERVAL '7 days'
+  AND realized_pnl IS NOT NULL;
+```
+
+Tripped iff `explore_count >= breakerMinTrades AND explore_pnl < breakerMaxCumLoss`. Result cached for `breakerCacheTtlMs` (default 5 min) to avoid per-signal queries. On trip, emits event `direction_exploration:breaker_tripped` and writes a note to `trading_config` key `direction_exploration_status`.
+
+### 2. `DirectionMultiplierLearningService` (modify)
+
+Location: `packages/dashboard/src/services/DirectionMultiplierLearningService.ts`
+
+Changes to `DEFAULT_CONFIG`:
+```ts
+minMultiplier: -1.25,           // unchanged
+maxMultiplier: 1.0,             // was 0.1
+maxPositiveMultiplier: 1.0,     // was 0.1
+```
+
+Changes to `bucketDirectionMultiplier` (new bucket set matching the widened range):
+```ts
+if (multiplier <= -0.5) return 'strong_negative';
+if (multiplier < 0.25)  return 'near_zero';
+if (multiplier < 0.75)  return 'weak_positive';
+return 'strong_positive';
+```
+
+No other learner logic changes. Promotion thresholds (`minSegmentTrades=24`, `minCandidateTrades=8`, `minImprovementPerTrade=0.75`, `minWinRateLift=0.08`) unchanged — we do **not** relax promotion criteria.
+
+### 3. `SignalEngine` (modify)
+
+Location: `packages/dashboard/src/services/SignalEngine.ts`
+
+- Inject `DirectionResolver` via constructor.
+- Replace existing direct call to `resolveDirectionMultiplier` with `directionResolver.resolve(context)`.
+- After `combiner.combine()` returns, enrich the output:
+
+```ts
+return {
+  ...combined,
+  wasExploration: resolution.wasExploration,
+  metadata: {
+    ...combined.metadata,
+    direction: {
+      segmentId: resolution.segmentId,
+      reason: resolution.reason,
+    },
+  },
+};
+```
+
+### 4. `WeightedAverageCombiner` (modify)
+
+Location: `packages/signals/src/combiners/WeightedAverageCombiner.ts`
+
+- Extend `CombinedSignalOutput` type:
+```ts
+interface CombinedSignalOutput {
+  // ... existing fields
+  appliedDirectionMultiplier: number;
+  // metadata remains Record<string, unknown>
+}
+```
+- In `combine()`, include `appliedDirectionMultiplier: multiplier` (line 163, where `multiplier` is already computed) in the output object.
+
+Combiner does **not** know about exploration. `wasExploration` is attached upstream in SignalEngine.
+
+### 5. `AutoSignalExecutor` (modify)
+
+Location: `packages/dashboard/src/services/AutoSignalExecutor.ts`
+
+- On position open, pass two new fields to repo:
+```ts
+await paperPositionsRepo.open({
+  // ... existing
+  appliedDirectionMultiplier: signal.appliedDirectionMultiplier,
+  wasExploration: signal.wasExploration ?? false,
+});
+```
+
+### 6. `paperPositionsRepo.open()` (modify)
+
+Location: `packages/dashboard/src/repos/paperPositionsRepo.ts` (or equivalent).
+
+- Extend parameter type with two new fields (both optional in the signature for manual-script callers; defaults `NULL` and `false`).
+- Extend the INSERT SQL:
+```sql
+INSERT INTO paper_positions (
+  ..., applied_direction_multiplier, was_exploration
+) VALUES (..., $N, $N+1)
+```
+
+### 7. DB migration (startup DDL)
+
+Location: `packages/dashboard/src/server.ts` — alongside existing `trading_config` CREATE TABLE IF NOT EXISTS block.
+
+```sql
+ALTER TABLE paper_positions
+  ADD COLUMN IF NOT EXISTS applied_direction_multiplier NUMERIC(5,3),
+  ADD COLUMN IF NOT EXISTS was_exploration BOOLEAN NOT NULL DEFAULT false;
+```
+
+- `applied_direction_multiplier`: NULLABLE (pre-migration rows remain NULL — distinguishes "unknown legacy" from explicit `0`).
+- `was_exploration`: NOT NULL DEFAULT false (semantic default for all historical rows and non-signal inserts).
+
+## Configuration
+
+New env vars (defaults in `docker-compose.gcp.yml`):
+
+```yaml
+ENABLE_DIRECTION_EXPLORATION: "true"
+DIRECTION_EXPLORATION_EPSILON: "0.10"
+DIRECTION_EXPLORATION_MIN: "0.0"
+DIRECTION_EXPLORATION_MAX: "1.0"
+DIRECTION_EXPLORATION_BREAKER_MIN_TRADES: "20"
+DIRECTION_EXPLORATION_BREAKER_WINDOW_DAYS: "7"
+DIRECTION_EXPLORATION_BREAKER_MAX_CUM_LOSS: "-150"
+```
+
+Kill switch: set `ENABLE_DIRECTION_EXPLORATION=false` and restart `dashboard-api` — exploration disabled without code change.
+
+## Success criteria (30-day evaluation window)
+
+**Primary (validates un-flip hypothesis):**
+- ≥1 segment promoted by learner to a multiplier in `[+0.25, +1.0]` with ≥24 trades and verified lift vs `-1.0` baseline per existing promotion criteria.
+
+**Secondary (supporting signal for despin global in follow-up PR):**
+- Aggregate over 30 days on exploration trades that closed with non-null `realized_pnl`:
+  - `AVG(realized_pnl) WHERE was_exploration = true` exceeds
+    `AVG(realized_pnl) WHERE was_exploration = false AND applied_direction_multiplier = -1.0`
+    by at least **$0.50 per trade**.
+  - Expected exploration volume at current throughput: ~24 trades/30d (10% × 8 trades/day × 30 days). Sample is statistically weak — this criterion is a **supporting signal**, not standalone evidence. The primary criterion (segment promotion) carries the decision weight.
+  - Below 20 trades, suppress this criterion entirely (not enough data to reason about).
+
+**Failure modes (kills hypothesis):**
+- Circuit breaker trips ≥2 times in 30 days → exploration is net-negative. Abandon widen-learner path; investigate signal quality upstream instead.
+- 30 days elapse with zero segments promoted AND no positive aggregate — evidence absent, rollback exploration, consider alternative approaches (counterfactual backtesting, manual segment seeding).
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|-----------|
+| Exploration trades all lose (worst case 10% × 10 trades/day × worst avg ~$15 = ~$15/day) | Medium | Circuit breaker auto-disable at −$150 / 7d |
+| New bucket definitions destabilize existing event_financial promotion | Low | `minImprovementPerTrade=0.75` gate prevents spurious re-promotion; segment needs real evidence to change bucket |
+| `wasExploration` not threaded to all open callers | Low | Repo param optional with default `false`; audit `start-paper-trading.js` + any manual-entry scripts in implementation |
+| Manual intervention needed if breaker trips silently | Low | Emit event + write status to `trading_config.direction_exploration_status` for daily review visibility |
+| Concurrent learner evaluation while exploration active causes transient whipsaw | Low | Learner runs every 6h; `minSegmentTrades=24` smooths short-term noise |
+
+## Out of scope (future work)
+
+- **Despin global multiplier** (Cambio 2 from brainstorm): requires evidence from this PR first.
+- **Thompson sampling / bandit logic**: consider if uniform exploration is slow to converge.
+- **Account reset**: not needed for this PR; re-evaluate after 30 days of data.
+- **Adaptive exploration bounds**: `[min, max]` env-var-only for now; could be learner-driven later.
+- **Signal-level direction auditing**: if results are inconclusive, deeper investigation into why raw signals produced poor WR — potentially a generator-quality issue, not a multiplier issue.
+
+## Implementation sequence
+
+Single PR; tasks will be detailed in the implementation plan:
+1. DB migration DDL in `server.ts` startup
+2. `DirectionResolver` module + unit tests (deterministic RNG, mocked repo)
+3. `DirectionMultiplierLearningService` config + bucket updates (with test coverage for new buckets)
+4. `WeightedAverageCombiner` output extension (typed field + tests)
+5. `SignalEngine` integration (wire resolver, enrich output)
+6. `AutoSignalExecutor` + `paperPositionsRepo.open()` param propagation
+7. Env vars in `docker-compose.gcp.yml`
+8. Integration test: end-to-end signal flow with mocked RNG hitting exploration branch

--- a/docs/plans/2026-04-20-direction-multiplier-exploration-design.md
+++ b/docs/plans/2026-04-20-direction-multiplier-exploration-design.md
@@ -120,6 +120,12 @@ class DirectionResolver {
 5. Roll `rng() < epsilon`. If miss → return global with `reason: 'global'`.
 6. Hit: `sampled = min + rng() * (max - min)` → return `{ multiplier: sampled, segmentId: null, wasExploration: true, reason: 'exploration' }`.
 
+**Policy caching:** `policyProvider` is expected to cache internally (TTL ≥ 60s) since `resolve()` is called per-market per-signal-cycle (~15 markets × 60s cadence = 15 calls/min). The learner writes the policy every 6h, so a 60s–5min TTL is safe. The existing `tradingConfigRepo` has no cache — wrap it in a memoizer at the DirectionResolver's policyProvider or reuse any existing cache in SignalEngine for the same key. Decision deferred to implementation, but required.
+
+**Natural bias of sampled distribution:** `WeightedAverageCombiner` discards any combined signal where `|strength * multiplier| < minCombinedStrength` (0.27). For a raw strength of ~0.5 (typical), exploration multipliers below ~0.55 produce no trade. Effective exploration is thus weighted toward the upper half of `[0, 1.0]`. This is a desirable filter — near-zero multipliers correspond to "no signal" and shouldn't trade anyway — but it means we won't get data points in `near_zero` bucket from exploration alone. The `near_zero` bucket will only see meaningful trades via the learner promoting into it, which is self-consistent.
+
+**Async transition:** `SignalEngine`'s current call to `resolveDirectionMultiplier(policy, ctx)` is synchronous; `directionResolver.resolve(ctx)` is async (must await policy + breaker). The per-market generation path already awaits other repos; adding one more await is mechanical but must be threaded through any sync-only helpers.
+
 **Circuit breaker logic (`isBreakerTripped`):**
 
 ```sql
@@ -131,7 +137,20 @@ WHERE was_exploration = true
   AND realized_pnl IS NOT NULL;
 ```
 
-Tripped iff `explore_count >= breakerMinTrades AND explore_pnl < breakerMaxCumLoss`. Result cached for `breakerCacheTtlMs` (default 5 min) to avoid per-signal queries. On trip, emits event `direction_exploration:breaker_tripped` and writes a note to `trading_config` key `direction_exploration_status`.
+Tripped iff `explore_count >= breakerMinTrades AND explore_pnl < breakerMaxCumLoss`. Result cached for `breakerCacheTtlMs` (default 5 min) to avoid per-signal queries. On trip, emits event `direction_exploration:breaker_tripped` and writes a status object to `trading_config` key `direction_exploration_status`:
+
+```json
+{
+  "state": "tripped",
+  "trippedAt": "2026-04-25T14:22:10Z",
+  "exploreCount": 22,
+  "explorePnl": -172.45,
+  "thresholdTrades": 20,
+  "thresholdLoss": -150
+}
+```
+
+When the breaker un-trips (because the 7-day rolling window has evicted the losing trades), the next `resolve()` call that finds it un-tripped rewrites the status with `{ "state": "active", ... }`. This state transition is observable by the daily review script via a simple `SELECT value FROM trading_config WHERE key = 'direction_exploration_status'`.
 
 ### 2. `DirectionMultiplierLearningService` (modify)
 
@@ -151,6 +170,15 @@ if (multiplier < 0.25)  return 'near_zero';
 if (multiplier < 0.75)  return 'weak_positive';
 return 'strong_positive';
 ```
+
+**Learner query modification (critical):** the existing query joins `signal_weights_history` to recover the multiplier-at-trade-time. That column only tracks **global** multiplier changes and would mis-attribute every exploration trade to whichever global value was active at the time (e.g. `-1.0`), making multi-bucket data invisible to the learner. Fix:
+
+```sql
+-- COALESCE prefers the per-trade applied value; falls back to historical global for legacy rows
+COALESCE(pp.applied_direction_multiplier, dm.weight, $2) AS direction_multiplier
+```
+
+This ensures exploration trades and future per-segment overrides are bucketed by the multiplier actually applied to them, not by the contemporaneous global.
 
 No other learner logic changes. Promotion thresholds (`minSegmentTrades=24`, `minCandidateTrades=8`, `minImprovementPerTrade=0.75`, `minWinRateLift=0.08`) unchanged — we do **not** relax promotion criteria.
 
@@ -284,11 +312,16 @@ Kill switch: set `ENABLE_DIRECTION_EXPLORATION=false` and restart `dashboard-api
 ## Implementation sequence
 
 Single PR; tasks will be detailed in the implementation plan:
-1. DB migration DDL in `server.ts` startup
-2. `DirectionResolver` module + unit tests (deterministic RNG, mocked repo)
-3. `DirectionMultiplierLearningService` config + bucket updates (with test coverage for new buckets)
-4. `WeightedAverageCombiner` output extension (typed field + tests)
-5. `SignalEngine` integration (wire resolver, enrich output)
-6. `AutoSignalExecutor` + `paperPositionsRepo.open()` param propagation
-7. Env vars in `docker-compose.gcp.yml`
-8. Integration test: end-to-end signal flow with mocked RNG hitting exploration branch
+1. DB migration DDL in `server.ts` startup (must run before any service that inserts into `paper_positions`)
+2. `paperPositionsRepo.open()` signature + INSERT extension
+3. `WeightedAverageCombiner` output extension (typed field + tests)
+4. `DirectionResolver` module + unit tests (deterministic RNG, mocked repo, breaker state transitions)
+5. `DirectionMultiplierLearningService` updates:
+   - `DEFAULT_CONFIG` range + `maxPositiveMultiplier`
+   - `bucketDirectionMultiplier` new buckets
+   - Learner SQL query: prefer `pp.applied_direction_multiplier` via COALESCE
+6. `SignalEngine` integration: inject resolver, replace sync `resolveDirectionMultiplier` with `await resolver.resolve()`, enrich output with `wasExploration` + `metadata.direction`
+7. `AutoSignalExecutor` propagates `appliedDirectionMultiplier` and `wasExploration` to repo
+8. Env vars in `docker-compose.gcp.yml`
+9. Audit of non-signal callers of `paperPositionsRepo.open()` (`start-paper-trading.js`, any test harness); leave legacy defaults where present
+10. Integration test: end-to-end signal flow with mocked RNG hitting exploration branch, and a breaker-trip scenario that falls back to global

--- a/docs/plans/2026-04-20-direction-multiplier-exploration-plan.md
+++ b/docs/plans/2026-04-20-direction-multiplier-exploration-plan.md
@@ -1,0 +1,1636 @@
+# Direction Multiplier Exploration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable epsilon-greedy exploration of positive direction-multiplier values, widen learner range to `[-1.25, +1.0]`, and record per-trade multiplier provenance so the `DirectionMultiplierLearningService` can discover un-flip segments.
+
+**Architecture:** New stateless `DirectionResolver` module sits between `SignalEngine` and `WeightedAverageCombiner`. It wraps the existing pure `resolveDirectionMultiplier()` and adds an exploration branch: on segment miss, roll a uniform random; if hit, sample a multiplier from `[min, max]`. A 5-min-cached circuit breaker reads recent exploration PnL from `paper_positions`. Two new columns (`applied_direction_multiplier`, `was_exploration`) propagate the applied multiplier through to closed trades so the learner can bucket them correctly.
+
+**Tech Stack:** TypeScript, Vitest, PostgreSQL/TimescaleDB, existing monorepo packages (`packages/dashboard`, `packages/signals`, `packages/data-collector`).
+
+**Spec:** [`docs/plans/2026-04-20-direction-multiplier-exploration-design.md`](./2026-04-20-direction-multiplier-exploration-design.md)
+
+---
+
+## Task 1: DB migration — init file + startup DDL
+
+**Files:**
+- Create: `packages/data-collector/src/database/init/017_direction_multiplier_exploration_columns.sql`
+- Modify: `packages/dashboard/src/server.ts` (startup DDL block near existing `trading_config` creation)
+
+- [ ] **Step 1: Create the init migration file**
+
+Create `packages/data-collector/src/database/init/017_direction_multiplier_exploration_columns.sql`:
+
+```sql
+-- Direction multiplier exploration: per-trade multiplier provenance
+-- Adds two columns to paper_positions so the learner can bucket trades
+-- by the actual applied multiplier (not just the contemporaneous global).
+ALTER TABLE paper_positions
+  ADD COLUMN IF NOT EXISTS applied_direction_multiplier NUMERIC(5,3),
+  ADD COLUMN IF NOT EXISTS was_exploration BOOLEAN NOT NULL DEFAULT false;
+```
+
+- [ ] **Step 2: Locate the startup DDL block in `server.ts`**
+
+Run: `grep -n "CREATE TABLE IF NOT EXISTS trading_config" packages/dashboard/src/server.ts`
+
+Expected output: a line number for the existing trading_config DDL.
+
+- [ ] **Step 3: Add the same ALTER TABLE statement in the startup DDL block**
+
+In `packages/dashboard/src/server.ts`, immediately after the `CREATE TABLE IF NOT EXISTS trading_config ...` execution, add:
+
+```ts
+await query(`
+  ALTER TABLE paper_positions
+    ADD COLUMN IF NOT EXISTS applied_direction_multiplier NUMERIC(5,3),
+    ADD COLUMN IF NOT EXISTS was_exploration BOOLEAN NOT NULL DEFAULT false
+`);
+console.log('paper_positions direction exploration columns ensured');
+```
+
+- [ ] **Step 4: Verify the migration file is picked up**
+
+Run: `ls packages/data-collector/src/database/init/ | tail -5`
+Expected: `017_direction_multiplier_exploration_columns.sql` appears after `016_...`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add packages/data-collector/src/database/init/017_direction_multiplier_exploration_columns.sql packages/dashboard/src/server.ts
+rtk git commit -m "migration: add applied_direction_multiplier and was_exploration to paper_positions"
+```
+
+---
+
+## Task 2: Extend `PaperPosition` + update both INSERT sites
+
+**Files:**
+- Modify: `packages/dashboard/src/database/repositories.ts` (PaperPosition interface + `insert()` line ~341 + `openPositionAtomically()` line ~421)
+- Modify: `packages/dashboard/src/database/repositories.test.ts`
+
+- [ ] **Step 1: Write failing test for the new columns**
+
+Add to `packages/dashboard/src/database/repositories.test.ts`:
+
+```ts
+describe('paperPositionsRepo — direction multiplier fields', () => {
+  it('includes applied_direction_multiplier and was_exploration in INSERT', async () => {
+    const querySpy = vi.spyOn(indexMod, 'query').mockResolvedValue({ rows: [], rowCount: 0 } as any);
+    await paperPositionsRepo.insert({
+      market_id: 'mkt1',
+      token_id: 'tok1',
+      side: 'long',
+      size: 10,
+      avg_entry_price: 0.5,
+      current_price: 0.5,
+      opened_at: new Date('2026-04-20T12:00:00Z'),
+      applied_direction_multiplier: 0.75,
+      was_exploration: true,
+    });
+    const sql = querySpy.mock.calls[0][0] as string;
+    const params = querySpy.mock.calls[0][1] as unknown[];
+    expect(sql).toContain('applied_direction_multiplier');
+    expect(sql).toContain('was_exploration');
+    expect(params).toContain(0.75);
+    expect(params).toContain(true);
+    querySpy.mockRestore();
+  });
+
+  it('defaults applied_direction_multiplier to null and was_exploration to false when omitted', async () => {
+    const querySpy = vi.spyOn(indexMod, 'query').mockResolvedValue({ rows: [], rowCount: 0 } as any);
+    await paperPositionsRepo.insert({
+      market_id: 'mkt1', token_id: 'tok1', side: 'long', size: 10,
+      avg_entry_price: 0.5, current_price: 0.5, opened_at: new Date(),
+    });
+    const params = querySpy.mock.calls[0][1] as unknown[];
+    expect(params).toContain(null);
+    expect(params).toContain(false);
+    querySpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && pnpm test repositories.test.ts -t "direction multiplier fields" 2>&1 | tail -20`
+Expected: FAIL — "applied_direction_multiplier" not in SQL / params.
+
+- [ ] **Step 3: Extend `PaperPosition` interface**
+
+In `packages/dashboard/src/database/repositories.ts`, inside the `PaperPosition` interface (around line 310-335), add:
+
+```ts
+  applied_direction_multiplier?: number | null;
+  was_exploration?: boolean;
+```
+
+- [ ] **Step 4: Update `insert()` (line ~341) INSERT statement**
+
+Replace the `insert()` body in `packages/dashboard/src/database/repositories.ts`:
+
+```ts
+  async insert(position: PaperPosition): Promise<void> {
+    await query(
+      `INSERT INTO paper_positions
+       (market_id, token_id, side, size, avg_entry_price, current_price,
+        unrealized_pnl, unrealized_pnl_pct, realized_pnl, stop_loss, take_profit,
+        opened_at, signal_type, metadata, market_score_at_entry, score_dimensions_at_entry,
+        execution_mode, applied_direction_multiplier, was_exploration)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
+      [
+        position.market_id,
+        position.token_id,
+        position.side,
+        position.size,
+        position.avg_entry_price,
+        position.current_price,
+        position.unrealized_pnl,
+        position.unrealized_pnl_pct,
+        position.realized_pnl ?? 0,
+        position.stop_loss,
+        position.take_profit,
+        position.opened_at,
+        position.signal_type,
+        JSON.stringify(position.metadata ?? {}),
+        position.market_score_at_entry ?? null,
+        position.score_dimensions_at_entry != null ? JSON.stringify(position.score_dimensions_at_entry) : null,
+        position.execution_mode ?? 'paper',
+        position.applied_direction_multiplier ?? null,
+        position.was_exploration ?? false,
+      ]
+    );
+  },
+```
+
+- [ ] **Step 5: Update `openPositionAtomically()` (line ~421) INSERT statement**
+
+In the same file, replace the `INSERT INTO paper_positions` block inside `openPositionAtomically`:
+
+```ts
+        await client.query(
+          `INSERT INTO paper_positions
+           (market_id, token_id, side, size, avg_entry_price, current_price,
+            unrealized_pnl, unrealized_pnl_pct, realized_pnl, stop_loss, take_profit,
+            opened_at, signal_type, metadata, market_score_at_entry, score_dimensions_at_entry,
+            execution_mode, applied_direction_multiplier, was_exploration)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
+          [
+            position.market_id, position.token_id, position.side, position.size,
+            position.avg_entry_price, position.current_price,
+            position.unrealized_pnl ?? 0, position.unrealized_pnl_pct ?? 0,
+            0, position.stop_loss, position.take_profit, position.opened_at,
+            position.signal_type, JSON.stringify(position.metadata ?? {}),
+            position.market_score_at_entry ?? null,
+            position.score_dimensions_at_entry != null ? JSON.stringify(position.score_dimensions_at_entry) : null,
+            position.execution_mode ?? 'paper',
+            position.applied_direction_multiplier ?? null,
+            position.was_exploration ?? false,
+          ]
+        );
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd packages/dashboard && pnpm test repositories.test.ts -t "direction multiplier fields" 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full repositories test suite to confirm no regressions**
+
+Run: `cd packages/dashboard && pnpm test repositories.test.ts 2>&1 | tail -15`
+Expected: all tests pass (pre-existing + the two new).
+
+- [ ] **Step 8: Commit**
+
+```bash
+rtk git add packages/dashboard/src/database/repositories.ts packages/dashboard/src/database/repositories.test.ts
+rtk git commit -m "feat(repo): persist applied_direction_multiplier and was_exploration on paper_positions inserts"
+```
+
+---
+
+## Task 3: Extend `CombinedSignalOutput` + populate from combiner
+
+**Files:**
+- Modify: `packages/signals/src/core/types/signal.types.ts` (interface at line ~167)
+- Modify: `packages/signals/src/combiners/WeightedAverageCombiner.ts` (output object at line ~188)
+- Modify: `packages/signals/src/combiners/WeightedAverageCombiner.test.ts`
+
+- [ ] **Step 1: Write failing test for the new field**
+
+Add to `packages/signals/src/combiners/WeightedAverageCombiner.test.ts`:
+
+```ts
+describe('WeightedAverageCombiner — applied direction multiplier', () => {
+  it('exposes applied multiplier in CombinedSignalOutput', () => {
+    const combiner = new WeightedAverageCombiner(baseWeights(), params());
+    combiner.setDirectionMultiplier(0.5, 'test-ctx');
+    const signals = [buildSignal({ signalId: 'momentum', direction: 'long', strength: 0.6, confidence: 0.8 })];
+    const result = combiner.combine(signals, undefined, 'event_long', 'test-ctx');
+    expect(result).not.toBeNull();
+    expect(result!.appliedDirectionMultiplier).toBe(0.5);
+  });
+
+  it('defaults appliedDirectionMultiplier to 1.0 when no context override', () => {
+    const combiner = new WeightedAverageCombiner(baseWeights(), params());
+    const signals = [buildSignal({ signalId: 'momentum', direction: 'long', strength: 0.6, confidence: 0.8 })];
+    const result = combiner.combine(signals);
+    expect(result).not.toBeNull();
+    expect(result!.appliedDirectionMultiplier).toBe(1.0);
+  });
+});
+```
+
+(Assumes `baseWeights`, `params`, and `buildSignal` test helpers already exist in the file. If not, copy from existing tests in the same file.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/signals && pnpm test WeightedAverageCombiner.test.ts -t "applied direction multiplier" 2>&1 | tail -20`
+Expected: FAIL — `appliedDirectionMultiplier` is undefined.
+
+- [ ] **Step 3: Extend `CombinedSignalOutput` interface**
+
+In `packages/signals/src/core/types/signal.types.ts`, at the `CombinedSignalOutput` interface (around line 167-175), add:
+
+```ts
+export interface CombinedSignalOutput extends SignalOutput {
+  /** Individual signals that contributed */
+  componentSignals: SignalOutput[];
+
+  /** Weights used in combination */
+  weights: Record<string, number>;
+
+  /** Multiplier applied to combined strength (post-flip value). Defaults to 1.0. */
+  appliedDirectionMultiplier: number;
+
+  /** Whether the multiplier came from epsilon-greedy exploration slot.
+   *  False for segment hits, global fallback, and breaker-tripped fallback. */
+  wasExploration?: boolean;
+}
+```
+
+(Keep existing fields; only `appliedDirectionMultiplier` and optional `wasExploration` are new.)
+
+- [ ] **Step 4: Populate `appliedDirectionMultiplier` in combiner output**
+
+In `packages/signals/src/combiners/WeightedAverageCombiner.ts`, modify the `combinedOutput` object built around line 188. The `multiplier` local variable is already computed at line 162. Add the new field:
+
+```ts
+    const combinedOutput: CombinedSignalOutput = {
+      signalId: 'combined',
+      marketId: firstSignal.marketId,
+      tokenId: firstSignal.tokenId,
+      direction,
+      strength,
+      confidence,
+      timestamp: now,
+      ttlMs: Math.min(...usedSignals.map(s => s.signal.ttlMs)),
+      componentSignals: usedSignals.map(s => s.signal),
+      weights: this.getCurrentWeights(usedSignals),
+      appliedDirectionMultiplier: multiplier,
+      metadata: {
+        combinerType: 'weighted_average',
+        signalCount: usedSignals.length,
+        conflictResolution: params.conflictResolution,
+      },
+    };
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd packages/signals && pnpm test WeightedAverageCombiner.test.ts -t "applied direction multiplier" 2>&1 | tail -20`
+Expected: PASS for both new cases.
+
+- [ ] **Step 6: Run the full combiner test suite**
+
+Run: `cd packages/signals && pnpm test WeightedAverageCombiner.test.ts 2>&1 | tail -15`
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+rtk git add packages/signals/src/core/types/signal.types.ts packages/signals/src/combiners/WeightedAverageCombiner.ts packages/signals/src/combiners/WeightedAverageCombiner.test.ts
+rtk git commit -m "feat(combiner): expose appliedDirectionMultiplier on CombinedSignalOutput"
+```
+
+---
+
+## Task 4: `DirectionResolver` — segment match path (happy path)
+
+**Files:**
+- Create: `packages/dashboard/src/services/DirectionResolver.ts`
+- Create: `packages/dashboard/src/services/DirectionResolver.test.ts`
+
+- [ ] **Step 1: Write failing test for the segment-match branch**
+
+Create `packages/dashboard/src/services/DirectionResolver.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DirectionResolver } from './DirectionResolver.js';
+import type { DirectionMultiplierPolicy } from './DirectionMultiplierPolicy.js';
+
+const stubRepo = {
+  getExplorationStats: vi.fn().mockResolvedValue({ count: 0, pnl: 0 }),
+};
+
+const stubConfig = {
+  enabled: true,
+  epsilon: 0.1,
+  min: 0.0,
+  max: 1.0,
+  breakerMinTrades: 20,
+  breakerWindowDays: 7,
+  breakerMaxCumLoss: -150,
+  breakerCacheTtlMs: 300_000,
+};
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+describe('DirectionResolver — segment match', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns segment multiplier with reason=segment when a segment matches', async () => {
+    const policy: DirectionMultiplierPolicy = {
+      global: -1.0,
+      minMultiplier: -1.25,
+      maxMultiplier: 1.0,
+      segments: [{
+        id: 'event_financial-20to40-medium',
+        multiplier: -1.25,
+        marketTypes: ['event_financial'],
+        priceRange: { min: 0.2, max: 0.4 },
+        durationBands: ['medium'],
+      }],
+    };
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: stubConfig,
+      rng: () => 0.5,  // would roll exploration if it got there
+      paperPositionsRepo: stubRepo as any,
+      logger,
+    });
+
+    const result = await resolver.resolve({
+      marketType: 'event_financial',
+      currentPrice: 0.3,
+      endDate: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000),  // medium duration
+    });
+
+    expect(result.multiplier).toBe(-1.25);
+    expect(result.segmentId).toBe('event_financial-20to40-medium');
+    expect(result.wasExploration).toBe(false);
+    expect(result.reason).toBe('segment');
+    expect(result.contextKey).toContain('event_financial');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && pnpm test DirectionResolver.test.ts 2>&1 | tail -20`
+Expected: FAIL — `DirectionResolver.js` cannot be resolved.
+
+- [ ] **Step 3: Implement minimal `DirectionResolver`**
+
+Create `packages/dashboard/src/services/DirectionResolver.ts`:
+
+```ts
+import {
+  resolveDirectionMultiplier,
+  type DirectionMultiplierContext,
+  type DirectionMultiplierPolicy,
+} from './DirectionMultiplierPolicy.js';
+
+export type DirectionResolveReason = 'segment' | 'global' | 'exploration' | 'breaker_tripped';
+
+export interface DirectionResolution {
+  multiplier: number;
+  contextKey: string;
+  segmentId: string | null;
+  wasExploration: boolean;
+  reason: DirectionResolveReason;
+}
+
+export interface DirectionExplorationConfig {
+  enabled: boolean;
+  epsilon: number;
+  min: number;
+  max: number;
+  breakerMinTrades: number;
+  breakerWindowDays: number;
+  breakerMaxCumLoss: number;
+  breakerCacheTtlMs: number;
+}
+
+export interface DirectionResolverPaperPositionsRepo {
+  getExplorationStats(windowDays: number): Promise<{ count: number; pnl: number }>;
+}
+
+interface Logger {
+  info(obj: object, msg?: string): void;
+  warn(obj: object, msg?: string): void;
+  error(obj: object, msg?: string): void;
+  debug(obj: object, msg?: string): void;
+}
+
+export interface DirectionResolverDeps {
+  policyProvider: () => Promise<DirectionMultiplierPolicy>;
+  explorationConfig: DirectionExplorationConfig;
+  paperPositionsRepo: DirectionResolverPaperPositionsRepo;
+  logger: Logger;
+  rng?: () => number;
+}
+
+export class DirectionResolver {
+  private readonly rng: () => number;
+
+  constructor(private readonly deps: DirectionResolverDeps) {
+    this.rng = deps.rng ?? Math.random;
+  }
+
+  async resolve(context: DirectionMultiplierContext): Promise<DirectionResolution> {
+    const policy = await this.deps.policyProvider();
+    const base = resolveDirectionMultiplier(policy, context);
+
+    if (base.segmentId !== null) {
+      return {
+        multiplier: base.multiplier,
+        contextKey: base.contextKey,
+        segmentId: base.segmentId,
+        wasExploration: false,
+        reason: 'segment',
+      };
+    }
+
+    // Segment miss — exploration and breaker branches added in later tasks.
+    return {
+      multiplier: policy.global,
+      contextKey: base.contextKey,
+      segmentId: null,
+      wasExploration: false,
+      reason: 'global',
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/dashboard && pnpm test DirectionResolver.test.ts 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add packages/dashboard/src/services/DirectionResolver.ts packages/dashboard/src/services/DirectionResolver.test.ts
+rtk git commit -m "feat: DirectionResolver skeleton with segment-match path"
+```
+
+---
+
+## Task 5: `DirectionResolver` — exploration sampling branch
+
+**Files:**
+- Modify: `packages/dashboard/src/services/DirectionResolver.ts`
+- Modify: `packages/dashboard/src/services/DirectionResolver.test.ts`
+
+- [ ] **Step 1: Write failing test for exploration and non-exploration paths**
+
+Add to `DirectionResolver.test.ts`:
+
+```ts
+describe('DirectionResolver — exploration sampling', () => {
+  const policy: DirectionMultiplierPolicy = {
+    global: -1.0, minMultiplier: -1.25, maxMultiplier: 1.0, segments: [],
+  };
+  const ctx = {
+    marketType: 'event_long',
+    currentPrice: 0.3,
+    endDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+  };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns global when segment misses and rng misses epsilon', async () => {
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: stubConfig,
+      // First rng call is the epsilon roll; 0.5 > 0.1 epsilon → miss
+      rng: () => 0.5,
+      paperPositionsRepo: stubRepo as any,
+      logger,
+    });
+    const result = await resolver.resolve(ctx);
+    expect(result.multiplier).toBe(-1.0);
+    expect(result.wasExploration).toBe(false);
+    expect(result.reason).toBe('global');
+  });
+
+  it('samples uniformly from [min, max] when segment misses and rng hits epsilon', async () => {
+    // 1st rng() = 0.05 → < 0.1 epsilon → hit.
+    // 2nd rng() = 0.7 → sampled = 0 + 0.7 * (1 - 0) = 0.7
+    const rngCalls = [0.05, 0.7];
+    let i = 0;
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: stubConfig,
+      rng: () => rngCalls[i++],
+      paperPositionsRepo: stubRepo as any,
+      logger,
+    });
+    const result = await resolver.resolve(ctx);
+    expect(result.multiplier).toBeCloseTo(0.7, 5);
+    expect(result.wasExploration).toBe(true);
+    expect(result.reason).toBe('exploration');
+    expect(result.segmentId).toBeNull();
+  });
+
+  it('returns global with reason=global when exploration is disabled, regardless of rng', async () => {
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: { ...stubConfig, enabled: false },
+      rng: () => 0.0,  // would normally trigger exploration
+      paperPositionsRepo: stubRepo as any,
+      logger,
+    });
+    const result = await resolver.resolve(ctx);
+    expect(result.multiplier).toBe(-1.0);
+    expect(result.wasExploration).toBe(false);
+    expect(result.reason).toBe('global');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/dashboard && pnpm test DirectionResolver.test.ts -t "exploration sampling" 2>&1 | tail -30`
+Expected: FAIL — current implementation always returns global on segment miss.
+
+- [ ] **Step 3: Extend `DirectionResolver.resolve()` with the exploration branch**
+
+In `packages/dashboard/src/services/DirectionResolver.ts`, replace the "Segment miss" block:
+
+```ts
+    // Segment miss — consider exploration.
+    if (!this.deps.explorationConfig.enabled) {
+      return {
+        multiplier: policy.global,
+        contextKey: base.contextKey,
+        segmentId: null,
+        wasExploration: false,
+        reason: 'global',
+      };
+    }
+
+    const roll = this.rng();
+    if (roll >= this.deps.explorationConfig.epsilon) {
+      return {
+        multiplier: policy.global,
+        contextKey: base.contextKey,
+        segmentId: null,
+        wasExploration: false,
+        reason: 'global',
+      };
+    }
+
+    const { min, max } = this.deps.explorationConfig;
+    const sampled = min + this.rng() * (max - min);
+    return {
+      multiplier: sampled,
+      contextKey: base.contextKey,
+      segmentId: null,
+      wasExploration: true,
+      reason: 'exploration',
+    };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/dashboard && pnpm test DirectionResolver.test.ts 2>&1 | tail -20`
+Expected: all 4 tests pass (segment + 3 exploration scenarios).
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add packages/dashboard/src/services/DirectionResolver.ts packages/dashboard/src/services/DirectionResolver.test.ts
+rtk git commit -m "feat(DirectionResolver): epsilon-greedy exploration on segment miss"
+```
+
+---
+
+## Task 6: `DirectionResolver` — circuit breaker with TTL cache
+
+**Files:**
+- Modify: `packages/dashboard/src/services/DirectionResolver.ts`
+- Modify: `packages/dashboard/src/services/DirectionResolver.test.ts`
+
+- [ ] **Step 1: Write failing tests for breaker-tripped and cache behavior**
+
+Add to `DirectionResolver.test.ts`:
+
+```ts
+describe('DirectionResolver — circuit breaker', () => {
+  const policy: DirectionMultiplierPolicy = {
+    global: -1.0, minMultiplier: -1.25, maxMultiplier: 1.0, segments: [],
+  };
+  const ctx = {
+    marketType: 'event_long',
+    currentPrice: 0.3,
+    endDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+  };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns global with reason=breaker_tripped when exploration losses exceed threshold', async () => {
+    const repo = { getExplorationStats: vi.fn().mockResolvedValue({ count: 22, pnl: -172.45 }) };
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: stubConfig,
+      rng: () => 0.05,  // would sample exploration otherwise
+      paperPositionsRepo: repo as any,
+      logger,
+    });
+    const result = await resolver.resolve(ctx);
+    expect(result.reason).toBe('breaker_tripped');
+    expect(result.wasExploration).toBe(false);
+    expect(result.multiplier).toBe(-1.0);
+  });
+
+  it('does not trip when count below minTrades', async () => {
+    const repo = { getExplorationStats: vi.fn().mockResolvedValue({ count: 19, pnl: -500 }) };
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: stubConfig,
+      rng: () => 0.05,
+      paperPositionsRepo: repo as any,
+      logger,
+    });
+    const result = await resolver.resolve(ctx);
+    // Should proceed to sampling, not breaker_tripped
+    expect(result.reason).toBe('exploration');
+  });
+
+  it('caches breaker state and does not requery within TTL', async () => {
+    const repo = { getExplorationStats: vi.fn().mockResolvedValue({ count: 22, pnl: -200 }) };
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: { ...stubConfig, breakerCacheTtlMs: 60_000 },
+      rng: () => 0.05,
+      paperPositionsRepo: repo as any,
+      logger,
+    });
+    await resolver.resolve(ctx);
+    await resolver.resolve(ctx);
+    await resolver.resolve(ctx);
+    expect(repo.getExplorationStats).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/dashboard && pnpm test DirectionResolver.test.ts -t "circuit breaker" 2>&1 | tail -30`
+Expected: FAIL — breaker logic not yet implemented.
+
+- [ ] **Step 3: Add breaker state + check to `DirectionResolver`**
+
+In `packages/dashboard/src/services/DirectionResolver.ts`, add a private cache field to the class and a private method:
+
+```ts
+export class DirectionResolver {
+  private readonly rng: () => number;
+  private breakerCache: { tripped: boolean; fetchedAt: number; stats: { count: number; pnl: number } } | null = null;
+
+  constructor(private readonly deps: DirectionResolverDeps) {
+    this.rng = deps.rng ?? Math.random;
+  }
+
+  private async isBreakerTripped(): Promise<boolean> {
+    const now = Date.now();
+    if (this.breakerCache && now - this.breakerCache.fetchedAt < this.deps.explorationConfig.breakerCacheTtlMs) {
+      return this.breakerCache.tripped;
+    }
+    const stats = await this.deps.paperPositionsRepo.getExplorationStats(
+      this.deps.explorationConfig.breakerWindowDays,
+    );
+    const tripped =
+      stats.count >= this.deps.explorationConfig.breakerMinTrades &&
+      stats.pnl < this.deps.explorationConfig.breakerMaxCumLoss;
+    this.breakerCache = { tripped, fetchedAt: now, stats };
+    return tripped;
+  }
+
+  async resolve(context: DirectionMultiplierContext): Promise<DirectionResolution> {
+    const policy = await this.deps.policyProvider();
+    const base = resolveDirectionMultiplier(policy, context);
+
+    if (base.segmentId !== null) {
+      return {
+        multiplier: base.multiplier,
+        contextKey: base.contextKey,
+        segmentId: base.segmentId,
+        wasExploration: false,
+        reason: 'segment',
+      };
+    }
+
+    if (!this.deps.explorationConfig.enabled) {
+      return {
+        multiplier: policy.global,
+        contextKey: base.contextKey,
+        segmentId: null,
+        wasExploration: false,
+        reason: 'global',
+      };
+    }
+
+    if (await this.isBreakerTripped()) {
+      return {
+        multiplier: policy.global,
+        contextKey: base.contextKey,
+        segmentId: null,
+        wasExploration: false,
+        reason: 'breaker_tripped',
+      };
+    }
+
+    const roll = this.rng();
+    if (roll >= this.deps.explorationConfig.epsilon) {
+      return {
+        multiplier: policy.global,
+        contextKey: base.contextKey,
+        segmentId: null,
+        wasExploration: false,
+        reason: 'global',
+      };
+    }
+
+    const { min, max } = this.deps.explorationConfig;
+    const sampled = min + this.rng() * (max - min);
+    return {
+      multiplier: sampled,
+      contextKey: base.contextKey,
+      segmentId: null,
+      wasExploration: true,
+      reason: 'exploration',
+    };
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/dashboard && pnpm test DirectionResolver.test.ts 2>&1 | tail -20`
+Expected: all 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add packages/dashboard/src/services/DirectionResolver.ts packages/dashboard/src/services/DirectionResolver.test.ts
+rtk git commit -m "feat(DirectionResolver): TTL-cached circuit breaker on exploration PnL"
+```
+
+---
+
+## Task 7: Add `getExplorationStats` to paperPositionsRepo + `trading_config` status write
+
+**Files:**
+- Modify: `packages/dashboard/src/database/repositories.ts` (add `getExplorationStats` method)
+- Modify: `packages/dashboard/src/services/DirectionResolver.ts` (write status on trip)
+- Modify: `packages/dashboard/src/services/DirectionResolver.test.ts`
+
+- [ ] **Step 1: Write failing test for status-write on trip**
+
+Add to `DirectionResolver.test.ts`:
+
+```ts
+describe('DirectionResolver — breaker status write', () => {
+  const policy: DirectionMultiplierPolicy = {
+    global: -1.0, minMultiplier: -1.25, maxMultiplier: 1.0, segments: [],
+  };
+  const ctx = {
+    marketType: 'event_long',
+    currentPrice: 0.3,
+    endDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+  };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('writes status=tripped to trading_config when breaker first trips', async () => {
+    const repo = { getExplorationStats: vi.fn().mockResolvedValue({ count: 22, pnl: -172.45 }) };
+    const setConfig = vi.fn().mockResolvedValue(undefined);
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: stubConfig,
+      rng: () => 0.05,
+      paperPositionsRepo: repo as any,
+      logger,
+      setTradingConfig: setConfig,
+    });
+    await resolver.resolve(ctx);
+    expect(setConfig).toHaveBeenCalledWith(
+      'direction_exploration_status',
+      expect.objectContaining({
+        state: 'tripped',
+        exploreCount: 22,
+        explorePnl: -172.45,
+        thresholdTrades: 20,
+        thresholdLoss: -150,
+      }),
+      expect.any(String),
+    );
+  });
+
+  it('writes status=active when breaker un-trips after previously tripped', async () => {
+    // First call: tripped. Second call (after cache expires): no longer tripped.
+    const repo = {
+      getExplorationStats: vi.fn()
+        .mockResolvedValueOnce({ count: 22, pnl: -172 })
+        .mockResolvedValueOnce({ count: 8, pnl: -30 }),
+    };
+    const setConfig = vi.fn().mockResolvedValue(undefined);
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: { ...stubConfig, breakerCacheTtlMs: 0 },  // disable cache for test
+      rng: () => 0.05,
+      paperPositionsRepo: repo as any,
+      logger,
+      setTradingConfig: setConfig,
+    });
+    await resolver.resolve(ctx);
+    await resolver.resolve(ctx);
+    const calls = setConfig.mock.calls.map(c => c[1].state);
+    expect(calls).toEqual(['tripped', 'active']);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/dashboard && pnpm test DirectionResolver.test.ts -t "breaker status write" 2>&1 | tail -30`
+Expected: FAIL — `setTradingConfig` not accepted in deps.
+
+- [ ] **Step 3: Add `setTradingConfig` to deps and wire into breaker transitions**
+
+In `packages/dashboard/src/services/DirectionResolver.ts`, extend `DirectionResolverDeps` and update the class:
+
+```ts
+export interface DirectionResolverDeps {
+  policyProvider: () => Promise<DirectionMultiplierPolicy>;
+  explorationConfig: DirectionExplorationConfig;
+  paperPositionsRepo: DirectionResolverPaperPositionsRepo;
+  logger: Logger;
+  rng?: () => number;
+  setTradingConfig?: (key: string, value: unknown, changeReason: string) => Promise<void>;
+}
+```
+
+Modify `isBreakerTripped` to detect transitions and call `setTradingConfig`:
+
+```ts
+  private async isBreakerTripped(): Promise<boolean> {
+    const now = Date.now();
+    if (this.breakerCache && now - this.breakerCache.fetchedAt < this.deps.explorationConfig.breakerCacheTtlMs) {
+      return this.breakerCache.tripped;
+    }
+    const stats = await this.deps.paperPositionsRepo.getExplorationStats(
+      this.deps.explorationConfig.breakerWindowDays,
+    );
+    const tripped =
+      stats.count >= this.deps.explorationConfig.breakerMinTrades &&
+      stats.pnl < this.deps.explorationConfig.breakerMaxCumLoss;
+
+    const prevTripped = this.breakerCache?.tripped ?? null;
+    this.breakerCache = { tripped, fetchedAt: now, stats };
+
+    if (this.deps.setTradingConfig && (prevTripped === null || prevTripped !== tripped)) {
+      const status = {
+        state: tripped ? 'tripped' : 'active',
+        transitionAt: new Date(now).toISOString(),
+        exploreCount: stats.count,
+        explorePnl: stats.pnl,
+        thresholdTrades: this.deps.explorationConfig.breakerMinTrades,
+        thresholdLoss: this.deps.explorationConfig.breakerMaxCumLoss,
+      };
+      try {
+        await this.deps.setTradingConfig(
+          'direction_exploration_status',
+          status,
+          `Direction exploration breaker ${status.state}`,
+        );
+      } catch (err) {
+        this.deps.logger.warn({ err }, 'Failed to persist direction_exploration_status');
+      }
+    }
+
+    return tripped;
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/dashboard && pnpm test DirectionResolver.test.ts 2>&1 | tail -20`
+Expected: all 9 tests pass.
+
+- [ ] **Step 5: Add `getExplorationStats` method to `paperPositionsRepo`**
+
+In `packages/dashboard/src/database/repositories.ts`, inside the `paperPositionsRepo` object, add:
+
+```ts
+  async getExplorationStats(windowDays: number): Promise<{ count: number; pnl: number }> {
+    const result = await query<{ count: string; pnl: string | null }>(
+      `SELECT COUNT(*) AS count, COALESCE(SUM(realized_pnl), 0) AS pnl
+       FROM paper_positions
+       WHERE was_exploration = true
+         AND closed_at >= NOW() - ($1 || ' days')::interval
+         AND realized_pnl IS NOT NULL`,
+      [String(windowDays)],
+    );
+    const row = result.rows[0];
+    return {
+      count: Number(row.count ?? 0),
+      pnl: Number(row.pnl ?? 0),
+    };
+  },
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add packages/dashboard/src/database/repositories.ts packages/dashboard/src/services/DirectionResolver.ts packages/dashboard/src/services/DirectionResolver.test.ts
+rtk git commit -m "feat(DirectionResolver): persist breaker state to trading_config on transitions"
+```
+
+---
+
+## Task 8: `DirectionMultiplierLearningService` — widen range + new buckets
+
+**Files:**
+- Modify: `packages/dashboard/src/services/DirectionMultiplierLearningService.ts` (DEFAULT_CONFIG around line 66, bucketing around line 80)
+- Modify: `packages/dashboard/src/services/DirectionMultiplierLearningService.test.ts`
+
+- [ ] **Step 1: Write failing tests for new buckets and range**
+
+Add to `packages/dashboard/src/services/DirectionMultiplierLearningService.test.ts`:
+
+```ts
+import { bucketDirectionMultiplier } from './DirectionMultiplierLearningService.js';
+// ^ If not currently exported, export it in Step 3.
+
+describe('DirectionMultiplierLearningService — widened buckets', () => {
+  it.each([
+    [-1.25, 'strong_negative'],
+    [-0.5,  'strong_negative'],
+    [-0.49, 'near_zero'],
+    [0.0,   'near_zero'],
+    [0.24,  'near_zero'],
+    [0.25,  'weak_positive'],
+    [0.5,   'weak_positive'],
+    [0.74,  'weak_positive'],
+    [0.75,  'strong_positive'],
+    [1.0,   'strong_positive'],
+  ])('buckets %f as %s', (mult, expected) => {
+    expect(bucketDirectionMultiplier(mult)).toBe(expected);
+  });
+
+  it('DEFAULT_CONFIG permits multipliers up to +1.0', () => {
+    const { DEFAULT_CONFIG } = require('./DirectionMultiplierLearningService.js');
+    expect(DEFAULT_CONFIG.maxMultiplier).toBe(1.0);
+    expect(DEFAULT_CONFIG.maxPositiveMultiplier).toBe(1.0);
+    expect(DEFAULT_CONFIG.minMultiplier).toBe(-1.25);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/dashboard && pnpm test DirectionMultiplierLearningService.test.ts -t "widened buckets" 2>&1 | tail -20`
+Expected: FAIL — bucket logic still uses old thresholds, config still capped at 0.1.
+
+- [ ] **Step 3: Update `DEFAULT_CONFIG`, `bucketDirectionMultiplier`, and export the bucket function**
+
+In `packages/dashboard/src/services/DirectionMultiplierLearningService.ts`:
+
+(a) Replace the `DEFAULT_CONFIG` block around line 66:
+
+```ts
+const DEFAULT_CONFIG: DirectionMultiplierLearningConfig = {
+  enabled: true,
+  evaluationIntervalMs: 6 * 60 * 60 * 1000,
+  lookbackDays: 30,
+  minSegmentTrades: 24,
+  minCandidateTrades: 8,
+  minImprovementPerTrade: 0.75,
+  minWinRateLift: 0.08,
+  maxSegments: 8,
+  minMultiplier: -1.25,
+  maxMultiplier: 1.0,
+  maxPositiveMultiplier: 1.0,
+};
+
+export { DEFAULT_CONFIG };
+```
+
+(b) Replace `bucketDirectionMultiplier` around line 80 and export it:
+
+```ts
+export function bucketDirectionMultiplier(multiplier: number): string {
+  if (multiplier <= -0.5) return 'strong_negative';
+  if (multiplier < 0.25)  return 'near_zero';
+  if (multiplier < 0.75)  return 'weak_positive';
+  return 'strong_positive';
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/dashboard && pnpm test DirectionMultiplierLearningService.test.ts 2>&1 | tail -15`
+Expected: all tests pass (pre-existing + new bucket tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add packages/dashboard/src/services/DirectionMultiplierLearningService.ts packages/dashboard/src/services/DirectionMultiplierLearningService.test.ts
+rtk git commit -m "feat(learner): widen direction multiplier range to [-1.25, +1.0] with new bucket set"
+```
+
+---
+
+## Task 9: `DirectionMultiplierLearningService` — prefer per-trade multiplier in learner query
+
+**Files:**
+- Modify: `packages/dashboard/src/services/DirectionMultiplierLearningService.ts` (query at line ~293)
+- Modify: `packages/dashboard/src/services/DirectionMultiplierLearningService.test.ts`
+
+- [ ] **Step 1: Write failing integration-style test for the query COALESCE ordering**
+
+Add to `DirectionMultiplierLearningService.test.ts`:
+
+```ts
+describe('DirectionMultiplierLearningService — query COALESCE', () => {
+  it('learner query prefers pp.applied_direction_multiplier over signal_weights_history', async () => {
+    // Inspect the SQL text the service would run — we do not need a live DB.
+    // The service uses `query` from index.js; we stub it and assert the SQL contains
+    // the COALESCE in the required order.
+    const indexMod = await import('../database/index.js');
+    const querySpy = vi.spyOn(indexMod, 'query').mockResolvedValue({ rows: [] } as any);
+    const signalWeightsMod = await import('../database/repositories.js');
+    vi.spyOn(signalWeightsMod.signalWeightsRepo, 'get').mockResolvedValue({ weight: -1.0 } as any);
+
+    const { DirectionMultiplierLearningService } = await import('./DirectionMultiplierLearningService.js');
+    const svc = new DirectionMultiplierLearningService();
+    await svc.evaluate();
+
+    const sqlExecuted = querySpy.mock.calls.map(c => c[0] as string).join('\n');
+    expect(sqlExecuted).toMatch(/COALESCE\s*\(\s*pp\.applied_direction_multiplier\s*,\s*dm\.weight\s*,\s*\$2\s*\)/i);
+    querySpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && pnpm test DirectionMultiplierLearningService.test.ts -t "query COALESCE" 2>&1 | tail -25`
+Expected: FAIL — SQL does not contain `pp.applied_direction_multiplier`.
+
+- [ ] **Step 3: Update the learner query**
+
+In `packages/dashboard/src/services/DirectionMultiplierLearningService.ts`, inside `evaluate()`, locate the SQL template around line 279 and replace the `COALESCE(dm.weight, $2) AS direction_multiplier` line:
+
+```ts
+       `SELECT
+          COALESCE(m.market_type, 'unknown') AS market_type,
+          CASE
+            WHEN pp.side = 'long' THEN pp.avg_entry_price
+            ELSE 1 - pp.avg_entry_price
+          END AS yes_entry_price,
+          CASE
+            WHEN m.end_date IS NULL THEN 'medium'
+            WHEN m.end_date - pp.opened_at <= INTERVAL '1 day' THEN 'intraday'
+            WHEN m.end_date - pp.opened_at <= INTERVAL '7 days' THEN 'short'
+            WHEN m.end_date - pp.opened_at <= INTERVAL '30 days' THEN 'medium'
+            ELSE 'long'
+          END AS duration_band,
+          COALESCE(pp.realized_pnl, 0) AS realized_pnl,
+          COALESCE(pp.applied_direction_multiplier, dm.weight, $2) AS direction_multiplier
+        FROM paper_positions pp
+        JOIN markets m ON m.id = pp.market_id
+        LEFT JOIN LATERAL (
+          SELECT swh.weight
+          FROM signal_weights_history swh
+          WHERE swh.signal_type = 'direction_multiplier'
+            AND swh.time <= pp.opened_at
+          ORDER BY swh.time DESC
+          LIMIT 1
+        ) dm ON TRUE
+        WHERE pp.closed_at IS NOT NULL
+          AND pp.opened_at >= NOW() - INTERVAL '1 day' * $1`,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/dashboard && pnpm test DirectionMultiplierLearningService.test.ts 2>&1 | tail -15`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add packages/dashboard/src/services/DirectionMultiplierLearningService.ts packages/dashboard/src/services/DirectionMultiplierLearningService.test.ts
+rtk git commit -m "fix(learner): prefer per-trade applied_direction_multiplier via COALESCE"
+```
+
+---
+
+## Task 10: Wire `DirectionResolver` into `SignalEngine`
+
+**Files:**
+- Modify: `packages/dashboard/src/services/SignalEngine.ts` (around lines 21, 283-291, 449-483)
+- Modify: `packages/dashboard/src/services/SignalEngine.test.ts` (if it exists) or add new coverage
+
+- [ ] **Step 1: Write failing test that verifies SignalEngine uses DirectionResolver and consolidates metadata**
+
+If `SignalEngine.test.ts` doesn't exist, create minimal coverage at `packages/dashboard/src/services/SignalEngine.test.ts`. Else append:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+
+describe('SignalEngine — DirectionResolver integration', () => {
+  it('passes resolver multiplier to combiner and exposes wasExploration + metadata.direction on output', async () => {
+    // Minimal boot: mock combiner.combine to return a stub CombinedSignalOutput.
+    // Use a fake DirectionResolver that returns a deterministic exploration result.
+    const fakeResolver = {
+      resolve: vi.fn().mockResolvedValue({
+        multiplier: 0.6,
+        contextKey: 'event_long-20to40-medium',
+        segmentId: null,
+        wasExploration: true,
+        reason: 'exploration',
+      }),
+    };
+    const stubCombined = {
+      signalId: 'combined',
+      marketId: 'mkt1',
+      tokenId: 'tok1',
+      direction: 'long' as const,
+      strength: 0.3,
+      confidence: 0.6,
+      timestamp: new Date(),
+      ttlMs: 60_000,
+      componentSignals: [],
+      weights: {},
+      appliedDirectionMultiplier: 0.6,
+      metadata: { combinerType: 'weighted_average' },
+    };
+    const combinerMock = {
+      getWeights: () => ({}),
+      setWeights: () => {},
+      setDirectionMultiplier: vi.fn(),
+      setDirectionMultipliers: vi.fn(),
+      combine: vi.fn().mockReturnValue(stubCombined),
+    };
+
+    // Full SignalEngine boot is heavy. Test the enrichment helper directly.
+    // Extract enrichCombined(output, resolution) into a named export below.
+    const { enrichCombinedWithDirection } = await import('./SignalEngine.js');
+    const enriched = enrichCombinedWithDirection(stubCombined as any, {
+      multiplier: 0.6,
+      contextKey: 'event_long-20to40-medium',
+      segmentId: null,
+      wasExploration: true,
+      reason: 'exploration',
+    });
+
+    expect(enriched.appliedDirectionMultiplier).toBe(0.6);
+    expect(enriched.wasExploration).toBe(true);
+    expect(enriched.metadata).toMatchObject({
+      direction: {
+        contextKey: 'event_long-20to40-medium',
+        segmentId: 'global',
+        reason: 'exploration',
+      },
+    });
+    expect(enriched.metadata).not.toHaveProperty('directionMultiplier');
+    expect(enriched.metadata).not.toHaveProperty('directionContextKey');
+    expect(enriched.metadata).not.toHaveProperty('directionPolicySegmentId');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && pnpm test SignalEngine.test.ts -t "DirectionResolver integration" 2>&1 | tail -25`
+Expected: FAIL — `enrichCombinedWithDirection` not exported.
+
+- [ ] **Step 3: Add `DirectionResolver` import, optional dep, and enrichment helper to `SignalEngine.ts`**
+
+In `packages/dashboard/src/services/SignalEngine.ts`:
+
+(a) Remove the existing `resolveDirectionMultiplier` import at line 21 if it is no longer used inline; replace with:
+
+```ts
+import type { DirectionResolver, DirectionResolution } from './DirectionResolver.js';
+```
+
+(Keep `sanitizeDirectionMultiplierPolicy` and policy-loading imports; only the pure resolver function is replaced.)
+
+(b) Export a helper that consolidates metadata (keeps this testable in isolation):
+
+```ts
+export function enrichCombinedWithDirection<T extends {
+  metadata?: Record<string, unknown>;
+}>(combined: T, resolution: DirectionResolution): T & {
+  appliedDirectionMultiplier: number;
+  wasExploration: boolean;
+} {
+  const { directionMultiplier: _a, directionContextKey: _b, directionPolicySegmentId: _c, ...restMeta } = (combined.metadata ?? {}) as Record<string, unknown>;
+  return {
+    ...combined,
+    appliedDirectionMultiplier: resolution.multiplier,
+    wasExploration: resolution.wasExploration,
+    metadata: {
+      ...restMeta,
+      direction: {
+        contextKey: resolution.contextKey,
+        segmentId: resolution.segmentId ?? 'global',
+        reason: resolution.reason,
+      },
+    },
+  };
+}
+```
+
+(c) Accept `directionResolver` as a **required** field in the SignalEngine constructor / initializer. Find the existing constructor / `initializeSignalEngine` function and add:
+
+```ts
+// Add to the class:
+private readonly directionResolver: DirectionResolver;
+```
+
+And in the constructor or `initializeSignalEngine` options:
+
+```ts
+// In config type:
+export interface SignalEngineConfig {
+  // ... existing
+  directionResolver: DirectionResolver;  // required
+}
+```
+
+Any existing SignalEngine tests that constructed the engine without a resolver need to be updated to pass a stub (e.g., `{ resolve: async () => ({ multiplier: -1.0, contextKey: 'stub', segmentId: null, wasExploration: false, reason: 'global' }) }`). The legacy synchronous `resolveDirectionMultiplier` call is removed from `SignalEngine.ts` entirely — all direction resolution goes through the resolver.
+
+(d) Replace the synchronous direction resolution at lines 449-458 with an async call:
+
+```ts
+    const directionResolution = await this.directionResolver.resolve({
+      marketType: market.marketType,
+      currentPrice: market.currentPrice,
+      endDate: market.endDate,
+      question: market.question,
+    });
+
+    this.combiner.setDirectionMultiplier(
+      directionResolution.multiplier,
+      directionResolution.contextKey,
+    );
+```
+
+(e) Replace the metadata write at lines 478-483 with the enrichment helper:
+
+```ts
+    const confidenceCap = this.computeBayesianConfidenceCap(context.priceBars);
+    combined.confidence *= confidenceCap;
+    const enriched = enrichCombinedWithDirection(combined, directionResolution);
+    // Return enriched, not combined
+```
+
+Update subsequent references in the same function body from `combined.` to `enriched.` where relevant (e.g., final return value, logging). Verify all call sites read from `enriched` onward.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/dashboard && pnpm test SignalEngine.test.ts -t "DirectionResolver integration" 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 5: Wire `DirectionResolver` in `server.ts`**
+
+In `packages/dashboard/src/server.ts`, around the existing SignalEngine initialization (near line 286), instantiate a resolver and pass it:
+
+```ts
+import { DirectionResolver } from './services/DirectionResolver.js';
+import { tradingConfigRepo, paperPositionsRepo } from './database/repositories.js';
+
+// Earlier, build a cached policy provider
+let cachedPolicy: { data: DirectionMultiplierPolicy; fetchedAt: number } | null = null;
+const POLICY_TTL_MS = 60_000;
+const policyProvider = async (): Promise<DirectionMultiplierPolicy> => {
+  const now = Date.now();
+  if (cachedPolicy && now - cachedPolicy.fetchedAt < POLICY_TTL_MS) return cachedPolicy.data;
+  const entry = await tradingConfigRepo.get('direction_multiplier_policy');
+  const data = sanitizeDirectionMultiplierPolicy(entry?.value as DirectionMultiplierPolicy | undefined ?? DEFAULT_DIRECTION_MULTIPLIER_POLICY);
+  cachedPolicy = { data, fetchedAt: now };
+  return data;
+};
+
+const directionResolver = new DirectionResolver({
+  policyProvider,
+  paperPositionsRepo,
+  logger,
+  setTradingConfig: (key, value, reason) => tradingConfigRepo.set(key, value, reason),
+  explorationConfig: {
+    enabled: process.env.ENABLE_DIRECTION_EXPLORATION !== 'false',
+    epsilon: parseFloat(process.env.DIRECTION_EXPLORATION_EPSILON ?? '0.10'),
+    min: parseFloat(process.env.DIRECTION_EXPLORATION_MIN ?? '0.0'),
+    max: parseFloat(process.env.DIRECTION_EXPLORATION_MAX ?? '1.0'),
+    breakerMinTrades: parseInt(process.env.DIRECTION_EXPLORATION_BREAKER_MIN_TRADES ?? '20', 10),
+    breakerWindowDays: parseInt(process.env.DIRECTION_EXPLORATION_BREAKER_WINDOW_DAYS ?? '7', 10),
+    breakerMaxCumLoss: parseFloat(process.env.DIRECTION_EXPLORATION_BREAKER_MAX_CUM_LOSS ?? '-150'),
+    breakerCacheTtlMs: 300_000,
+  },
+});
+
+// Existing initializeSignalEngine call — add directionResolver to options
+const signalEngine = initializeSignalEngine({
+  enabled: true,
+  computeIntervalMs: parseInt(process.env.SIGNAL_INTERVAL_MS || '60000', 10),
+  maxMarketsPerCycle: parseInt(process.env.MAX_SIGNAL_MARKETS || '15', 10),
+  minPriceBars: 3,
+  minCombinedConfidence: optimizedParams.minCombinedConfidence,
+  minCombinedStrength: optimizedParams.minCombinedStrength,
+  directionResolver,
+});
+```
+
+- [ ] **Step 6: Run the full SignalEngine test suite**
+
+Run: `cd packages/dashboard && pnpm test SignalEngine 2>&1 | tail -15`
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+rtk git add packages/dashboard/src/services/SignalEngine.ts packages/dashboard/src/services/SignalEngine.test.ts packages/dashboard/src/server.ts
+rtk git commit -m "feat: wire DirectionResolver into SignalEngine and consolidate metadata.direction"
+```
+
+---
+
+## Task 11: Propagate `appliedDirectionMultiplier` + `wasExploration` through `AutoSignalExecutor`
+
+**Files:**
+- Modify: `packages/dashboard/src/services/AutoSignalExecutor.ts`
+- Modify: `packages/dashboard/src/services/AutoSignalExecutor.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `packages/dashboard/src/services/AutoSignalExecutor.test.ts`:
+
+```ts
+describe('AutoSignalExecutor — direction multiplier propagation', () => {
+  it('passes appliedDirectionMultiplier and wasExploration to paperPositionsRepo', async () => {
+    const openSpy = vi.spyOn(paperPositionsRepo, 'openPositionAtomically')
+      .mockResolvedValue({ opened: true });
+    // Construct a signal with the new fields
+    const signal = buildCombinedSignal({
+      direction: 'long',
+      strength: 0.4,
+      confidence: 0.7,
+      appliedDirectionMultiplier: 0.75,
+      wasExploration: true,
+    });
+    const executor = buildExecutor();
+    await executor.executeSignal(signal);
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const positionArg = openSpy.mock.calls[0][0];
+    expect(positionArg.applied_direction_multiplier).toBe(0.75);
+    expect(positionArg.was_exploration).toBe(true);
+    openSpy.mockRestore();
+  });
+
+  it('defaults both fields to null/false when signal omits them', async () => {
+    const openSpy = vi.spyOn(paperPositionsRepo, 'openPositionAtomically')
+      .mockResolvedValue({ opened: true });
+    const signal = buildCombinedSignal({ direction: 'long', strength: 0.4, confidence: 0.7 });
+    const executor = buildExecutor();
+    await executor.executeSignal(signal);
+    const positionArg = openSpy.mock.calls[0][0];
+    expect(positionArg.applied_direction_multiplier ?? null).toBeNull();
+    expect(positionArg.was_exploration ?? false).toBe(false);
+    openSpy.mockRestore();
+  });
+});
+```
+
+(Reuse `buildCombinedSignal` / `buildExecutor` helpers already present in the file. If those helpers don't accept the new fields, widen their signatures first.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && pnpm test AutoSignalExecutor.test.ts -t "direction multiplier propagation" 2>&1 | tail -20`
+Expected: FAIL — the two position fields are not populated.
+
+- [ ] **Step 3: Populate the fields in `AutoSignalExecutor`**
+
+In `packages/dashboard/src/services/AutoSignalExecutor.ts`, locate the position-construction block before `paperPositionsRepo.openPositionAtomically(...)`. Add the two fields to the object literal:
+
+```ts
+    const position: PaperPosition = {
+      // ... existing
+      applied_direction_multiplier: signal.appliedDirectionMultiplier ?? null,
+      was_exploration: signal.wasExploration ?? false,
+    };
+    const result = await paperPositionsRepo.openPositionAtomically(position, cost, fee);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/dashboard && pnpm test AutoSignalExecutor.test.ts -t "direction multiplier propagation" 2>&1 | tail -15`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full executor suite to confirm no regressions**
+
+Run: `cd packages/dashboard && pnpm test AutoSignalExecutor 2>&1 | tail -15`
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add packages/dashboard/src/services/AutoSignalExecutor.ts packages/dashboard/src/services/AutoSignalExecutor.test.ts
+rtk git commit -m "feat(executor): propagate appliedDirectionMultiplier and wasExploration to paper_positions"
+```
+
+---
+
+## Task 12: Env vars in `docker-compose.gcp.yml`
+
+**Files:**
+- Modify: `docker-compose.gcp.yml` (dashboard-api service `environment:` block)
+
+- [ ] **Step 1: Add env vars to the dashboard-api service**
+
+In `docker-compose.gcp.yml`, under `services.dashboard-api.environment`, append:
+
+```yaml
+      - ENABLE_DIRECTION_EXPLORATION=true
+      - DIRECTION_EXPLORATION_EPSILON=0.10
+      - DIRECTION_EXPLORATION_MIN=0.0
+      - DIRECTION_EXPLORATION_MAX=1.0
+      - DIRECTION_EXPLORATION_BREAKER_MIN_TRADES=20
+      - DIRECTION_EXPLORATION_BREAKER_WINDOW_DAYS=7
+      - DIRECTION_EXPLORATION_BREAKER_MAX_CUM_LOSS=-150
+```
+
+- [ ] **Step 2: Verify YAML is valid**
+
+Run: `rtk git diff docker-compose.gcp.yml`
+Expected: only the new lines in the dashboard-api environment section; no indentation drift.
+
+- [ ] **Step 3: Commit**
+
+```bash
+rtk git add docker-compose.gcp.yml
+rtk git commit -m "chore: add direction exploration env vars to dashboard-api service"
+```
+
+---
+
+## Task 13: End-to-end integration test — exploration branch hitting persistence
+
+**Files:**
+- Create: `packages/dashboard/src/services/__tests__/DirectionExploration.integration.test.ts`
+
+- [ ] **Step 1: Write the integration test**
+
+Create the file with contents:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DirectionResolver } from '../DirectionResolver.js';
+import { enrichCombinedWithDirection } from '../SignalEngine.js';
+import type { DirectionMultiplierPolicy } from '../DirectionMultiplierPolicy.js';
+
+describe('Direction exploration — end-to-end integration', () => {
+  const policy: DirectionMultiplierPolicy = {
+    global: -1.0, minMultiplier: -1.25, maxMultiplier: 1.0, segments: [],
+  };
+  const ctx = {
+    marketType: 'event_long',
+    currentPrice: 0.3,
+    endDate: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000),
+  };
+  const stubRepo = {
+    getExplorationStats: vi.fn().mockResolvedValue({ count: 5, pnl: 0 }),
+    openPositionAtomically: vi.fn().mockResolvedValue({ opened: true }),
+  };
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('an exploration resolution ends up persisted with was_exploration=true', async () => {
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: {
+        enabled: true, epsilon: 1.0, min: 0.0, max: 1.0,
+        breakerMinTrades: 20, breakerWindowDays: 7, breakerMaxCumLoss: -150, breakerCacheTtlMs: 300_000,
+      },
+      rng: (() => { let i = 0; const vals = [0.0, 0.6]; return () => vals[i++ % 2]; })(),
+      paperPositionsRepo: stubRepo as any,
+      logger,
+    });
+
+    const resolution = await resolver.resolve(ctx);
+    expect(resolution.wasExploration).toBe(true);
+    expect(resolution.multiplier).toBeCloseTo(0.6, 5);
+
+    // Simulate combiner producing a combined output with appliedDirectionMultiplier set
+    const combined = {
+      signalId: 'combined', marketId: 'mkt1', tokenId: 'tok1',
+      direction: 'long' as const, strength: 0.3, confidence: 0.7,
+      timestamp: new Date(), ttlMs: 60_000, componentSignals: [], weights: {},
+      appliedDirectionMultiplier: resolution.multiplier, metadata: {},
+    };
+    const enriched = enrichCombinedWithDirection(combined, resolution);
+    expect(enriched.wasExploration).toBe(true);
+    expect(enriched.appliedDirectionMultiplier).toBeCloseTo(0.6, 5);
+
+    // Simulate executor building the PaperPosition payload
+    const positionPayload = {
+      market_id: 'mkt1', token_id: 'tok1', side: 'long' as const, size: 10,
+      avg_entry_price: 0.3, current_price: 0.3,
+      opened_at: new Date(),
+      applied_direction_multiplier: enriched.appliedDirectionMultiplier,
+      was_exploration: enriched.wasExploration,
+    };
+    await stubRepo.openPositionAtomically(positionPayload, 3.0, 0.01);
+    expect(stubRepo.openPositionAtomically).toHaveBeenCalledWith(
+      expect.objectContaining({
+        applied_direction_multiplier: expect.closeTo(0.6, 5),
+        was_exploration: true,
+      }),
+      3.0, 0.01,
+    );
+  });
+
+  it('breaker-tripped resolution persists with was_exploration=false and multiplier=global', async () => {
+    stubRepo.getExplorationStats = vi.fn().mockResolvedValue({ count: 25, pnl: -200 });
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: {
+        enabled: true, epsilon: 1.0, min: 0.0, max: 1.0,
+        breakerMinTrades: 20, breakerWindowDays: 7, breakerMaxCumLoss: -150, breakerCacheTtlMs: 300_000,
+      },
+      rng: () => 0.0,  // would trigger exploration otherwise
+      paperPositionsRepo: stubRepo as any,
+      logger,
+    });
+    const resolution = await resolver.resolve(ctx);
+    expect(resolution.reason).toBe('breaker_tripped');
+    expect(resolution.wasExploration).toBe(false);
+    expect(resolution.multiplier).toBe(-1.0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `cd packages/dashboard && pnpm test DirectionExploration.integration 2>&1 | tail -20`
+Expected: PASS (both tests).
+
+- [ ] **Step 3: Run the whole dashboard test suite to confirm no regressions**
+
+Run: `cd packages/dashboard && pnpm test 2>&1 | tail -15`
+Expected: all tests pass except the known pre-existing `OptimizationScheduler.test.ts` Vite resolution failure (documented in recent daily reviews).
+
+- [ ] **Step 4: Commit**
+
+```bash
+rtk git add packages/dashboard/src/services/__tests__/DirectionExploration.integration.test.ts
+rtk git commit -m "test: integration coverage for direction exploration resolution to persistence"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Step 1: Run the full monorepo test suite**
+
+Run: `pnpm -r test 2>&1 | tail -25`
+Expected: all packages pass (except the known pre-existing failure noted above).
+
+- [ ] **Step 2: Run type check**
+
+Run: `pnpm -r build 2>&1 | tail -15`
+Expected: no TypeScript errors.
+
+- [ ] **Step 3: Inspect the git log**
+
+Run: `rtk git log --oneline -15`
+Expected: 13 commits corresponding to the tasks above, in order.
+
+- [ ] **Step 4: Push branch and open PR**
+
+```bash
+rtk git push -u origin HEAD
+rtk gh pr create --title "feat: direction multiplier exploration (widen learner + epsilon-greedy)" --body "See docs/plans/2026-04-20-direction-multiplier-exploration-design.md for motivation and design. Implements docs/plans/2026-04-20-direction-multiplier-exploration-plan.md."
+```

--- a/packages/dashboard/src/database/repositories.test.ts
+++ b/packages/dashboard/src/database/repositories.test.ts
@@ -67,6 +67,48 @@ describe('paperPositionsRepo.get', () => {
   });
 });
 
+describe('paperPositionsRepo — direction multiplier fields', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(query).mockResolvedValue({ rows: [], rowCount: 0 } as any);
+  });
+
+  it('includes applied_direction_multiplier and was_exploration in INSERT', async () => {
+    await paperPositionsRepo.insert({
+      market_id: 'mkt1',
+      token_id: 'tok1',
+      side: 'long',
+      size: 10,
+      avg_entry_price: 0.5,
+      current_price: 0.5,
+      opened_at: new Date('2026-04-20T12:00:00Z'),
+      applied_direction_multiplier: 0.75,
+      was_exploration: true,
+    });
+    const sql = vi.mocked(query).mock.calls[0][0] as string;
+    const params = vi.mocked(query).mock.calls[0][1] as unknown[];
+    expect(sql).toContain('applied_direction_multiplier');
+    expect(sql).toContain('was_exploration');
+    expect(params).toContain(0.75);
+    expect(params).toContain(true);
+  });
+
+  it('defaults applied_direction_multiplier to null and was_exploration to false when omitted', async () => {
+    await paperPositionsRepo.insert({
+      market_id: 'mkt1',
+      token_id: 'tok1',
+      side: 'long',
+      size: 10,
+      avg_entry_price: 0.5,
+      current_price: 0.5,
+      opened_at: new Date(),
+    });
+    const params = vi.mocked(query).mock.calls[0][1] as unknown[];
+    expect(params).toContain(null);
+    expect(params).toContain(false);
+  });
+});
+
 describe('paperPositionsRepo.openPositionAtomically', () => {
   let mockClient: { query: ReturnType<typeof vi.fn> };
 

--- a/packages/dashboard/src/database/repositories.ts
+++ b/packages/dashboard/src/database/repositories.ts
@@ -498,6 +498,22 @@ export const paperPositionsRepo = {
       );
     }
   },
+
+  async getExplorationStats(windowDays: number): Promise<{ count: number; pnl: number }> {
+    const result = await query<{ count: string; pnl: string | null }>(
+      `SELECT COUNT(*) AS count, COALESCE(SUM(realized_pnl), 0) AS pnl
+       FROM paper_positions
+       WHERE was_exploration = true
+         AND closed_at >= NOW() - ($1 || ' days')::interval
+         AND realized_pnl IS NOT NULL`,
+      [String(windowDays)],
+    );
+    const row = result.rows[0];
+    return {
+      count: Number(row.count ?? 0),
+      pnl: Number(row.pnl ?? 0),
+    };
+  },
 };
 
 // ============================================

--- a/packages/dashboard/src/database/repositories.ts
+++ b/packages/dashboard/src/database/repositories.ts
@@ -333,6 +333,8 @@ export interface PaperPosition {
   market_score_at_entry?: number | null;
   score_dimensions_at_entry?: Record<string, unknown> | null;
   execution_mode?: string;
+  applied_direction_multiplier?: number | null;
+  was_exploration?: boolean;
 }
 
 export const paperPositionsRepo = {
@@ -342,8 +344,8 @@ export const paperPositionsRepo = {
        (market_id, token_id, side, size, avg_entry_price, current_price,
         unrealized_pnl, unrealized_pnl_pct, realized_pnl, stop_loss, take_profit,
         opened_at, signal_type, metadata, market_score_at_entry, score_dimensions_at_entry,
-        execution_mode)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+        execution_mode, applied_direction_multiplier, was_exploration)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
       [
         position.market_id,
         position.token_id,
@@ -362,6 +364,8 @@ export const paperPositionsRepo = {
         position.market_score_at_entry ?? null,
         position.score_dimensions_at_entry != null ? JSON.stringify(position.score_dimensions_at_entry) : null,
         position.execution_mode ?? 'paper',
+        position.applied_direction_multiplier ?? null,
+        position.was_exploration ?? false,
       ]
     );
   },
@@ -422,8 +426,8 @@ export const paperPositionsRepo = {
            (market_id, token_id, side, size, avg_entry_price, current_price,
             unrealized_pnl, unrealized_pnl_pct, realized_pnl, stop_loss, take_profit,
             opened_at, signal_type, metadata, market_score_at_entry, score_dimensions_at_entry,
-            execution_mode)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+            execution_mode, applied_direction_multiplier, was_exploration)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
           [
             position.market_id, position.token_id, position.side, position.size,
             position.avg_entry_price, position.current_price,
@@ -433,6 +437,8 @@ export const paperPositionsRepo = {
             position.market_score_at_entry ?? null,
             position.score_dimensions_at_entry != null ? JSON.stringify(position.score_dimensions_at_entry) : null,
             position.execution_mode ?? 'paper',
+            position.applied_direction_multiplier ?? null,
+            position.was_exploration ?? false,
           ]
         );
         return { opened: true };

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -180,6 +180,14 @@ async function main(): Promise<void> {
         $fn$ LANGUAGE plpgsql
       `).catch(() => {});
 
+      // Ensure direction multiplier exploration columns exist
+      await query(`
+        ALTER TABLE paper_positions
+          ADD COLUMN IF NOT EXISTS applied_direction_multiplier NUMERIC(5,3),
+          ADD COLUMN IF NOT EXISTS was_exploration BOOLEAN NOT NULL DEFAULT false
+      `);
+      console.log('paper_positions direction exploration columns ensured');
+
       // Check for blocking autovacuum every 15 minutes
       setInterval(async () => {
         try {

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -8,10 +8,16 @@
 import pino from 'pino';
 import { createDashboardServer } from './api/server.js';
 import { initializeDatabase, closeDatabase, healthCheck, isDatabaseConfigured, query } from './database/index.js';
-import { signalWeightsRepo, tradingConfigRepo } from './database/repositories.js';
+import { signalWeightsRepo, tradingConfigRepo, paperPositionsRepo } from './database/repositories.js';
 import { initializeOptimizationScheduler } from './services/OptimizationScheduler.js';
 import { initializeDirectionMultiplierLearningService } from './services/DirectionMultiplierLearningService.js';
 import { initializeSignalEngine } from './services/SignalEngine.js';
+import { DirectionResolver } from './services/DirectionResolver.js';
+import {
+  sanitizeDirectionMultiplierPolicy,
+  DEFAULT_DIRECTION_MULTIPLIER_POLICY,
+  type DirectionMultiplierPolicy,
+} from './services/DirectionMultiplierPolicy.js';
 import { getPolymarketService } from './services/PolymarketService.js';
 import { getTradingAutomation } from './services/TradingAutomation.js';
 import { initializePositionCleanupService } from './services/PositionCleanupService.js';
@@ -291,6 +297,35 @@ async function main(): Promise<void> {
       await directionMultiplierLearning.start();
       console.log('DirectionMultiplierLearningService started');
 
+      // Cached policy provider (60s TTL) — avoids querying trading_config on every signal resolve
+      let cachedPolicy: { data: DirectionMultiplierPolicy; fetchedAt: number } | null = null;
+      const POLICY_TTL_MS = 60_000;
+      const policyProvider = async (): Promise<DirectionMultiplierPolicy> => {
+        const now = Date.now();
+        if (cachedPolicy && now - cachedPolicy.fetchedAt < POLICY_TTL_MS) return cachedPolicy.data;
+        const rawPolicy = await tradingConfigRepo.get<DirectionMultiplierPolicy>('direction_multiplier_policy');
+        const data = sanitizeDirectionMultiplierPolicy(rawPolicy ?? DEFAULT_DIRECTION_MULTIPLIER_POLICY);
+        cachedPolicy = { data, fetchedAt: now };
+        return data;
+      };
+
+      const directionResolver = new DirectionResolver({
+        policyProvider,
+        paperPositionsRepo,
+        logger: logger as any,
+        setTradingConfig: (key, value, reason) => tradingConfigRepo.set(key, value, reason),
+        explorationConfig: {
+          enabled: process.env.ENABLE_DIRECTION_EXPLORATION !== 'false',
+          epsilon: parseFloat(process.env.DIRECTION_EXPLORATION_EPSILON ?? '0.10'),
+          min: parseFloat(process.env.DIRECTION_EXPLORATION_MIN ?? '0.0'),
+          max: parseFloat(process.env.DIRECTION_EXPLORATION_MAX ?? '1.0'),
+          breakerMinTrades: parseInt(process.env.DIRECTION_EXPLORATION_BREAKER_MIN_TRADES ?? '20', 10),
+          breakerWindowDays: parseInt(process.env.DIRECTION_EXPLORATION_BREAKER_WINDOW_DAYS ?? '7', 10),
+          breakerMaxCumLoss: parseFloat(process.env.DIRECTION_EXPLORATION_BREAKER_MAX_CUM_LOSS ?? '-150'),
+          breakerCacheTtlMs: 300_000,
+        },
+      });
+
       const signalEngine = initializeSignalEngine({
         enabled: true,
         computeIntervalMs: parseInt(process.env.SIGNAL_INTERVAL_MS || '60000', 10),
@@ -298,6 +333,7 @@ async function main(): Promise<void> {
         minPriceBars: 3,           // Bayesian confidence cap handles data scarcity
         minCombinedConfidence: optimizedParams.minCombinedConfidence,
         minCombinedStrength: optimizedParams.minCombinedStrength,
+        directionResolver,
       });
 
       // Start market classifier (classifies new markets via Haiku every 30min)

--- a/packages/dashboard/src/services/AutoSignalExecutor.test.ts
+++ b/packages/dashboard/src/services/AutoSignalExecutor.test.ts
@@ -479,4 +479,72 @@ describe('AutoSignalExecutor', () => {
       expect(longSharesA).toBe(longSharesB);
     });
   });
+
+  // =========================================================
+  // T11: direction multiplier + exploration flag propagation
+  // =========================================================
+  describe('AutoSignalExecutor — direction multiplier propagation', () => {
+    function fullMockChain() {
+      (query as any).mockImplementation((sql: string) => {
+        if (sql.includes('FROM markets WHERE id')) {
+          return Promise.resolve({ rows: [{ is_active: true, is_resolved: false, end_date: null }] });
+        }
+        if (sql.includes('FROM paper_account')) {
+          return Promise.resolve({ rows: [{ available_capital: '100000', current_capital: '10000' }] });
+        }
+        if (sql.includes('market_score') && sql.includes('current_price_yes')) {
+          return Promise.resolve({ rows: [{ market_score: '0.5', current_price_yes: '0.5', volume_24h: '1000', spread: '0.01', end_date: null }] });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+    }
+
+    function buildCombinedSignal(overrides: Partial<SignalResult> & { appliedDirectionMultiplier?: number; wasExploration?: boolean }): SignalResult {
+      const { appliedDirectionMultiplier, wasExploration, ...rest } = overrides;
+      const base = makeSignal(rest);
+      return {
+        ...base,
+        ...(appliedDirectionMultiplier !== undefined ? { appliedDirectionMultiplier } : {}),
+        ...(wasExploration !== undefined ? { wasExploration } : {}),
+      } as SignalResult;
+    }
+
+    function buildExecutor() {
+      return new AutoSignalExecutor({ enabled: true, cooldownMs: 0 });
+    }
+
+    it('passes appliedDirectionMultiplier and wasExploration to paperPositionsRepo', async () => {
+      const openSpy = vi.spyOn(paperPositionsRepo, 'openPositionAtomically')
+        .mockResolvedValue({ opened: true });
+      fullMockChain();
+      const signal = buildCombinedSignal({
+        direction: 'long',
+        strength: 0.4,
+        confidence: 0.7,
+        appliedDirectionMultiplier: 0.75,
+        wasExploration: true,
+      });
+      const executor = buildExecutor();
+      await executor.processSignal(signal);
+      expect(openSpy).toHaveBeenCalledTimes(1);
+      const positionArg = openSpy.mock.calls[0][0];
+      expect(positionArg.applied_direction_multiplier).toBe(0.75);
+      expect(positionArg.was_exploration).toBe(true);
+      openSpy.mockRestore();
+    });
+
+    it('defaults both fields to null/false when signal omits them', async () => {
+      const openSpy = vi.spyOn(paperPositionsRepo, 'openPositionAtomically')
+        .mockResolvedValue({ opened: true });
+      fullMockChain();
+      const signal = buildCombinedSignal({ direction: 'long', strength: 0.4, confidence: 0.7 });
+      const executor = buildExecutor();
+      await executor.processSignal(signal);
+      expect(openSpy).toHaveBeenCalledTimes(1);
+      const positionArg = openSpy.mock.calls[0][0];
+      expect(positionArg.applied_direction_multiplier ?? null).toBeNull();
+      expect(positionArg.was_exploration ?? false).toBe(false);
+      openSpy.mockRestore();
+    });
+  });
 });

--- a/packages/dashboard/src/services/AutoSignalExecutor.ts
+++ b/packages/dashboard/src/services/AutoSignalExecutor.ts
@@ -72,6 +72,8 @@ export interface SignalResult {
   price: number;
   marketType?: string;  // crypto_intraday, crypto_daily, event_short, event_long
   metadata?: Record<string, unknown>;
+  appliedDirectionMultiplier?: number;  // multiplier used by SignalEngine (from DirectionResolver)
+  wasExploration?: boolean;             // true when this trade is an exploration branch
 }
 
 export interface ExecutorConfig {
@@ -799,6 +801,8 @@ export class AutoSignalExecutor extends EventEmitter {
           market_score_at_entry: marketScoreAtEntry,
           score_dimensions_at_entry: scoreDimensionsAtEntry ?? undefined,
           execution_mode: executionMode,
+          applied_direction_multiplier: signal.appliedDirectionMultiplier ?? null,
+          was_exploration: signal.wasExploration ?? false,
         },
         actualValue,
         actualFee,

--- a/packages/dashboard/src/services/DirectionMultiplierLearningService.test.ts
+++ b/packages/dashboard/src/services/DirectionMultiplierLearningService.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { bucketDirectionMultiplier, DEFAULT_CONFIG, deriveDirectionMultiplierPolicy, type DirectionLearningRow } from './DirectionMultiplierLearningService.js';
 
 function repeat(row: DirectionLearningRow, count: number): DirectionLearningRow[] {
@@ -102,5 +102,27 @@ describe('DirectionMultiplierLearningService — widened buckets', () => {
     expect(DEFAULT_CONFIG.maxMultiplier).toBe(1.0);
     expect(DEFAULT_CONFIG.maxPositiveMultiplier).toBe(1.0);
     expect(DEFAULT_CONFIG.minMultiplier).toBe(-1.25);
+  });
+});
+
+describe('DirectionMultiplierLearningService — query COALESCE', () => {
+  it('learner query prefers pp.applied_direction_multiplier over signal_weights_history', async () => {
+    // Inspect the SQL text the service would run — we do not need a live DB.
+    // The service uses `query` from index.js; we stub it and assert the SQL contains
+    // the COALESCE in the required order.
+    const indexMod = await import('../database/index.js');
+    const querySpy = vi.spyOn(indexMod, 'query').mockResolvedValue({ rows: [] } as any);
+    const isDatabaseConfiguredSpy = vi.spyOn(indexMod, 'isDatabaseConfigured').mockReturnValue(true);
+    const signalWeightsMod = await import('../database/repositories.js');
+    vi.spyOn(signalWeightsMod.signalWeightsRepo, 'get').mockResolvedValue({ weight: -1.0 } as any);
+
+    const { DirectionMultiplierLearningService } = await import('./DirectionMultiplierLearningService.js');
+    const svc = new DirectionMultiplierLearningService();
+    await svc.evaluate();
+
+    const sqlExecuted = querySpy.mock.calls.map(c => c[0] as string).join('\n');
+    expect(sqlExecuted).toMatch(/COALESCE\s*\(\s*pp\.applied_direction_multiplier\s*,\s*dm\.weight\s*,\s*\$2\s*\)/i);
+    querySpy.mockRestore();
+    isDatabaseConfiguredSpy.mockRestore();
   });
 });

--- a/packages/dashboard/src/services/DirectionMultiplierLearningService.test.ts
+++ b/packages/dashboard/src/services/DirectionMultiplierLearningService.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { deriveDirectionMultiplierPolicy, type DirectionLearningRow } from './DirectionMultiplierLearningService.js';
+import { bucketDirectionMultiplier, DEFAULT_CONFIG, deriveDirectionMultiplierPolicy, type DirectionLearningRow } from './DirectionMultiplierLearningService.js';
 
 function repeat(row: DirectionLearningRow, count: number): DirectionLearningRow[] {
   return Array.from({ length: count }, () => ({ ...row }));
@@ -7,20 +7,22 @@ function repeat(row: DirectionLearningRow, count: number): DirectionLearningRow[
 
 describe('DirectionMultiplierLearningService policy derivation', () => {
   it('creates a segment override when a bucket clearly beats the baseline', () => {
+    // Global multiplier -1.0 → strong_negative bucket (the losing baseline)
+    // near_zero bucket wins clearly → should produce a segment override
     const rows = [
       ...repeat({
         marketType: 'event_financial',
         priceBucket: '40to60',
         durationBand: 'medium',
         realizedPnl: 4,
-        directionMultiplier: -1.2,
+        directionMultiplier: 0.1,
       }, 12),
       ...repeat({
         marketType: 'event_financial',
         priceBucket: '40to60',
         durationBand: 'medium',
         realizedPnl: -1,
-        directionMultiplier: -0.7,
+        directionMultiplier: -1.2,
       }, 12),
     ];
 
@@ -34,13 +36,13 @@ describe('DirectionMultiplierLearningService policy derivation', () => {
       minWinRateLift: 0.05,
       maxSegments: 5,
       minMultiplier: -1.25,
-      maxMultiplier: 0.1,
-      maxPositiveMultiplier: 0.1,
+      maxMultiplier: 1.0,
+      maxPositiveMultiplier: 1.0,
     });
 
     expect(policy.segments).toHaveLength(1);
     expect(policy.segments[0].id).toBe('event_financial-40to60-medium');
-    expect(policy.segments[0].multiplier).toBeLessThan(-1.1);
+    expect(policy.segments[0].multiplier).toBeGreaterThan(-0.5);
     expect(summary.segmentCount).toBe(1);
   });
 
@@ -72,10 +74,33 @@ describe('DirectionMultiplierLearningService policy derivation', () => {
       minWinRateLift: 0.05,
       maxSegments: 5,
       minMultiplier: -1.25,
-      maxMultiplier: 0.1,
-      maxPositiveMultiplier: 0.1,
+      maxMultiplier: 1.0,
+      maxPositiveMultiplier: 1.0,
     });
 
     expect(policy.segments).toHaveLength(0);
+  });
+});
+
+describe('DirectionMultiplierLearningService — widened buckets', () => {
+  it.each([
+    [-1.25, 'strong_negative'],
+    [-0.5,  'strong_negative'],
+    [-0.49, 'near_zero'],
+    [0.0,   'near_zero'],
+    [0.24,  'near_zero'],
+    [0.25,  'weak_positive'],
+    [0.5,   'weak_positive'],
+    [0.74,  'weak_positive'],
+    [0.75,  'strong_positive'],
+    [1.0,   'strong_positive'],
+  ])('buckets %f as %s', (mult, expected) => {
+    expect(bucketDirectionMultiplier(mult)).toBe(expected);
+  });
+
+  it('DEFAULT_CONFIG permits multipliers up to +1.0', () => {
+    expect(DEFAULT_CONFIG.maxMultiplier).toBe(1.0);
+    expect(DEFAULT_CONFIG.maxPositiveMultiplier).toBe(1.0);
+    expect(DEFAULT_CONFIG.minMultiplier).toBe(-1.25);
   });
 });

--- a/packages/dashboard/src/services/DirectionMultiplierLearningService.ts
+++ b/packages/dashboard/src/services/DirectionMultiplierLearningService.ts
@@ -291,7 +291,7 @@ export class DirectionMultiplierLearningService extends EventEmitter {
            ELSE 'long'
          END AS duration_band,
          COALESCE(pp.realized_pnl, 0) AS realized_pnl,
-         COALESCE(dm.weight, $2) AS direction_multiplier
+         COALESCE(pp.applied_direction_multiplier, dm.weight, $2) AS direction_multiplier
        FROM paper_positions pp
        JOIN markets m ON m.id = pp.market_id
        LEFT JOIN LATERAL (

--- a/packages/dashboard/src/services/DirectionMultiplierLearningService.ts
+++ b/packages/dashboard/src/services/DirectionMultiplierLearningService.ts
@@ -63,7 +63,7 @@ export interface DirectionMultiplierLearningSummary {
   segments: SegmentSummary[];
 }
 
-const DEFAULT_CONFIG: DirectionMultiplierLearningConfig = {
+export const DEFAULT_CONFIG: DirectionMultiplierLearningConfig = {
   enabled: true,
   evaluationIntervalMs: 6 * 60 * 60 * 1000,
   lookbackDays: 30,
@@ -73,14 +73,15 @@ const DEFAULT_CONFIG: DirectionMultiplierLearningConfig = {
   minWinRateLift: 0.08,
   maxSegments: 8,
   minMultiplier: -1.25,
-  maxMultiplier: 0.1,
-  maxPositiveMultiplier: 0.1,
+  maxMultiplier: 1.0,
+  maxPositiveMultiplier: 1.0,
 };
 
-function bucketDirectionMultiplier(multiplier: number): string {
-  if (multiplier <= -1.1) return 'strong_negative';
-  if (multiplier < -0.25) return 'weak_negative';
-  return 'non_negative';
+export function bucketDirectionMultiplier(multiplier: number): string {
+  if (multiplier <= -0.5) return 'strong_negative';
+  if (multiplier < 0.25)  return 'near_zero';
+  if (multiplier < 0.75)  return 'weak_positive';
+  return 'strong_positive';
 }
 
 function scoreCandidate(stats: CandidateStats): number {

--- a/packages/dashboard/src/services/DirectionResolver.test.ts
+++ b/packages/dashboard/src/services/DirectionResolver.test.ts
@@ -176,3 +176,63 @@ describe('DirectionResolver — circuit breaker', () => {
     expect(repo.getExplorationStats).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('DirectionResolver — breaker status write', () => {
+  const policy: DirectionMultiplierPolicy = {
+    global: -1.0, minMultiplier: -1.25, maxMultiplier: 1.0, segments: [],
+  };
+  const ctx = {
+    marketType: 'event_long',
+    currentPrice: 0.3,
+    endDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+  };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('writes status=tripped to trading_config when breaker first trips', async () => {
+    const repo = { getExplorationStats: vi.fn().mockResolvedValue({ count: 22, pnl: -172.45 }) };
+    const setConfig = vi.fn().mockResolvedValue(undefined);
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: stubConfig,
+      rng: () => 0.05,
+      paperPositionsRepo: repo as any,
+      logger,
+      setTradingConfig: setConfig,
+    });
+    await resolver.resolve(ctx);
+    expect(setConfig).toHaveBeenCalledWith(
+      'direction_exploration_status',
+      expect.objectContaining({
+        state: 'tripped',
+        exploreCount: 22,
+        explorePnl: -172.45,
+        thresholdTrades: 20,
+        thresholdLoss: -150,
+      }),
+      expect.any(String),
+    );
+  });
+
+  it('writes status=active when breaker un-trips after previously tripped', async () => {
+    // First call: tripped. Second call (after cache expires): no longer tripped.
+    const repo = {
+      getExplorationStats: vi.fn()
+        .mockResolvedValueOnce({ count: 22, pnl: -172 })
+        .mockResolvedValueOnce({ count: 8, pnl: -30 }),
+    };
+    const setConfig = vi.fn().mockResolvedValue(undefined);
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: { ...stubConfig, breakerCacheTtlMs: 0 },  // disable cache for test
+      rng: () => 0.05,
+      paperPositionsRepo: repo as any,
+      logger,
+      setTradingConfig: setConfig,
+    });
+    await resolver.resolve(ctx);
+    await resolver.resolve(ctx);
+    const calls = setConfig.mock.calls.map(c => c[1].state);
+    expect(calls).toEqual(['tripped', 'active']);
+  });
+});

--- a/packages/dashboard/src/services/DirectionResolver.test.ts
+++ b/packages/dashboard/src/services/DirectionResolver.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DirectionResolver } from './DirectionResolver.js';
+import type { DirectionMultiplierPolicy } from './DirectionMultiplierPolicy.js';
+
+const stubRepo = {
+  getExplorationStats: vi.fn().mockResolvedValue({ count: 0, pnl: 0 }),
+};
+
+const stubConfig = {
+  enabled: true,
+  epsilon: 0.1,
+  min: 0.0,
+  max: 1.0,
+  breakerMinTrades: 20,
+  breakerWindowDays: 7,
+  breakerMaxCumLoss: -150,
+  breakerCacheTtlMs: 300_000,
+};
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+describe('DirectionResolver — segment match', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns segment multiplier with reason=segment when a segment matches', async () => {
+    const policy: DirectionMultiplierPolicy = {
+      global: -1.0,
+      minMultiplier: -1.25,
+      maxMultiplier: 1.0,
+      segments: [{
+        id: 'event_financial-20to40-medium',
+        multiplier: -1.25,
+        marketTypes: ['event_financial'],
+        priceRange: { min: 0.2, max: 0.4 },
+        durationBands: ['medium'],
+      }],
+    };
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: stubConfig,
+      rng: () => 0.5,
+      paperPositionsRepo: stubRepo as any,
+      logger,
+    });
+
+    const result = await resolver.resolve({
+      marketType: 'event_financial',
+      currentPrice: 0.3,
+      endDate: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000),  // medium duration
+    });
+
+    expect(result.multiplier).toBe(-1.25);
+    expect(result.segmentId).toBe('event_financial-20to40-medium');
+    expect(result.wasExploration).toBe(false);
+    expect(result.reason).toBe('segment');
+    expect(result.contextKey).toContain('event_financial');
+  });
+});

--- a/packages/dashboard/src/services/DirectionResolver.test.ts
+++ b/packages/dashboard/src/services/DirectionResolver.test.ts
@@ -69,7 +69,7 @@ describe('DirectionResolver — exploration sampling', () => {
     endDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
   };
 
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => { vi.clearAllMocks(); });
 
   it('returns global when segment misses and rng misses epsilon', async () => {
     const resolver = new DirectionResolver({
@@ -130,7 +130,7 @@ describe('DirectionResolver — circuit breaker', () => {
     endDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
   };
 
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => { vi.clearAllMocks(); });
 
   it('returns global with reason=breaker_tripped when exploration losses exceed threshold', async () => {
     const repo = { getExplorationStats: vi.fn().mockResolvedValue({ count: 22, pnl: -172.45 }) };
@@ -187,7 +187,7 @@ describe('DirectionResolver — breaker status write', () => {
     endDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
   };
 
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => { vi.clearAllMocks(); });
 
   it('writes status=tripped to trading_config when breaker first trips', async () => {
     const repo = { getExplorationStats: vi.fn().mockResolvedValue({ count: 22, pnl: -172.45 }) };

--- a/packages/dashboard/src/services/DirectionResolver.test.ts
+++ b/packages/dashboard/src/services/DirectionResolver.test.ts
@@ -119,3 +119,60 @@ describe('DirectionResolver — exploration sampling', () => {
     expect(result.reason).toBe('global');
   });
 });
+
+describe('DirectionResolver — circuit breaker', () => {
+  const policy: DirectionMultiplierPolicy = {
+    global: -1.0, minMultiplier: -1.25, maxMultiplier: 1.0, segments: [],
+  };
+  const ctx = {
+    marketType: 'event_long',
+    currentPrice: 0.3,
+    endDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+  };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns global with reason=breaker_tripped when exploration losses exceed threshold', async () => {
+    const repo = { getExplorationStats: vi.fn().mockResolvedValue({ count: 22, pnl: -172.45 }) };
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: stubConfig,
+      rng: () => 0.05,  // would sample exploration otherwise
+      paperPositionsRepo: repo as any,
+      logger,
+    });
+    const result = await resolver.resolve(ctx);
+    expect(result.reason).toBe('breaker_tripped');
+    expect(result.wasExploration).toBe(false);
+    expect(result.multiplier).toBe(-1.0);
+  });
+
+  it('does not trip when count below minTrades', async () => {
+    const repo = { getExplorationStats: vi.fn().mockResolvedValue({ count: 19, pnl: -500 }) };
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: stubConfig,
+      rng: () => 0.05,
+      paperPositionsRepo: repo as any,
+      logger,
+    });
+    const result = await resolver.resolve(ctx);
+    // Should proceed to sampling, not breaker_tripped
+    expect(result.reason).toBe('exploration');
+  });
+
+  it('caches breaker state and does not requery within TTL', async () => {
+    const repo = { getExplorationStats: vi.fn().mockResolvedValue({ count: 22, pnl: -200 }) };
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: { ...stubConfig, breakerCacheTtlMs: 60_000 },
+      rng: () => 0.05,
+      paperPositionsRepo: repo as any,
+      logger,
+    });
+    await resolver.resolve(ctx);
+    await resolver.resolve(ctx);
+    await resolver.resolve(ctx);
+    expect(repo.getExplorationStats).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/dashboard/src/services/DirectionResolver.test.ts
+++ b/packages/dashboard/src/services/DirectionResolver.test.ts
@@ -58,3 +58,64 @@ describe('DirectionResolver — segment match', () => {
     expect(result.contextKey).toContain('event_financial');
   });
 });
+
+describe('DirectionResolver — exploration sampling', () => {
+  const policy: DirectionMultiplierPolicy = {
+    global: -1.0, minMultiplier: -1.25, maxMultiplier: 1.0, segments: [],
+  };
+  const ctx = {
+    marketType: 'event_long',
+    currentPrice: 0.3,
+    endDate: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+  };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns global when segment misses and rng misses epsilon', async () => {
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: stubConfig,
+      // First rng call is the epsilon roll; 0.5 > 0.1 epsilon → miss
+      rng: () => 0.5,
+      paperPositionsRepo: stubRepo as any,
+      logger,
+    });
+    const result = await resolver.resolve(ctx);
+    expect(result.multiplier).toBe(-1.0);
+    expect(result.wasExploration).toBe(false);
+    expect(result.reason).toBe('global');
+  });
+
+  it('samples uniformly from [min, max] when segment misses and rng hits epsilon', async () => {
+    // 1st rng() = 0.05 → < 0.1 epsilon → hit.
+    // 2nd rng() = 0.7 → sampled = 0 + 0.7 * (1 - 0) = 0.7
+    const rngCalls = [0.05, 0.7];
+    let i = 0;
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: stubConfig,
+      rng: () => rngCalls[i++],
+      paperPositionsRepo: stubRepo as any,
+      logger,
+    });
+    const result = await resolver.resolve(ctx);
+    expect(result.multiplier).toBeCloseTo(0.7, 5);
+    expect(result.wasExploration).toBe(true);
+    expect(result.reason).toBe('exploration');
+    expect(result.segmentId).toBeNull();
+  });
+
+  it('returns global with reason=global when exploration is disabled, regardless of rng', async () => {
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: { ...stubConfig, enabled: false },
+      rng: () => 0.0,  // would normally trigger exploration
+      paperPositionsRepo: stubRepo as any,
+      logger,
+    });
+    const result = await resolver.resolve(ctx);
+    expect(result.multiplier).toBe(-1.0);
+    expect(result.wasExploration).toBe(false);
+    expect(result.reason).toBe('global');
+  });
+});

--- a/packages/dashboard/src/services/DirectionResolver.ts
+++ b/packages/dashboard/src/services/DirectionResolver.ts
@@ -1,0 +1,77 @@
+import {
+  resolveDirectionMultiplier,
+  type DirectionMultiplierContext,
+  type DirectionMultiplierPolicy,
+} from './DirectionMultiplierPolicy.js';
+
+export type DirectionResolveReason = 'segment' | 'global' | 'exploration' | 'breaker_tripped';
+
+export interface DirectionResolution {
+  multiplier: number;
+  contextKey: string;
+  segmentId: string | null;
+  wasExploration: boolean;
+  reason: DirectionResolveReason;
+}
+
+export interface DirectionExplorationConfig {
+  enabled: boolean;
+  epsilon: number;
+  min: number;
+  max: number;
+  breakerMinTrades: number;
+  breakerWindowDays: number;
+  breakerMaxCumLoss: number;
+  breakerCacheTtlMs: number;
+}
+
+export interface DirectionResolverPaperPositionsRepo {
+  getExplorationStats(windowDays: number): Promise<{ count: number; pnl: number }>;
+}
+
+interface Logger {
+  info(obj: object, msg?: string): void;
+  warn(obj: object, msg?: string): void;
+  error(obj: object, msg?: string): void;
+  debug(obj: object, msg?: string): void;
+}
+
+export interface DirectionResolverDeps {
+  policyProvider: () => Promise<DirectionMultiplierPolicy>;
+  explorationConfig: DirectionExplorationConfig;
+  paperPositionsRepo: DirectionResolverPaperPositionsRepo;
+  logger: Logger;
+  rng?: () => number;
+}
+
+export class DirectionResolver {
+  private readonly rng: () => number;
+
+  constructor(private readonly deps: DirectionResolverDeps) {
+    this.rng = deps.rng ?? Math.random;
+  }
+
+  async resolve(context: DirectionMultiplierContext): Promise<DirectionResolution> {
+    const policy = await this.deps.policyProvider();
+    const base = resolveDirectionMultiplier(policy, context);
+
+    if (base.segmentId !== null) {
+      return {
+        multiplier: base.multiplier,
+        contextKey: base.contextKey,
+        segmentId: base.segmentId,
+        wasExploration: false,
+        reason: 'segment',
+      };
+    }
+
+    // Segment miss — exploration and breaker branches added in later tasks.
+    return {
+      multiplier: policy.global,
+      contextKey: base.contextKey,
+      segmentId: null,
+      wasExploration: false,
+      reason: 'global',
+    };
+  }
+}

--- a/packages/dashboard/src/services/DirectionResolver.ts
+++ b/packages/dashboard/src/services/DirectionResolver.ts
@@ -46,9 +46,25 @@ export interface DirectionResolverDeps {
 
 export class DirectionResolver {
   private readonly rng: () => number;
+  private breakerCache: { tripped: boolean; fetchedAt: number; stats: { count: number; pnl: number } } | null = null;
 
   constructor(private readonly deps: DirectionResolverDeps) {
     this.rng = deps.rng ?? Math.random;
+  }
+
+  private async isBreakerTripped(): Promise<boolean> {
+    const now = Date.now();
+    if (this.breakerCache && now - this.breakerCache.fetchedAt < this.deps.explorationConfig.breakerCacheTtlMs) {
+      return this.breakerCache.tripped;
+    }
+    const stats = await this.deps.paperPositionsRepo.getExplorationStats(
+      this.deps.explorationConfig.breakerWindowDays,
+    );
+    const tripped =
+      stats.count >= this.deps.explorationConfig.breakerMinTrades &&
+      stats.pnl < this.deps.explorationConfig.breakerMaxCumLoss;
+    this.breakerCache = { tripped, fetchedAt: now, stats };
+    return tripped;
   }
 
   async resolve(context: DirectionMultiplierContext): Promise<DirectionResolution> {
@@ -73,6 +89,16 @@ export class DirectionResolver {
         segmentId: null,
         wasExploration: false,
         reason: 'global',
+      };
+    }
+
+    if (await this.isBreakerTripped()) {
+      return {
+        multiplier: policy.global,
+        contextKey: base.contextKey,
+        segmentId: null,
+        wasExploration: false,
+        reason: 'breaker_tripped',
       };
     }
 

--- a/packages/dashboard/src/services/DirectionResolver.ts
+++ b/packages/dashboard/src/services/DirectionResolver.ts
@@ -42,6 +42,7 @@ export interface DirectionResolverDeps {
   paperPositionsRepo: DirectionResolverPaperPositionsRepo;
   logger: Logger;
   rng?: () => number;
+  setTradingConfig?: (key: string, value: unknown, changeReason: string) => Promise<void>;
 }
 
 export class DirectionResolver {
@@ -63,7 +64,30 @@ export class DirectionResolver {
     const tripped =
       stats.count >= this.deps.explorationConfig.breakerMinTrades &&
       stats.pnl < this.deps.explorationConfig.breakerMaxCumLoss;
+
+    const prevTripped = this.breakerCache?.tripped ?? null;
     this.breakerCache = { tripped, fetchedAt: now, stats };
+
+    if (this.deps.setTradingConfig && (prevTripped === null || prevTripped !== tripped)) {
+      const status = {
+        state: tripped ? 'tripped' : 'active',
+        transitionAt: new Date(now).toISOString(),
+        exploreCount: stats.count,
+        explorePnl: stats.pnl,
+        thresholdTrades: this.deps.explorationConfig.breakerMinTrades,
+        thresholdLoss: this.deps.explorationConfig.breakerMaxCumLoss,
+      };
+      try {
+        await this.deps.setTradingConfig(
+          'direction_exploration_status',
+          status,
+          `Direction exploration breaker ${status.state}`,
+        );
+      } catch (err) {
+        this.deps.logger.warn({ err }, 'Failed to persist direction_exploration_status');
+      }
+    }
+
     return tripped;
   }
 

--- a/packages/dashboard/src/services/DirectionResolver.ts
+++ b/packages/dashboard/src/services/DirectionResolver.ts
@@ -65,13 +65,36 @@ export class DirectionResolver {
       };
     }
 
-    // Segment miss — exploration and breaker branches added in later tasks.
+    // Segment miss — consider exploration.
+    if (!this.deps.explorationConfig.enabled) {
+      return {
+        multiplier: policy.global,
+        contextKey: base.contextKey,
+        segmentId: null,
+        wasExploration: false,
+        reason: 'global',
+      };
+    }
+
+    const roll = this.rng();
+    if (roll >= this.deps.explorationConfig.epsilon) {
+      return {
+        multiplier: policy.global,
+        contextKey: base.contextKey,
+        segmentId: null,
+        wasExploration: false,
+        reason: 'global',
+      };
+    }
+
+    const { min, max } = this.deps.explorationConfig;
+    const sampled = min + this.rng() * (max - min);
     return {
-      multiplier: policy.global,
+      multiplier: sampled,
       contextKey: base.contextKey,
       segmentId: null,
-      wasExploration: false,
-      reason: 'global',
+      wasExploration: true,
+      reason: 'exploration',
     };
   }
 }

--- a/packages/dashboard/src/services/SignalEngine.test.ts
+++ b/packages/dashboard/src/services/SignalEngine.test.ts
@@ -201,3 +201,44 @@ describe('SignalEngine — 50/50 Market Filter', () => {
     expect(filterMarkets(markets)).toBe(0);
   });
 });
+
+describe('SignalEngine — DirectionResolver integration', () => {
+  it('passes resolver multiplier to combiner and exposes wasExploration + metadata.direction on output', async () => {
+    const stubCombined = {
+      signalId: 'combined',
+      marketId: 'mkt1',
+      tokenId: 'tok1',
+      direction: 'long' as const,
+      strength: 0.3,
+      confidence: 0.6,
+      timestamp: new Date(),
+      ttlMs: 60_000,
+      componentSignals: [],
+      weights: {},
+      appliedDirectionMultiplier: 0.6,
+      metadata: { combinerType: 'weighted_average' },
+    };
+
+    const { enrichCombinedWithDirection } = await import('./SignalEngine.js');
+    const enriched = enrichCombinedWithDirection(stubCombined as any, {
+      multiplier: 0.6,
+      contextKey: 'event_long-20to40-medium',
+      segmentId: null,
+      wasExploration: true,
+      reason: 'exploration',
+    });
+
+    expect(enriched.appliedDirectionMultiplier).toBe(0.6);
+    expect(enriched.wasExploration).toBe(true);
+    expect(enriched.metadata).toMatchObject({
+      direction: {
+        contextKey: 'event_long-20to40-medium',
+        segmentId: 'global',
+        reason: 'exploration',
+      },
+    });
+    expect(enriched.metadata).not.toHaveProperty('directionMultiplier');
+    expect(enriched.metadata).not.toHaveProperty('directionContextKey');
+    expect(enriched.metadata).not.toHaveProperty('directionPolicySegmentId');
+  });
+});

--- a/packages/dashboard/src/services/SignalEngine.ts
+++ b/packages/dashboard/src/services/SignalEngine.ts
@@ -15,12 +15,7 @@ import { signalWeightsRepo, tradingConfigRepo } from '../database/repositories.j
 import { getTradingAutomation } from './TradingAutomation.js';
 import { getDbEventListener } from './DbEventListener.js';
 import type { SignalResult } from './AutoSignalExecutor.js';
-import {
-  DEFAULT_DIRECTION_MULTIPLIER_POLICY,
-  buildDirectionMultiplierMap,
-  sanitizeDirectionMultiplierPolicy,
-  type DirectionMultiplierPolicy,
-} from './DirectionMultiplierPolicy.js';
+import { DEFAULT_DIRECTION_MULTIPLIER_POLICY } from './DirectionMultiplierPolicy.js';
 import type { DirectionResolver, DirectionResolution } from './DirectionResolver.js';
 
 
@@ -139,7 +134,6 @@ export class SignalEngine extends EventEmitter {
   private activeMarkets: ActiveMarket[] = [];
   private lastComputeTime: Date | null = null;
   private signalsGenerated = 0;
-  private directionMultiplierPolicy: DirectionMultiplierPolicy = DEFAULT_DIRECTION_MULTIPLIER_POLICY;
   private readonly directionResolver: DirectionResolver;
 
   constructor(config: SignalEngineConfig) {
@@ -311,18 +305,11 @@ export class SignalEngine extends EventEmitter {
         ? parseFloat(String(dmEntry.weight))
         : DEFAULT_DIRECTION_MULTIPLIER_POLICY.global;
 
-      const configuredPolicy = await tradingConfigRepo.get<Partial<DirectionMultiplierPolicy>>(
-        'direction_multiplier_policy'
-      );
-      this.directionMultiplierPolicy = sanitizeDirectionMultiplierPolicy(
-        configuredPolicy,
-        globalDirectionMultiplier
-      );
-
+      // Per-market direction is now owned by DirectionResolver.resolve() on every signal;
+      // only the global fallback multiplier (for the combiner's internal default) is synced here.
       if (dmEntry) {
         this.combiner.setDirectionMultiplier(globalDirectionMultiplier);
       }
-      this.combiner.setDirectionMultipliers(buildDirectionMultiplierMap(this.directionMultiplierPolicy));
     } catch (error) {
       console.error('[SignalEngine] Failed to sync weights:', error);
     }
@@ -1053,7 +1040,7 @@ export class SignalEngine extends EventEmitter {
    * Returns null if market price is extreme (no profitable trade possible)
    */
   private convertToSignalResult(
-    output: SignalOutput,
+    output: SignalOutput & { appliedDirectionMultiplier?: number; wasExploration?: boolean },
     market: ActiveMarket
   ): SignalResult | null {
     // Dynamic price filter based on market type
@@ -1098,6 +1085,8 @@ export class SignalEngine extends EventEmitter {
       price,
       marketType: market.marketType,
       metadata: output.metadata,
+      appliedDirectionMultiplier: output.appliedDirectionMultiplier,
+      wasExploration: output.wasExploration ?? false,
     };
   }
 

--- a/packages/dashboard/src/services/SignalEngine.ts
+++ b/packages/dashboard/src/services/SignalEngine.ts
@@ -18,10 +18,10 @@ import type { SignalResult } from './AutoSignalExecutor.js';
 import {
   DEFAULT_DIRECTION_MULTIPLIER_POLICY,
   buildDirectionMultiplierMap,
-  resolveDirectionMultiplier,
   sanitizeDirectionMultiplierPolicy,
   type DirectionMultiplierPolicy,
 } from './DirectionMultiplierPolicy.js';
+import type { DirectionResolver, DirectionResolution } from './DirectionResolver.js';
 
 
 // Import from signals package
@@ -63,13 +63,45 @@ export interface SignalEngineConfig {
   computeIntervalMs: number;     // How often to compute signals (60000 = 1 min)
   maxMarketsPerCycle: number;    // Max markets to process per cycle
   minPriceBars: number;          // Minimum price bars needed
-  syncWeightsIntervalMs: number; // How often to sync weights from DB
+  syncWeightsIntervalMs?: number; // How often to sync weights from DB
   minCombinedConfidence?: number; // Open threshold — minimum confidence to enter a new position (0-1)
   minCombinedStrength?: number;   // Minimum combined signal strength (0-1)
   exitThreshold?: number;         // Exit threshold — minimum confidence to close an existing position (lower than open)
+  directionResolver: DirectionResolver; // Required — resolves per-market direction multiplier
 }
 
-const DEFAULT_CONFIG: SignalEngineConfig = {
+/**
+ * Enrich a combined signal output with direction resolution metadata.
+ * Strips old flat metadata keys and writes a consolidated `metadata.direction` object.
+ */
+export function enrichCombinedWithDirection<T extends {
+  metadata?: Record<string, unknown>;
+}>(
+  combined: T,
+  resolution: DirectionResolution,
+): T & { appliedDirectionMultiplier: number; wasExploration: boolean } {
+  const {
+    directionMultiplier: _a,
+    directionContextKey: _b,
+    directionPolicySegmentId: _c,
+    ...restMeta
+  } = (combined.metadata ?? {}) as Record<string, unknown>;
+  return {
+    ...combined,
+    appliedDirectionMultiplier: resolution.multiplier,
+    wasExploration: resolution.wasExploration,
+    metadata: {
+      ...restMeta,
+      direction: {
+        contextKey: resolution.contextKey,
+        segmentId: resolution.segmentId ?? 'global',
+        reason: resolution.reason,
+      },
+    },
+  };
+}
+
+const DEFAULT_CONFIG: Omit<SignalEngineConfig, 'directionResolver'> = {
   enabled: true,
   computeIntervalMs: 60000,      // 1 minute
   maxMarketsPerCycle: 50,
@@ -108,10 +140,12 @@ export class SignalEngine extends EventEmitter {
   private lastComputeTime: Date | null = null;
   private signalsGenerated = 0;
   private directionMultiplierPolicy: DirectionMultiplierPolicy = DEFAULT_DIRECTION_MULTIPLIER_POLICY;
+  private readonly directionResolver: DirectionResolver;
 
-  constructor(config?: Partial<SignalEngineConfig>) {
+  constructor(config: SignalEngineConfig) {
     super();
     this.config = { ...DEFAULT_CONFIG, ...config };
+    this.directionResolver = config.directionResolver;
 
     // Initialize signal generators
     this.initializeSignals();
@@ -446,7 +480,7 @@ export class SignalEngine extends EventEmitter {
     const combinedWeights = this.priceRangeModifier.modifyWeights(durationWeights, market.currentPrice);
     this.combiner.setWeights(combinedWeights);
 
-    const directionResolution = resolveDirectionMultiplier(this.directionMultiplierPolicy, {
+    const directionResolution = await this.directionResolver.resolve({
       marketType: market.marketType,
       currentPrice: market.currentPrice,
       endDate: market.endDate,
@@ -454,7 +488,7 @@ export class SignalEngine extends EventEmitter {
     });
     this.combiner.setDirectionMultiplier(
       directionResolution.multiplier,
-      directionResolution.contextKey
+      directionResolution.contextKey,
     );
 
     // Combine signals with market-type-specific weights and a separate direction context
@@ -475,22 +509,17 @@ export class SignalEngine extends EventEmitter {
     // Apply Bayesian confidence cap based on data availability
     const confidenceCap = this.computeBayesianConfidenceCap(context.priceBars);
     combined.confidence *= confidenceCap;
-    combined.metadata = {
-      ...(combined.metadata ?? {}),
-      directionMultiplier: directionResolution.multiplier,
-      directionContextKey: directionResolution.contextKey,
-      directionPolicySegmentId: directionResolution.segmentId ?? 'global',
-    };
+    const enriched = enrichCombinedWithDirection(combined, directionResolution);
 
     // Re-check confidence after cap — use exitThreshold as pass-through floor
     // (SignalEngine lets through anything ≥ exitThreshold; AutoSignalExecutor re-applies
     // the higher openThreshold for new positions, enabling hysteresis)
-    if (combined.confidence < (this.config.exitThreshold ?? 0.25)) {
+    if (enriched.confidence < (this.config.exitThreshold ?? 0.25)) {
       return null;
     }
 
     // Convert to SignalResult format for AutoSignalExecutor
-    return this.convertToSignalResult(combined, market);
+    return this.convertToSignalResult(enriched, market);
   }
 
   /**
@@ -1161,12 +1190,12 @@ let signalEngine: SignalEngine | null = null;
 
 export function getSignalEngine(): SignalEngine {
   if (!signalEngine) {
-    signalEngine = new SignalEngine();
+    throw new Error('[SignalEngine] Not initialized — call initializeSignalEngine() first');
   }
   return signalEngine;
 }
 
-export function initializeSignalEngine(config?: Partial<SignalEngineConfig>): SignalEngine {
+export function initializeSignalEngine(config: SignalEngineConfig): SignalEngine {
   signalEngine = new SignalEngine(config);
   return signalEngine;
 }

--- a/packages/dashboard/src/services/__tests__/DirectionExploration.integration.test.ts
+++ b/packages/dashboard/src/services/__tests__/DirectionExploration.integration.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DirectionResolver } from '../DirectionResolver.js';
+import { enrichCombinedWithDirection } from '../SignalEngine.js';
+import type { DirectionMultiplierPolicy } from '../DirectionMultiplierPolicy.js';
+
+describe('Direction exploration — end-to-end integration', () => {
+  const policy: DirectionMultiplierPolicy = {
+    global: -1.0, minMultiplier: -1.25, maxMultiplier: 1.0, segments: [],
+  };
+  const ctx = {
+    marketType: 'event_long',
+    currentPrice: 0.3,
+    endDate: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000),
+  };
+  const stubRepo = {
+    getExplorationStats: vi.fn().mockResolvedValue({ count: 5, pnl: 0 }),
+    openPositionAtomically: vi.fn().mockResolvedValue({ opened: true }),
+  };
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('an exploration resolution ends up persisted with was_exploration=true', async () => {
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: {
+        enabled: true, epsilon: 1.0, min: 0.0, max: 1.0,
+        breakerMinTrades: 20, breakerWindowDays: 7, breakerMaxCumLoss: -150, breakerCacheTtlMs: 300_000,
+      },
+      rng: (() => { let i = 0; const vals = [0.0, 0.6]; return () => vals[i++ % 2]; })(),
+      paperPositionsRepo: stubRepo as any,
+      logger,
+    });
+
+    const resolution = await resolver.resolve(ctx);
+    expect(resolution.wasExploration).toBe(true);
+    expect(resolution.multiplier).toBeCloseTo(0.6, 5);
+
+    // Simulate combiner producing a combined output with appliedDirectionMultiplier set
+    const combined = {
+      signalId: 'combined', marketId: 'mkt1', tokenId: 'tok1',
+      direction: 'long' as const, strength: 0.3, confidence: 0.7,
+      timestamp: new Date(), ttlMs: 60_000, componentSignals: [], weights: {},
+      appliedDirectionMultiplier: resolution.multiplier, metadata: {},
+    };
+    const enriched = enrichCombinedWithDirection(combined, resolution);
+    expect(enriched.wasExploration).toBe(true);
+    expect(enriched.appliedDirectionMultiplier).toBeCloseTo(0.6, 5);
+
+    // Simulate executor building the PaperPosition payload
+    const positionPayload = {
+      market_id: 'mkt1', token_id: 'tok1', side: 'long' as const, size: 10,
+      avg_entry_price: 0.3, current_price: 0.3,
+      opened_at: new Date(),
+      applied_direction_multiplier: enriched.appliedDirectionMultiplier,
+      was_exploration: enriched.wasExploration,
+    };
+    await stubRepo.openPositionAtomically(positionPayload, 3.0, 0.01);
+    expect(stubRepo.openPositionAtomically).toHaveBeenCalledWith(
+      expect.objectContaining({
+        applied_direction_multiplier: expect.closeTo(0.6, 5),
+        was_exploration: true,
+      }),
+      3.0, 0.01,
+    );
+  });
+
+  it('breaker-tripped resolution persists with was_exploration=false and multiplier=global', async () => {
+    stubRepo.getExplorationStats = vi.fn().mockResolvedValue({ count: 25, pnl: -200 });
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: {
+        enabled: true, epsilon: 1.0, min: 0.0, max: 1.0,
+        breakerMinTrades: 20, breakerWindowDays: 7, breakerMaxCumLoss: -150, breakerCacheTtlMs: 300_000,
+      },
+      rng: () => 0.0,  // would trigger exploration otherwise
+      paperPositionsRepo: stubRepo as any,
+      logger,
+    });
+    const resolution = await resolver.resolve(ctx);
+    expect(resolution.reason).toBe('breaker_tripped');
+    expect(resolution.wasExploration).toBe(false);
+    expect(resolution.multiplier).toBe(-1.0);
+  });
+});

--- a/packages/dashboard/src/services/__tests__/DirectionExploration.integration.test.ts
+++ b/packages/dashboard/src/services/__tests__/DirectionExploration.integration.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
 import { DirectionResolver } from '../DirectionResolver.js';
 import { enrichCombinedWithDirection } from '../SignalEngine.js';
 import type { DirectionMultiplierPolicy } from '../DirectionMultiplierPolicy.js';
@@ -81,5 +83,21 @@ describe('Direction exploration — end-to-end integration', () => {
     expect(resolution.reason).toBe('breaker_tripped');
     expect(resolution.wasExploration).toBe(false);
     expect(resolution.multiplier).toBe(-1.0);
+  });
+});
+
+describe('convertToSignalResult propagation (source-pinning)', () => {
+  it('preserves appliedDirectionMultiplier and wasExploration from enriched output to SignalResult', () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../SignalEngine.ts'),
+      'utf8',
+    );
+    const fnStart = source.indexOf('convertToSignalResult(');
+    expect(fnStart).toBeGreaterThan(-1);
+    // Find the end of the function body by looking for the next JSDoc comment
+    const fnEnd = source.indexOf('/**\n   * Send signals', fnStart);
+    const fnBody = source.substring(fnStart, fnEnd);
+    expect(fnBody).toContain('appliedDirectionMultiplier');
+    expect(fnBody).toContain('wasExploration');
   });
 });

--- a/packages/data-collector/src/database/init/017_direction_multiplier_exploration_columns.sql
+++ b/packages/data-collector/src/database/init/017_direction_multiplier_exploration_columns.sql
@@ -1,0 +1,6 @@
+-- Direction multiplier exploration: per-trade multiplier provenance
+-- Adds two columns to paper_positions so the learner can bucket trades
+-- by the actual applied multiplier (not just the contemporaneous global).
+ALTER TABLE paper_positions
+  ADD COLUMN IF NOT EXISTS applied_direction_multiplier NUMERIC(5,3),
+  ADD COLUMN IF NOT EXISTS was_exploration BOOLEAN NOT NULL DEFAULT false;

--- a/packages/signals/src/combiners/WeightedAverageCombiner.test.ts
+++ b/packages/signals/src/combiners/WeightedAverageCombiner.test.ts
@@ -15,6 +15,32 @@ function createSignal(signalId: string, strength: number): SignalOutput {
   };
 }
 
+function baseWeights(): Record<string, number> {
+  return { momentum: 1 };
+}
+
+function params(): Record<string, unknown> {
+  return { minCombinedStrength: 0.01, minCombinedConfidence: 0.01 };
+}
+
+function buildSignal(opts: {
+  signalId: string;
+  direction: 'long' | 'short';
+  strength: number;
+  confidence: number;
+}): SignalOutput {
+  return {
+    signalId: opts.signalId,
+    marketId: 'market-1',
+    tokenId: 'token-1',
+    direction: opts.direction.toUpperCase() as 'LONG' | 'SHORT',
+    strength: opts.direction === 'long' ? Math.abs(opts.strength) : -Math.abs(opts.strength),
+    confidence: opts.confidence,
+    timestamp: new Date(),
+    ttlMs: 60_000,
+  };
+}
+
 describe('WeightedAverageCombiner direction context', () => {
   it('uses market type for signal weights and direction context for multiplier overrides', () => {
     const combiner = new WeightedAverageCombiner(
@@ -60,5 +86,25 @@ describe('WeightedAverageCombiner direction context', () => {
     expect(combined).not.toBeNull();
     expect(combined?.strength).toBeCloseTo(-0.8, 5);
     expect(combined?.direction).toBe('SHORT');
+  });
+});
+
+describe('WeightedAverageCombiner — applied direction multiplier', () => {
+  it('exposes applied multiplier in CombinedSignalOutput', () => {
+    const combiner = new WeightedAverageCombiner(baseWeights(), params());
+    combiner.setDirectionMultiplier(0.5, 'test-ctx');
+    const signals = [buildSignal({ signalId: 'momentum', direction: 'long', strength: 0.6, confidence: 0.8 })];
+    const result = combiner.combine(signals, undefined, 'event_long', 'test-ctx');
+    expect(result).not.toBeNull();
+    expect(result!.appliedDirectionMultiplier).toBe(0.5);
+  });
+
+  it('exposes appliedDirectionMultiplier matching the explicitly set global multiplier', () => {
+    const combiner = new WeightedAverageCombiner(baseWeights(), params());
+    combiner.setDirectionMultiplier(1.0);  // explicit global; does not touch context map
+    const signals = [buildSignal({ signalId: 'momentum', direction: 'long', strength: 0.6, confidence: 0.8 })];
+    const result = combiner.combine(signals);
+    expect(result).not.toBeNull();
+    expect(result!.appliedDirectionMultiplier).toBe(1.0);
   });
 });

--- a/packages/signals/src/combiners/WeightedAverageCombiner.ts
+++ b/packages/signals/src/combiners/WeightedAverageCombiner.ts
@@ -53,7 +53,8 @@ export class WeightedAverageCombiner implements ISignalCombiner {
   private parameters: WeightedAverageParams;
   /** Multiplier applied to combined strength before direction determination.
    *  -1 = flip all signals (contrarian). Context overrides are stored separately
-   *  so market-type-specific signal weights remain independent from direction policy. */
+   *  so market-type-specific signal weights remain independent from direction policy.
+   *  Default -1 (contrarian/flip); callers can override per context key for exploration. */
   private directionMultiplier: number = -1;
   private contextDirectionMultipliers: Record<string, number> = {};
 
@@ -196,6 +197,7 @@ export class WeightedAverageCombiner implements ISignalCombiner {
       ttlMs: Math.min(...usedSignals.map(s => s.signal.ttlMs)),
       componentSignals: usedSignals.map(s => s.signal),
       weights: this.getCurrentWeights(usedSignals),
+      appliedDirectionMultiplier: multiplier,
       metadata: {
         combinerType: 'weighted_average',
         signalCount: usedSignals.length,

--- a/packages/signals/src/combiners/WeightedAverageCombiner.ts
+++ b/packages/signals/src/combiners/WeightedAverageCombiner.ts
@@ -198,6 +198,7 @@ export class WeightedAverageCombiner implements ISignalCombiner {
       componentSignals: usedSignals.map(s => s.signal),
       weights: this.getCurrentWeights(usedSignals),
       appliedDirectionMultiplier: multiplier,
+      wasExploration: false,  // enrichCombinedWithDirection overwrites this when exploration is active
       metadata: {
         combinerType: 'weighted_average',
         signalCount: usedSignals.length,

--- a/packages/signals/src/core/types/signal.types.ts
+++ b/packages/signals/src/core/types/signal.types.ts
@@ -168,8 +168,15 @@ export interface CombinedSignalOutput extends SignalOutput {
   /** Individual signals that contributed */
   componentSignals: SignalOutput[];
 
-  /** Weights used for each signal */
+  /** Weights used in combination */
   weights: Record<string, number>;
+
+  /** Multiplier applied to combined strength (post-flip value). Defaults to 1.0. */
+  appliedDirectionMultiplier: number;
+
+  /** Whether the multiplier came from epsilon-greedy exploration slot.
+   *  False for segment hits, global fallback, and breaker-tripped fallback. */
+  wasExploration?: boolean;
 }
 
 export interface ISignalCombiner {

--- a/packages/signals/src/core/types/signal.types.ts
+++ b/packages/signals/src/core/types/signal.types.ts
@@ -176,7 +176,7 @@ export interface CombinedSignalOutput extends SignalOutput {
 
   /** Whether the multiplier came from epsilon-greedy exploration slot.
    *  False for segment hits, global fallback, and breaker-tripped fallback. */
-  wasExploration?: boolean;
+  wasExploration: boolean;
 }
 
 export interface ISignalCombiner {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     // resolve them without a pre-built dist/ directory.
     alias: {
       '@polymarket-trader/backtest': path.resolve(__dirname, 'packages/backtest/src/index.ts'),
+      '@polymarket-trader/signals': path.resolve(__dirname, 'packages/signals/src/index.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

Enables epsilon-greedy exploration of positive direction-multiplier values to break the cold-start trap in `DirectionMultiplierLearningService`. The learner currently can't promote any segment away from global `-1.0` because all trades are stuck in the `strong_negative` bucket. Post-reset counterfactual analysis showed 86.9% WR if trades had been taken with an inverted multiplier (vs 13.1% actual) — strong prior evidence that positive multipliers may win in several segments. This PR widens the learner range to `[-1.25, +1.0]`, adds 4 new buckets, and introduces a `DirectionResolver` that samples random multipliers from `[0, 1.0]` on ~10% of segment-miss trades.

Design and analysis: `docs/plans/2026-04-20-direction-multiplier-exploration-design.md`
Plan: `docs/plans/2026-04-20-direction-multiplier-exploration-plan.md`

**Scope-bounded. Explicit non-goals preserved:**
- Global multiplier stays pinned at `-1.0` (no change to optimizer param space; PR #104 intent intact)
- No Thompson sampling / bandit logic (uniform exploration only)
- No account reset
- Combiner math unchanged (only output extension)

## What changed

- **DB**: two new columns on `paper_positions` — `applied_direction_multiplier NUMERIC(5,3)` (nullable) and `was_exploration BOOLEAN NOT NULL DEFAULT false`. Dual-path migration (init file `017_...sql` + startup DDL in `server.ts`).
- **`DirectionResolver`** (new module): wraps the pure `resolveDirectionMultiplier()`. On segment miss + exploration enabled + breaker not tripped + `rng() < epsilon`, samples uniform from `[min, max]`. Otherwise falls through to global `-1.0`. State is observable via `trading_config.direction_exploration_status` on breaker transitions.
- **Circuit breaker**: auto-disables exploration when >=20 exploration trades accumulate >$150 losses in a 7-day window. Cached 5min to avoid per-signal DB hits.
- **Learner**: `DEFAULT_CONFIG.maxMultiplier` widened from `0.1` to `1.0`; `bucketDirectionMultiplier` replaced with `{strong_negative, near_zero, weak_positive, strong_positive}` aligned to the new range. Query now prefers `pp.applied_direction_multiplier` via COALESCE — exploration trades are finally visible to promotion.
- **`SignalEngine`**: `DirectionResolver` injected (required); `enrichCombinedWithDirection` helper sets top-level `appliedDirectionMultiplier` + `wasExploration` on output and consolidates `metadata.direction = { contextKey, segmentId, reason }`.
- **`AutoSignalExecutor`**: propagates both fields into the `PaperPosition` payload.
- **Env vars** in `docker-compose.gcp.yml`: `ENABLE_DIRECTION_EXPLORATION=true`, `EPSILON=0.10`, `MIN=0.0`, `MAX=1.0`, breaker thresholds. Kill switch: set `ENABLE_DIRECTION_EXPLORATION=false` + restart.

## Success criteria (30-day window)

- **Primary**: >=1 segment promoted to a multiplier in `[+0.25, +1.0]` with >=24 trades and verified lift vs `-1.0` baseline per existing promotion gates.
- **Secondary** (supporting, not standalone): aggregate exploration PnL per trade exceeds `-1.0` baseline by >=\$0.50. Sample size weak at current throughput (~24 exploration trades/30d); primary carries decision weight.
- **Failure mode**: breaker trips >=2 times in 30 days → exploration is net-negative; roll back.

## Review notes

- 15 commits across 13 TDD-driven tasks with two-stage review (spec compliance + code quality) per task.
- Final review caught a critical bug: `convertToSignalResult` was dropping the two new fields, which would have silently no-op'd the whole feature in production. Fixed in `c4bcff6` with regression test + `wasExploration` made required on `CombinedSignalOutput` so TypeScript flags future regressions.
- 670 dashboard tests pass. Pre-existing `OptimizationScheduler.test.ts` Vite-resolution skip remains (documented in daily reviews).
- All spec non-goals verified in the final review (global pin preserved, optimizer param space untouched, combiner math unchanged).

## Test plan

- [ ] Merge PR
- [ ] Verify deploy workflow completes (GHCR build + VM pull)
- [ ] On VM: verify the two columns exist via `\d paper_positions`
- [ ] On VM: verify env vars loaded via `docker exec polymarket-dashboard-api env | grep DIRECTION_EXPLORATION`
- [ ] Watch `docker logs polymarket-dashboard-api` for the first ~10 signals — expect to see `wasExploration=true` on ~10% of them (log line includes `reason` from the resolver)
- [ ] Monitor `trading_config.direction_exploration_status` daily — state should stay `active` unless exploration PnL truly degrades
- [ ] After 7 days: query `paper_positions` for `was_exploration=true` count and mean `realized_pnl` vs baseline (`applied_direction_multiplier = -1.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added direction multiplier exploration capability with configurable epsilon-greedy sampling within user-defined bounds.
  * Implemented automatic circuit-breaker mechanism to halt exploration when cumulative losses exceed configured thresholds.
  * Enhanced trade tracking to record whether each trade used exploration or matched policy.

* **Chores**
  * Extended database schema to support direction exploration tracking.
  * Added environment variables to enable and configure exploration parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->