### PR TITLE
perf(scorer): NOT EXISTS antijoin for realized-vol NULL-out

### DIFF
--- a/packages/data-collector/src/services/Scheduler.test.ts
+++ b/packages/data-collector/src/services/Scheduler.test.ts
@@ -16,9 +16,9 @@ describe('computeRealizedVolatility', () => {
   it('executes the UPDATE and the NULL-out UPDATE without throwing', async () => {
     (query as unknown as Mock).mockResolvedValue({ rowCount: 10, rows: [] });
     await expect(computeRealizedVolatility()).resolves.not.toThrow();
-    // Two UPDATE statements issued: set vols + null out stale
+    // Two UPDATE statements issued: set vols + null out stale (second may be wrapped in CTE)
     const updateCalls = (query as unknown as Mock).mock.calls.filter(
-      (c) => typeof c[0] === 'string' && c[0].trim().startsWith('UPDATE markets'),
+      (c) => typeof c[0] === 'string' && c[0].includes('UPDATE markets'),
     );
     expect(updateCalls.length).toBe(2);
   });

--- a/packages/data-collector/src/services/Scheduler.ts
+++ b/packages/data-collector/src/services/Scheduler.ts
@@ -43,15 +43,22 @@ export async function computeRealizedVolatility(): Promise<void> {
     `);
 
     // Null out markets that no longer have qualifying recent data.
+    // NOT EXISTS + CTE pattern lets the planner use HashAntiJoin rather than
+    // the nested-loop forced by NOT IN. Production measured 100s → expected <5s.
     const nullResult = await query(`
-      UPDATE markets
+      WITH valid_tokens AS (
+        SELECT token_id
+        FROM price_history
+        WHERE time > NOW() - INTERVAL '24 hours'
+        GROUP BY token_id
+        HAVING COUNT(*) >= 6
+      )
+      UPDATE markets m
       SET realized_volatility_24h = NULL, realized_volatility_bar_count = NULL
-      WHERE realized_volatility_24h IS NOT NULL
-        AND clob_token_id_yes NOT IN (
-          SELECT token_id FROM price_history
-          WHERE time > NOW() - INTERVAL '24 hours'
-          GROUP BY token_id
-          HAVING COUNT(*) >= 6
+      WHERE m.realized_volatility_24h IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM valid_tokens v
+          WHERE v.token_id = m.clob_token_id_yes
         )
     `);
 


### PR DESCRIPTION
NULL-out UPDATE in computeRealizedVolatility took 100s of 120s total. Switch NOT IN (subquery) to CTE + NOT EXISTS → HashAntiJoin. Expected drop to <5s. Semantics preserved.