### PR TITLE
feat: shadow pool — separate live and shadow lanes for market tracking

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -75,6 +75,8 @@ services:
       CLOB_API_URL: https://clob.polymarket.com
       DATA_API_URL: https://data-api.polymarket.com
       MAX_TRACKED_MARKETS: "35"
+      ALLOWED_MARKET_TYPES: "crypto_intraday,crypto_daily,event_financial,event_short"
+      MAX_SHADOW_MARKETS: "10"
       DB_POOL_MAX: "8"
       DB_IDLE_TIMEOUT_MS: "10000"
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}

--- a/docs/plans/2026-04-25-shadow-pool-design.md
+++ b/docs/plans/2026-04-25-shadow-pool-design.md
@@ -1,0 +1,183 @@
+# Shadow Pool Design — Live + Shadow Lane Separation
+
+**Date**: 2026-04-25
+**Status**: Design (pending implementation plan)
+**Related**: Issue #131 (96h trade drought), `project_crypto_data_gap.md`, `feedback_no_diversity_quota.md`
+
+## Problem
+
+The system has a closed loop that traps 14,386 crypto markets in `tracking_status='cold'`, producing 96h+ trade droughts:
+
+1. All crypto markets are cold.
+2. `ClobCollector.snapshotCurrentPricesToHistory()` (and every other ClobCollector method) filters by `tracking_status IN ('warming','active','cooling')` — cold markets never get `price_history` rows.
+3. `SignalEngine` requires `EXISTS in price_history (last 24h)` to consider a market — crypto excluded.
+4. `MarketRotator` candidate query is `WHERE tracking_status='cold' ORDER BY market_score DESC LIMIT 50`. event_long avg score 0.725 dominates over crypto 0.622. Top-50 are always event_long → crypto never promoted.
+5. Loop closes.
+
+The asymmetry: `ALLOWED_MARKET_TYPES` excludes event_long. So 91% of the live pool is occupied by markets the executor will reject. Markets we *would* trade (crypto, event_short, event_financial) get starved by markets we *won't* trade.
+
+Diversity quotas were rejected by the user (see `feedback_no_diversity_quota.md`): pool selection must remain merit-based. The structural fix is to separate the pools so live operates on `ALLOWED_MARKET_TYPES` only, and a small shadow pool keeps observing non-allowed types for promotion decisions.
+
+## Goal
+
+Split tracking into two parallel lanes:
+- **Live lane**: candidates restricted to `ALLOWED_MARKET_TYPES`. Operates trades.
+- **Shadow lane**: candidates restricted to types NOT in `ALLOWED_MARKET_TYPES`. Observes via `shadow_trades` only. Used by daily auto-review to inform promotion decisions.
+
+Crypto markets compete in the live lane against event_short/event_financial — winning naturally because event_long no longer crowds them out. Trade drought ends. Shadow lane keeps event_long signal data for empirical validation of the allowlist.
+
+## Architecture
+
+**Single new column**: `markets.is_shadow BOOLEAN NOT NULL DEFAULT false`. Combined with existing `tracking_status` (cold/warming/active/cooling), defines a market's lane. A market is in exactly one lane at a time.
+
+Lane assignment is **derived** from `market_type` and `ALLOWED_MARKET_TYPES`:
+- `is_shadow = false` if `market_type ∈ ALLOWED_MARKET_TYPES`
+- `is_shadow = true` otherwise
+
+The flag is materialized (not computed per query) for performance, and recomputed on every market sync. When `ALLOWED_MARKET_TYPES` env changes, a startup hook does a batch UPDATE.
+
+**Two rotation passes per cycle**: `MarketRotator.rotate(lane)` is invoked twice — once with `lane='live'`, once with `lane='shadow'`. Same engine, same hysteresis logic, separate budgets:
+- Live: `MAX_TRACKED_MARKETS=40` (existing).
+- Shadow: `MAX_SHADOW_MARKETS=10` (new env, default 10).
+
+**Signal pipeline** unchanged in shape. SignalEngine processes both lanes uniformly. AutoSignalExecutor short-circuits shadow signals to `shadow_trades` directly, bypassing the rejection path.
+
+## Components
+
+### `markets` schema
+- Add `is_shadow BOOLEAN NOT NULL DEFAULT false` via startup `ALTER TABLE IF NOT EXISTS` pattern (post-init migration, consistent with how the project applies schema changes after first volume init).
+- Partial indexes for hot rotator paths:
+  - `CREATE INDEX IF NOT EXISTS idx_markets_live_cold_candidates ON markets(market_score DESC) WHERE is_shadow=false AND tracking_status='cold' AND is_active=true AND is_resolved=false`
+  - `CREATE INDEX IF NOT EXISTS idx_markets_shadow_cold_candidates ON markets(market_score DESC) WHERE is_shadow=true AND tracking_status='cold' AND is_active=true AND is_resolved=false`
+
+### `GammaCollector` / sync-markets job
+- On upsert, compute `is_shadow = market_type NOT IN ALLOWED_LIST` and write it.
+- The `ALLOWED_LIST` is read from `ALLOWED_MARKET_TYPES` env once at process start (already the pattern in `AutoSignalExecutor`).
+
+### Startup hook (in `packages/dashboard/src/server.ts`)
+- Owned by the dashboard process because it already reads `ALLOWED_MARKET_TYPES` (via `AutoSignalExecutor`) and is responsible for other post-init ALTER TABLE migrations in the codebase.
+- Runs after schema migration (column add) and before the SignalEngine starts emitting signals or the data-collector's rotator first runs:
+  ```sql
+  UPDATE markets
+  SET is_shadow = (market_type IS NULL OR NOT (market_type = ANY($1::text[])))
+  WHERE is_resolved = false;
+  ```
+- Blocks startup until complete. Logged with row counts (rows updated, rows that flipped lanes, rows already correct).
+- Idempotent: re-running with the same allowed list is a no-op (UPDATE matches nothing because all rows already have correct `is_shadow`).
+
+### `MarketRotator` (`packages/data-collector/src/services/MarketRotator.ts`)
+- Refactor: existing `rotate()` becomes `rotate(lane: 'live' | 'shadow'): Promise<RotationResult>`. Internal queries add `AND is_shadow = $lane_bool`.
+- New public method `rotateAll(): Promise<{ live: RotationResult; shadow: RotationResult }>` orchestrates both lanes sequentially (shared DB connection; parallelizing has no clear benefit and complicates lock contention).
+- Single `MarketRotator` instance is constructed with two `RotationConfig`s internally — one per lane. Constructor signature changes from `constructor(config?: Partial<RotationConfig>)` to `constructor(liveConfig?: Partial<RotationConfig>, shadowConfig?: Partial<RotationConfig>)`. The lane parameter selects which config applies inside `rotate()`.
+- `MIN_CANDIDATE_SCORE=0.15` shared between lanes.
+- The Scheduler entry currently calling `rotator.rotate()` becomes `rotator.rotateAll()`.
+- `DEFAULT_CONFIG` for shadow defaults: `maxTracked = parseInt(process.env.MAX_SHADOW_MARKETS || '10', 10)`. All other defaults inherited from the existing live config.
+
+### `ClobCollector`
+- **No code change to filter clauses.** The 5 sites filtering `tracking_status IN ('warming','active','cooling')` correctly serve both lanes — once shadow markets get promoted, they enter the snapshot/orderbook/price-update pipeline automatically.
+- Verification only: confirm logs show `Price snapshots inserted` for shadow markets after they reach warming.
+
+### `SignalEngine` (`packages/dashboard/src/services/SignalEngine.ts`)
+- `ActiveMarket` type adds `isShadow: boolean`.
+- `setActiveMarkets()` filter unchanged — it already includes both lanes via tracking_status.
+- `SignalResult` adds `isShadow: boolean`, populated from the source `ActiveMarket`.
+- `PolymarketService.updateSignalEngine()` populates `isShadow` from the markets query.
+
+### `AutoSignalExecutor` (`packages/dashboard/src/services/AutoSignalExecutor.ts`)
+- New first check in `processSignal()`:
+  ```ts
+  if (signal.isShadow) {
+    await this.insertShadowTrade(signal);
+    return { executed: false, reason: 'shadow_lane' };
+  }
+  ```
+- The existing `market_type_not_allowed` gate stays as defense-in-depth (handles the rare case of a live signal whose market_type isn't in ALLOWED — possible if ALLOWED env was changed without a sync). Insert path stays the same.
+
+### `shadow_trades` table and `MarketPerformanceTracker`
+- No schema change. No code change. The table receives entries via the new short-circuit path instead of the rejection path; semantically identical.
+
+## Data Flow — Crypto Market Lifecycle
+
+1. GammaCollector inserts/updates a `crypto_intraday` market. `is_shadow=false` (it's in ALLOWED_MARKET_TYPES).
+2. ClobCollector updates `current_price_yes` (no tracking_status filter on that path; already works).
+3. Rotator live lane runs. Sees this market as a cold candidate. Crypto markets now compete only against other ALLOWED types (event_short, event_financial). Wins ranking → promoted to warming.
+4. ClobCollector's `snapshotCurrentPricesToHistory()` matches `tracking_status='warming'` filter → inserts price_history rows.
+5. After 3 bars, rotator promotes warming → active.
+6. SignalEngine generates signals. AutoExecutor sees `isShadow=false` → live trade flow.
+
+**Symmetric for an event_long market**: lands `is_shadow=true`, competes in shadow lane only, generates `shadow_trades` entries when SignalEngine emits.
+
+## Migration Strategy (Deploy Day)
+
+Pre-deploy state: 32 markets in active+warming, ~29 of them event_long (live pool dominated by non-allowed types).
+
+Post-startup-hook state:
+- 29 event_long markets: `is_shadow=true, tracking_status=active`. Now in shadow lane, **already over the cap** (29 vs MAX_SHADOW_MARKETS=10).
+- 2 event_financial + 1 event_short: `is_shadow=false, tracking_status=active`. In live lane, far below cap (3 vs 40).
+
+Next rotator cycle (within 5 min of deploy):
+- Shadow lane: hysteresis-based demotions select worst-scoring event_long markets without open positions and demote them. `maxRotationsPerHour=5` rate limits this — convergence to 10 takes ~4 hours of natural rotation.
+- Live lane: emergency-fill mode triggers (`activeCount=3 < emergencyFillThreshold=20`). Aggressive warming fill from cold candidates that are now exclusively `is_shadow=false`. Crypto and event_short candidates flow in.
+
+Within ~6 hours: pools converge to target sizes. Trade drought ends as live markets accumulate bars and signals.
+
+**Markets with open positions** that fall into the wrong lane after migration (e.g., an event_long with a position open from before the deploy): logged but not auto-closed. Position closes naturally via stop-loss, signal exit, or near-resolution gate. Identical to the existing cooling pattern.
+
+## Out of Scope
+
+Explicit non-goals for this spec:
+- **Daily auto-review consuming shadow_trades.** This spec only ensures the data stream stays alive. Adding shadow_trades summary to the auto-review report is a separate follow-up.
+- **Automatic promotion of market_types to ALLOWED.** The decision remains manual via env var change + redeploy.
+- **Per-type scorer weights for shadow.** Optuna keeps training on live trades only; shadow lane uses the same `__global__` weights it already uses for non-event_long types.
+- **Changes to `MarketScorer`.** The scoring formula is unchanged. The change is in *which subset* gets ranked.
+- **Tuning `MAX_SHADOW_MARKETS`.** Default 10, env-overridable. No optimization for now.
+- **Removing the `market_type_not_allowed → insertShadowTrade` defensive path.** Kept for safety against env/sync drift.
+
+## Error Handling
+
+- **`ALLOWED_MARKET_TYPES` env unset**: existing behavior treats this as "all types allowed" (backward-compat). Then `is_shadow` is always false; shadow lane stays empty. No drought (this is what the system did before live/shadow distinction existed).
+- **`ALLOWED_MARKET_TYPES` env malformed (empty after parse, etc.)**: fail-closed. Refuse to start. No silent fallback.
+- **Unknown `market_type`** (classifier emits a value not in any known list): default `is_shadow=true`. Routing to shadow is safer than to live.
+- **Race at startup**: the batch UPDATE in the startup hook completes before the rotator's first scheduled tick. The rotator's first run sees a consistent `is_shadow` column.
+- **Index creation failure**: `CREATE INDEX IF NOT EXISTS` is non-blocking; rotator queries work without the index but slower. Logged as warning.
+- **Position open in market that became shadow**: log `WARN`, do not close. Existing position lifecycle (stop-loss, near-resolution) handles it.
+
+## Testing
+
+- **Unit `MarketRotator`**:
+  - Existing tests pass after the `lane` parameter refactor (defaults preserved).
+  - New: `rotate('live')` ignores markets with `is_shadow=true` regardless of score.
+  - New: `rotate('shadow')` ignores `is_shadow=false` markets.
+  - New: per-lane `maxTracked` honored independently.
+- **Unit `AutoSignalExecutor`**:
+  - Signal with `isShadow=true` → calls `insertShadowTrade` exactly once, does not touch `paper_positions`, returns `{ executed: false, reason: 'shadow_lane' }`.
+  - Signal with `isShadow=false` and allowed market_type → existing live flow unchanged.
+- **Unit `GammaCollector` upsert**:
+  - Allowed market_type → row written with `is_shadow=false`.
+  - Non-allowed market_type → row written with `is_shadow=true`.
+  - Null/unknown market_type → `is_shadow=true`.
+- **Migration test**:
+  - Idempotency: running the startup hook twice produces no extra writes (UPDATE matches no rows on second run).
+  - Realignment: changing ALLOWED env and re-running the hook flips `is_shadow` correctly for affected rows.
+
+## Success Criteria (24h post-deploy)
+
+All four must hold:
+1. `SELECT COUNT(*) FROM markets WHERE is_shadow=false AND tracking_status='active' AND market_type IN ('crypto_intraday','crypto_daily','event_short','event_financial')` ≥ 5.
+2. `SELECT COUNT(*) FROM price_history WHERE market_id IN (SELECT id FROM markets WHERE market_type LIKE 'crypto_%') AND time > NOW() - INTERVAL '1 hour'` > 0.
+3. `SELECT COUNT(*) FROM shadow_trades WHERE time > NOW() - INTERVAL '24 hours'` > 0.
+4. `SELECT EXTRACT(EPOCH FROM (NOW() - MAX(opened_at)))/3600 FROM paper_positions` < 6 (most recent open within 6 hours).
+
+## Rollback Triggers
+
+If any of these occurs in the first 24h, revert:
+- VM RSS sustained > 900MB.
+- Zero trades opened in 24h post-deploy (drought persists despite the fix).
+- `shadow_trades` insertion rate falls below pre-deploy baseline (the rejection-path-derived rate).
+- Any data corruption (markets with `is_shadow=NULL`, or markets visible in both lanes simultaneously).
+
+Rollback path: revert the merge commit on main, redeploy. The schema column stays (NOT NULL DEFAULT false → no breakage). The startup hook becomes a no-op without the rest of the code referring to `is_shadow`.
+
+## Open Questions
+
+None at design time. All architectural decisions confirmed during brainstorming session 2026-04-25.

--- a/docs/plans/2026-04-25-shadow-pool-design.md
+++ b/docs/plans/2026-04-25-shadow-pool-design.md
@@ -28,100 +28,95 @@ Crypto markets compete in the live lane against event_short/event_financial — 
 
 ## Architecture
 
-**Single new column**: `markets.is_shadow BOOLEAN NOT NULL DEFAULT false`. Combined with existing `tracking_status` (cold/warming/active/cooling), defines a market's lane. A market is in exactly one lane at a time.
+**No new schema column.** Lane membership is **derived dynamically** in each `MarketRotator` query from the existing `markets.market_type` and the `ALLOWED_MARKET_TYPES` env var. The env var is the single source of truth; deriving on each rotator pass eliminates duplication, removes startup-hook races between dashboard and data-collector, and makes the rotator self-correcting when the env changes (next deploy applies the new allowlist immediately, no realignment job needed).
 
-Lane assignment is **derived** from `market_type` and `ALLOWED_MARKET_TYPES`:
-- `is_shadow = false` if `market_type ∈ ALLOWED_MARKET_TYPES`
-- `is_shadow = true` otherwise
-
-The flag is materialized (not computed per query) for performance, and recomputed on every market sync. When `ALLOWED_MARKET_TYPES` env changes, a startup hook does a batch UPDATE.
-
-**Two rotation passes per cycle**: `MarketRotator.rotate(lane)` is invoked twice — once with `lane='live'`, once with `lane='shadow'`. Same engine, same hysteresis logic, separate budgets:
+**Two rotation passes per cycle**: `MarketRotator.rotate(lane)` is invoked twice per scheduler tick — once with `lane='live'`, once with `lane='shadow'`. Same engine, same hysteresis logic, separate budgets:
 - Live: `MAX_TRACKED_MARKETS=40` (existing).
 - Shadow: `MAX_SHADOW_MARKETS=10` (new env, default 10).
 
-**Signal pipeline** unchanged in shape. SignalEngine processes both lanes uniformly. AutoSignalExecutor short-circuits shadow signals to `shadow_trades` directly, bypassing the rejection path.
+**Lane derivation** in candidate SQL:
+- Live: `AND market_type = ANY($allowed_types::text[])`
+- Shadow: `AND (market_type IS NULL OR NOT (market_type = ANY($allowed_types::text[])))`
+
+Same idea for the active/warming/cooling fetch in `rotate()` — each lane sees only its own population.
+
+**Signal pipeline unchanged.** SignalEngine processes everything currently in `tracking_status IN (warming, active, cooling)` — no awareness of lane. The lane manifests itself only at the executor: when `AutoSignalExecutor` sees a signal with `market_type ∉ ALLOWED_MARKET_TYPES` and no open position, it already inserts to `shadow_trades` and returns. That code path stays untouched. The novelty is that with shadow markets actually in the active pool (instead of starved by event_long), shadow_trades flow gets richer.
 
 ## Components
 
 ### `markets` schema
-- Add `is_shadow BOOLEAN NOT NULL DEFAULT false` via startup `ALTER TABLE IF NOT EXISTS` pattern (post-init migration, consistent with how the project applies schema changes after first volume init).
-- Partial indexes for hot rotator paths:
-  - `CREATE INDEX IF NOT EXISTS idx_markets_live_cold_candidates ON markets(market_score DESC) WHERE is_shadow=false AND tracking_status='cold' AND is_active=true AND is_resolved=false`
-  - `CREATE INDEX IF NOT EXISTS idx_markets_shadow_cold_candidates ON markets(market_score DESC) WHERE is_shadow=true AND tracking_status='cold' AND is_active=true AND is_resolved=false`
-
-### `GammaCollector` / sync-markets job
-- On upsert, compute `is_shadow = market_type NOT IN ALLOWED_LIST` and write it.
-- The `ALLOWED_LIST` is read from `ALLOWED_MARKET_TYPES` env once at process start (already the pattern in `AutoSignalExecutor`).
-
-### Startup hook (in `packages/dashboard/src/server.ts`)
-- Owned by the dashboard process because it already reads `ALLOWED_MARKET_TYPES` (via `AutoSignalExecutor`) and is responsible for other post-init ALTER TABLE migrations in the codebase.
-- Runs after schema migration (column add) and before the SignalEngine starts emitting signals or the data-collector's rotator first runs:
-  ```sql
-  UPDATE markets
-  SET is_shadow = (market_type IS NULL OR NOT (market_type = ANY($1::text[])))
-  WHERE is_resolved = false;
-  ```
-- Blocks startup until complete. Logged with row counts (rows updated, rows that flipped lanes, rows already correct).
-- Idempotent: re-running with the same allowed list is a no-op (UPDATE matches nothing because all rows already have correct `is_shadow`).
+**No change.** No new columns, no migrations, no startup hooks.
 
 ### `MarketRotator` (`packages/data-collector/src/services/MarketRotator.ts`)
-- Refactor: existing `rotate()` becomes `rotate(lane: 'live' | 'shadow'): Promise<RotationResult>`. Internal queries add `AND is_shadow = $lane_bool`.
-- New public method `rotateAll(): Promise<{ live: RotationResult; shadow: RotationResult }>` orchestrates both lanes sequentially (shared DB connection; parallelizing has no clear benefit and complicates lock contention).
-- Single `MarketRotator` instance is constructed with two `RotationConfig`s internally — one per lane. Constructor signature changes from `constructor(config?: Partial<RotationConfig>)` to `constructor(liveConfig?: Partial<RotationConfig>, shadowConfig?: Partial<RotationConfig>)`. The lane parameter selects which config applies inside `rotate()`.
-- `MIN_CANDIDATE_SCORE=0.15` shared between lanes.
-- The Scheduler entry currently calling `rotator.rotate()` becomes `rotator.rotateAll()`.
-- `DEFAULT_CONFIG` for shadow defaults: `maxTracked = parseInt(process.env.MAX_SHADOW_MARKETS || '10', 10)`. All other defaults inherited from the existing live config.
+
+Refactor in three steps:
+
+1. **Constructor takes two configs**: `constructor(liveConfig?: Partial<RotationConfig>, shadowConfig?: Partial<RotationConfig>)`. Default for shadow inherits from live but with `maxTracked = parseInt(process.env.MAX_SHADOW_MARKETS || '10', 10)`.
+
+2. **`rotate()` becomes `rotate(lane: 'live' | 'shadow')`**. The two SQL queries inside (`tracked` fetch at L199 and `candidates` fetch at L262) gain a `market_type` predicate parameterized by the allowed-types array. The instance picks the right config based on `lane`.
+
+3. **New `rotateAll(): Promise<{ live: RotationResult; shadow: RotationResult }>`**. Calls `rotate('live')` then `rotate('shadow')` sequentially using a single shared connection. Sequential because parallelizing has no clear benefit and keeps lock contention simple.
+
+The allowed-types array is read once at module load:
+```ts
+const ALLOWED_MARKET_TYPES_ARR: string[] = process.env.ALLOWED_MARKET_TYPES
+  ? process.env.ALLOWED_MARKET_TYPES.split(',').map(t => t.trim()).filter(Boolean)
+  : [];
+```
+
+If empty/unset, the live lane gets all types (backward-compat), and the shadow lane is empty.
+
+### `Scheduler` (`packages/data-collector/src/services/Scheduler.ts`)
+At `Scheduler.ts:346`, `await this.marketRotator.rotate()` becomes `await this.marketRotator.rotateAll()`. The result is logged with both lanes' counts.
+
+### `data-collector` env wiring
+The data-collector container needs `ALLOWED_MARKET_TYPES` set (currently only the dashboard container has it). Update `docker-compose.gcp.yml` to pass the same value to both services from a shared `.env` file or duplicate the entry. This is required because the lane derivation now lives inside the rotator (data-collector process).
 
 ### `ClobCollector`
-- **No code change to filter clauses.** The 5 sites filtering `tracking_status IN ('warming','active','cooling')` correctly serve both lanes — once shadow markets get promoted, they enter the snapshot/orderbook/price-update pipeline automatically.
-- Verification only: confirm logs show `Price snapshots inserted` for shadow markets after they reach warming.
+**No code change.** The five sites filtering `tracking_status IN ('warming','active','cooling')` correctly serve both lanes — once shadow markets get promoted by the new shadow rotator, they enter the snapshot/orderbook/price-update pipeline automatically. Verification only: confirm logs show `Price snapshots inserted` for shadow markets after they reach warming.
 
-### `SignalEngine` (`packages/dashboard/src/services/SignalEngine.ts`)
-- `ActiveMarket` type adds `isShadow: boolean`.
-- `setActiveMarkets()` filter unchanged — it already includes both lanes via tracking_status.
-- `SignalResult` adds `isShadow: boolean`, populated from the source `ActiveMarket`.
-- `PolymarketService.updateSignalEngine()` populates `isShadow` from the markets query.
+### `SignalEngine`
+**No code change.** Already lane-agnostic. Processes whatever is in `tracking_status IN (warming, active, cooling)`.
 
-### `AutoSignalExecutor` (`packages/dashboard/src/services/AutoSignalExecutor.ts`)
-- New first check in `processSignal()`:
-  ```ts
-  if (signal.isShadow) {
-    await this.insertShadowTrade(signal);
-    return { executed: false, reason: 'shadow_lane' };
-  }
-  ```
-- The existing `market_type_not_allowed` gate stays as defense-in-depth (handles the rare case of a live signal whose market_type isn't in ALLOWED — possible if ALLOWED env was changed without a sync). Insert path stays the same.
+### `PolymarketService.updateSignalEngine()`
+**No code change.** Already passes through `marketType` (line 495 of `PolymarketService.ts`). The executor uses it to gate.
+
+### `AutoSignalExecutor`
+**No code change.** The existing market-type gate at lines 462–481 already does exactly what shadow lane needs:
+- Signal with non-allowed `market_type` and no open position → `insertShadowTrade(signal)` + return.
+- Signal with non-allowed `market_type` and existing open position → falls through to close logic (correct: legacy positions can still close).
+- Signal with allowed `market_type` → live trade flow.
+
+Verification only: confirm shadow_trades inserts increase post-deploy.
 
 ### `shadow_trades` table and `MarketPerformanceTracker`
-- No schema change. No code change. The table receives entries via the new short-circuit path instead of the rejection path; semantically identical.
+No schema change. No code change. The table receives more entries because more non-allowed markets are now active and producing signals.
 
 ## Data Flow — Crypto Market Lifecycle
 
-1. GammaCollector inserts/updates a `crypto_intraday` market. `is_shadow=false` (it's in ALLOWED_MARKET_TYPES).
-2. ClobCollector updates `current_price_yes` (no tracking_status filter on that path; already works).
-3. Rotator live lane runs. Sees this market as a cold candidate. Crypto markets now compete only against other ALLOWED types (event_short, event_financial). Wins ranking → promoted to warming.
-4. ClobCollector's `snapshotCurrentPricesToHistory()` matches `tracking_status='warming'` filter → inserts price_history rows.
-5. After 3 bars, rotator promotes warming → active.
-6. SignalEngine generates signals. AutoExecutor sees `isShadow=false` → live trade flow.
+1. GammaCollector inserts/updates a `crypto_intraday` market (no awareness of lanes; just metadata as today).
+2. `MarketClassifier` (in dashboard) eventually sets `market_type='crypto_intraday'`.
+3. ClobCollector updates `current_price_yes` (no tracking_status filter on that path; already works).
+4. Rotator's next `rotateAll()` tick. Live lane query filters `market_type = ANY('{crypto_intraday, crypto_daily, event_short, event_financial}')`. This crypto market now competes only against allowed types. event_long no longer in the contest. Wins ranking → promoted to warming.
+5. ClobCollector's `snapshotCurrentPricesToHistory()` matches `tracking_status='warming'` filter → inserts price_history rows.
+6. After 3 bars, rotator promotes warming → active.
+7. SignalEngine generates signals. AutoExecutor sees `market_type='crypto_intraday' ∈ ALLOWED` → live trade flow.
 
-**Symmetric for an event_long market**: lands `is_shadow=true`, competes in shadow lane only, generates `shadow_trades` entries when SignalEngine emits.
+**Symmetric for an event_long market**: shadow lane query catches it, promotes to warming/active in the shadow budget. SignalEngine generates signals. AutoExecutor sees non-allowed market_type, no open position → `insertShadowTrade` + return.
 
 ## Migration Strategy (Deploy Day)
 
-Pre-deploy state: 32 markets in active+warming, ~29 of them event_long (live pool dominated by non-allowed types).
+Pre-deploy state: 32 markets in active+warming, ~29 of them event_long. The rotator currently treats them as live candidates because there's only one lane.
 
-Post-startup-hook state:
-- 29 event_long markets: `is_shadow=true, tracking_status=active`. Now in shadow lane, **already over the cap** (29 vs MAX_SHADOW_MARKETS=10).
-- 2 event_financial + 1 event_short: `is_shadow=false, tracking_status=active`. In live lane, far below cap (3 vs 40).
-
-Next rotator cycle (within 5 min of deploy):
-- Shadow lane: hysteresis-based demotions select worst-scoring event_long markets without open positions and demote them. `maxRotationsPerHour=5` rate limits this — convergence to 10 takes ~4 hours of natural rotation.
-- Live lane: emergency-fill mode triggers (`activeCount=3 < emergencyFillThreshold=20`). Aggressive warming fill from cold candidates that are now exclusively `is_shadow=false`. Crypto and event_short candidates flow in.
+Post-deploy state right after the new code starts:
+- **No data migration runs.** No batch UPDATE. The `markets` table is unchanged.
+- The first `rotateAll()` call sees the active pool through two new lenses:
+  - Live lane: 3 markets active (event_short + event_financial). Way below `MAX_TRACKED_MARKETS=40` → emergency-fill mode triggers, aggressive warming fill from cold candidates that match `market_type = ANY(allowed)`. Crypto and event_short candidates flow in.
+  - Shadow lane: 29 markets active (event_long). Way above `MAX_SHADOW_MARKETS=10` → hysteresis-based demotion of worst-scoring event_long markets without open positions, capped at `maxRotationsPerHour=5`. Convergence to 10 takes ~4–6 hours of natural rotation.
 
 Within ~6 hours: pools converge to target sizes. Trade drought ends as live markets accumulate bars and signals.
 
-**Markets with open positions** that fall into the wrong lane after migration (e.g., an event_long with a position open from before the deploy): logged but not auto-closed. Position closes naturally via stop-loss, signal exit, or near-resolution gate. Identical to the existing cooling pattern.
+**Markets with open positions**: stay in their current `tracking_status` regardless of lane. The lane gate is non-destructive — a market doesn't get force-demoted just because the lane reshuffled. Existing positions close naturally via stop-loss, signal exit, or near-resolution gate. Identical to the existing cooling pattern.
 
 ## Out of Scope
 
@@ -131,52 +126,50 @@ Explicit non-goals for this spec:
 - **Per-type scorer weights for shadow.** Optuna keeps training on live trades only; shadow lane uses the same `__global__` weights it already uses for non-event_long types.
 - **Changes to `MarketScorer`.** The scoring formula is unchanged. The change is in *which subset* gets ranked.
 - **Tuning `MAX_SHADOW_MARKETS`.** Default 10, env-overridable. No optimization for now.
-- **Removing the `market_type_not_allowed → insertShadowTrade` defensive path.** Kept for safety against env/sync drift.
+- **Changes to `AutoSignalExecutor`.** The existing market-type gate already handles shadow correctly.
 
 ## Error Handling
 
-- **`ALLOWED_MARKET_TYPES` env unset**: existing behavior treats this as "all types allowed" (backward-compat). Then `is_shadow` is always false; shadow lane stays empty. No drought (this is what the system did before live/shadow distinction existed).
-- **`ALLOWED_MARKET_TYPES` env malformed (empty after parse, etc.)**: fail-closed. Refuse to start. No silent fallback.
-- **Unknown `market_type`** (classifier emits a value not in any known list): default `is_shadow=true`. Routing to shadow is safer than to live.
-- **Race at startup**: the batch UPDATE in the startup hook completes before the rotator's first scheduled tick. The rotator's first run sees a consistent `is_shadow` column.
-- **Index creation failure**: `CREATE INDEX IF NOT EXISTS` is non-blocking; rotator queries work without the index but slower. Logged as warning.
-- **Position open in market that became shadow**: log `WARN`, do not close. Existing position lifecycle (stop-loss, near-resolution) handles it.
+- **`ALLOWED_MARKET_TYPES` env unset on data-collector**: `ALLOWED_MARKET_TYPES_ARR` is empty. The rotator interprets this as "all types allowed in live lane" (the live query becomes `market_type = ANY('{}')` which matches nothing — **this would be wrong**). Mitigation: when the array is empty, the live lane query omits the type predicate entirely (`AND TRUE`), and the shadow lane is empty. Backward-compatible with the pre-existing single-pool behavior.
+- **`ALLOWED_MARKET_TYPES` env malformed (whitespace, empty entries)**: parse with `.filter(Boolean)` and trim. If the result is empty, treat as unset (above).
+- **`ALLOWED_MARKET_TYPES` mismatch between dashboard and data-collector containers**: the rotator promotes by data-collector's view; the executor gates by dashboard's view. Drift is silently tolerated but produces nonsense (a market promoted as "live" by data-collector that the executor sees as "shadow"). Mitigation: docker-compose binds both services to the same env value (single source). Document this as an operational invariant.
+- **Unknown `market_type`** (classifier hasn't run yet, returns NULL, or returns a value not in any list): NULL falls into the shadow lane (correct: don't risk live trading on uncategorized markets). A non-NULL unknown type also falls into shadow (same reasoning).
+- **Index regression**: existing market_score indexes don't include market_type. Rotator queries are bounded by `LIMIT 50` and run on schedule (every 5 min), so missing index is acceptable. If query plan shows a problem post-deploy, add a partial index. Not part of this spec.
 
 ## Testing
 
 - **Unit `MarketRotator`**:
-  - Existing tests pass after the `lane` parameter refactor (defaults preserved).
-  - New: `rotate('live')` ignores markets with `is_shadow=true` regardless of score.
-  - New: `rotate('shadow')` ignores `is_shadow=false` markets.
-  - New: per-lane `maxTracked` honored independently.
+  - Existing tests pass after the `lane` parameter refactor (defaults preserved when called with no lane in legacy path, OR existing tests updated to pass `'live'` explicitly — pick one consistent style).
+  - New: `rotate('live')` query, when `ALLOWED_MARKET_TYPES_ARR=['crypto_intraday','event_short']`, returns only candidates matching those types. Mocked DB query asserted on parameter value.
+  - New: `rotate('shadow')` query returns only candidates whose market_type is NULL or NOT in the allowed list.
+  - New: per-lane `maxTracked` honored independently — populating live to 40 doesn't restrict shadow's 10.
+  - New: `rotateAll()` returns both results and runs them sequentially (verified by call ordering on mocked query).
 - **Unit `AutoSignalExecutor`**:
-  - Signal with `isShadow=true` → calls `insertShadowTrade` exactly once, does not touch `paper_positions`, returns `{ executed: false, reason: 'shadow_lane' }`.
-  - Signal with `isShadow=false` and allowed market_type → existing live flow unchanged.
-- **Unit `GammaCollector` upsert**:
-  - Allowed market_type → row written with `is_shadow=false`.
-  - Non-allowed market_type → row written with `is_shadow=true`.
-  - Null/unknown market_type → `is_shadow=true`.
-- **Migration test**:
-  - Idempotency: running the startup hook twice produces no extra writes (UPDATE matches no rows on second run).
-  - Realignment: changing ALLOWED env and re-running the hook flips `is_shadow` correctly for affected rows.
+  - **No new tests required.** The existing market-type gate tests already cover the behavior we want. The change in this spec is *that more shadow_trades inserts happen*, not *how* they happen. Re-run existing tests to confirm no regression.
+- **Integration (smoke, post-deploy on VM)**:
+  - SQL: `SELECT COUNT(*) FROM markets WHERE tracking_status='active' AND market_type IN (allowed_types)` ≥ 5 within 6h.
+  - SQL: `SELECT COUNT(*) FROM price_history WHERE market_id IN (crypto markets) AND time > NOW() - INTERVAL '1 hour'` > 0.
+  - SQL: `SELECT COUNT(*) FROM shadow_trades WHERE time > NOW() - INTERVAL '24 hours'` ≥ pre-deploy baseline.
+  - Logs: rotator log line includes both `live` and `shadow` results.
+- **No data migration test needed** (no schema change).
 
 ## Success Criteria (24h post-deploy)
 
 All four must hold:
-1. `SELECT COUNT(*) FROM markets WHERE is_shadow=false AND tracking_status='active' AND market_type IN ('crypto_intraday','crypto_daily','event_short','event_financial')` ≥ 5.
+1. `SELECT COUNT(*) FROM markets WHERE tracking_status='active' AND market_type IN ('crypto_intraday','crypto_daily','event_short','event_financial')` ≥ 5.
 2. `SELECT COUNT(*) FROM price_history WHERE market_id IN (SELECT id FROM markets WHERE market_type LIKE 'crypto_%') AND time > NOW() - INTERVAL '1 hour'` > 0.
 3. `SELECT COUNT(*) FROM shadow_trades WHERE time > NOW() - INTERVAL '24 hours'` > 0.
 4. `SELECT EXTRACT(EPOCH FROM (NOW() - MAX(opened_at)))/3600 FROM paper_positions` < 6 (most recent open within 6 hours).
 
 ## Rollback Triggers
 
-If any of these occurs in the first 24h, revert:
+If any of these occurs in the first 24h, revert the merge commit:
 - VM RSS sustained > 900MB.
 - Zero trades opened in 24h post-deploy (drought persists despite the fix).
-- `shadow_trades` insertion rate falls below pre-deploy baseline (the rejection-path-derived rate).
-- Any data corruption (markets with `is_shadow=NULL`, or markets visible in both lanes simultaneously).
+- `shadow_trades` insertion rate falls below pre-deploy baseline.
+- Rotator failures in logs (e.g. SQL syntax error, type mismatch on the array parameter).
 
-Rollback path: revert the merge commit on main, redeploy. The schema column stays (NOT NULL DEFAULT false → no breakage). The startup hook becomes a no-op without the rest of the code referring to `is_shadow`.
+Rollback is trivial because there's no schema change. Reverting the merge commit returns the rotator to single-pool behavior. The active pool may be temporarily stuck in whatever distribution the new code produced; one or two cycles of the original rotator restore equilibrium.
 
 ## Open Questions
 

--- a/docs/plans/2026-04-25-shadow-pool-design.md
+++ b/docs/plans/2026-04-25-shadow-pool-design.md
@@ -92,6 +92,50 @@ Verification only: confirm shadow_trades inserts increase post-deploy.
 ### `shadow_trades` table and `MarketPerformanceTracker`
 No schema change. No code change. The table receives more entries because more non-allowed markets are now active and producing signals.
 
+### Daily auto-review integration
+
+Two files updated to consume the now-richer shadow data and turn it into actionable promotion recommendations:
+
+**`scripts/daily-review.sh`** — replace the existing `shadow_summary` aggregation (lines 523–532) with a richer per-type breakdown over a 30-day window:
+```sql
+SELECT market_type,
+       COUNT(*) AS total,
+       COUNT(*) FILTER (WHERE resolved_at IS NOT NULL) AS resolved,
+       ROUND(AVG(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)::numeric, 4) AS avg_pnl,
+       ROUND(
+         (COUNT(*) FILTER (WHERE resolved_at IS NOT NULL AND theoretical_pnl > 0)::numeric
+           / NULLIF(COUNT(*) FILTER (WHERE resolved_at IS NOT NULL), 0))::numeric,
+         3
+       ) AS win_rate,
+       ROUND(STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)::numeric, 4) AS pnl_stddev,
+       ROUND(
+         CASE WHEN STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL) > 0
+           THEN AVG(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)
+                / STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)
+           ELSE 0 END::numeric,
+         3
+       ) AS sharpe
+FROM shadow_trades
+WHERE time >= NOW() - INTERVAL '30 days'
+GROUP BY market_type
+```
+
+**`scripts/daily-review-prompt.md`** — the existing "Market Type Execution Gate" section already explains the concept but never asks Claude to *act* on it. Add a new explicit instruction block:
+
+> ### Shadow → Live promotion recommendation
+>
+> Inspect `shadow_summary`. For each `market_type` that meets ALL of:
+> - `resolved >= 50` (sufficient sample size)
+> - `sharpe >= 0.20` (positive risk-adjusted edge)
+> - `win_rate >= 0.50`
+> - Not already in the live `ALLOWED_MARKET_TYPES` list (compare against the env value documented above)
+>
+> Recommend in the issue: "Consider adding `<market_type>` to `ALLOWED_MARKET_TYPES`. Shadow data over 30 days: N=X resolved, win_rate=Y, Sharpe=Z." Do NOT auto-create a PR for the env change — promotion is a manual decision tied to a deploy. The recommendation is informational.
+>
+> Conversely, if any `market_type` *currently* in `ALLOWED_MARKET_TYPES` has live data that contradicts the prior shadow signal (e.g. live Sharpe is now negative over 30 days while shadow was positive), flag it for review.
+
+The thresholds (50 trades, Sharpe 0.20, win_rate 0.50) are intentional starting points; tune by observation, not optimization. They're documented in this spec so future review changes have a baseline.
+
 ## Data Flow — Crypto Market Lifecycle
 
 1. GammaCollector inserts/updates a `crypto_intraday` market (no awareness of lanes; just metadata as today).
@@ -121,8 +165,7 @@ Within ~6 hours: pools converge to target sizes. Trade drought ends as live mark
 ## Out of Scope
 
 Explicit non-goals for this spec:
-- **Daily auto-review consuming shadow_trades.** This spec only ensures the data stream stays alive. Adding shadow_trades summary to the auto-review report is a separate follow-up.
-- **Automatic promotion of market_types to ALLOWED.** The decision remains manual via env var change + redeploy.
+- **Automatic promotion of market_types to ALLOWED.** The auto-review surfaces a recommendation (per the integration above), but the env change + redeploy stays manual.
 - **Per-type scorer weights for shadow.** Optuna keeps training on live trades only; shadow lane uses the same `__global__` weights it already uses for non-event_long types.
 - **Changes to `MarketScorer`.** The scoring formula is unchanged. The change is in *which subset* gets ranked.
 - **Tuning `MAX_SHADOW_MARKETS`.** Default 10, env-overridable. No optimization for now.
@@ -151,6 +194,7 @@ Explicit non-goals for this spec:
   - SQL: `SELECT COUNT(*) FROM price_history WHERE market_id IN (crypto markets) AND time > NOW() - INTERVAL '1 hour'` > 0.
   - SQL: `SELECT COUNT(*) FROM shadow_trades WHERE time > NOW() - INTERVAL '24 hours'` ≥ pre-deploy baseline.
   - Logs: rotator log line includes both `live` and `shadow` results.
+  - Daily auto-review run after deploy: the issue body's `shadow_summary` JSON includes the new fields (`win_rate`, `pnl_stddev`, `sharpe`) and the prompt's promotion-recommendation logic fires (or correctly stays silent if no type meets thresholds).
 - **No data migration test needed** (no schema change).
 
 ## Success Criteria (24h post-deploy)

--- a/docs/plans/2026-04-25-shadow-pool-plan.md
+++ b/docs/plans/2026-04-25-shadow-pool-plan.md
@@ -1,0 +1,1003 @@
+# Shadow Pool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the market tracking pool into a live lane (operates trades, restricted to `ALLOWED_MARKET_TYPES`) and a shadow lane (observes via `shadow_trades`, all other types), to break the closed loop trapping crypto markets in cold and end the 96h trade drought.
+
+**Architecture:** Lane membership is derived dynamically per rotator query from the existing `markets.market_type` column and the `ALLOWED_MARKET_TYPES` env var — no schema change, no startup hook, no realignment job. `MarketRotator.rotate()` becomes `rotate(lane)`; new `rotateAll()` orchestrates both lanes per scheduler tick. ClobCollector / SignalEngine / AutoSignalExecutor get zero code change because the existing market-type gate at `AutoSignalExecutor.ts:462-481` already routes non-allowed signals to `shadow_trades`. The daily auto-review report and prompt are extended to surface promotion recommendations when shadow performance crosses thresholds.
+
+**Tech Stack:** TypeScript + Node.js, Vitest, PostgreSQL/TimescaleDB, pino logging, pnpm monorepo, docker-compose. Spec: `docs/plans/2026-04-25-shadow-pool-design.md`.
+
+---
+
+## File Structure
+
+| Path | Change | Responsibility |
+|---|---|---|
+| `packages/data-collector/src/services/MarketRotator.ts` | Modify | Lane-aware rotation: parse ALLOWED env, two configs, `rotate(lane)`, `rotateAll()`. |
+| `packages/data-collector/src/services/MarketRotator.test.ts` | Modify | Cover lane filtering, config separation, `rotateAll()` orchestration. |
+| `packages/data-collector/src/services/Scheduler.ts` | Modify (single line) | Call `rotateAll()` instead of `rotate()`. |
+| `docker-compose.gcp.yml` | Modify | Add `ALLOWED_MARKET_TYPES` and `MAX_SHADOW_MARKETS` to `data-collector` container env. |
+| `scripts/daily-review.sh` | Modify | Replace `shadow_summary` aggregation with richer per-type 30-day metrics (win rate, stddev, Sharpe). |
+| `scripts/daily-review-prompt.md` | Modify | Add explicit promotion-recommendation block with thresholds. |
+
+No new files. No schema migrations. No new packages.
+
+---
+
+### Task 1: `parseAllowedMarketTypes` helper
+
+A pure function for parsing the env var. Isolating it makes the env-handling logic testable without instantiating the rotator.
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketRotator.ts`
+- Test: `packages/data-collector/src/services/MarketRotator.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `MarketRotator.test.ts`, in a new `describe` block before the existing `describe('MarketRotator', ...)`:
+
+```typescript
+import { parseAllowedMarketTypes } from './MarketRotator.js';
+
+describe('parseAllowedMarketTypes', () => {
+  it('returns empty array when env is undefined', () => {
+    expect(parseAllowedMarketTypes(undefined)).toEqual([]);
+  });
+
+  it('returns empty array when env is empty string', () => {
+    expect(parseAllowedMarketTypes('')).toEqual([]);
+  });
+
+  it('parses single value', () => {
+    expect(parseAllowedMarketTypes('crypto_intraday')).toEqual(['crypto_intraday']);
+  });
+
+  it('parses comma-separated values', () => {
+    expect(parseAllowedMarketTypes('crypto_intraday,crypto_daily,event_short')).toEqual([
+      'crypto_intraday',
+      'crypto_daily',
+      'event_short',
+    ]);
+  });
+
+  it('trims whitespace around values', () => {
+    expect(parseAllowedMarketTypes(' crypto_intraday , event_short ')).toEqual([
+      'crypto_intraday',
+      'event_short',
+    ]);
+  });
+
+  it('drops empty entries from trailing or duplicate commas', () => {
+    expect(parseAllowedMarketTypes('crypto_intraday,,event_short,')).toEqual([
+      'crypto_intraday',
+      'event_short',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd packages/data-collector && pnpm exec vitest run src/services/MarketRotator.test.ts -t 'parseAllowedMarketTypes'
+```
+
+Expected: FAIL with `Cannot find module './MarketRotator.js'` import error or `parseAllowedMarketTypes is not a function`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `MarketRotator.ts`, immediately after the existing `MIN_CANDIDATE_SCORE` export (around line 6):
+
+```typescript
+/**
+ * Parse the ALLOWED_MARKET_TYPES env value into a clean array.
+ * Empty / undefined / whitespace-only entries are dropped.
+ * An empty result means "no allowlist configured" — the live lane interprets
+ * this as unrestricted (backward-compat) and the shadow lane as empty.
+ */
+export function parseAllowedMarketTypes(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map(t => t.trim())
+    .filter(Boolean);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd packages/data-collector && pnpm exec vitest run src/services/MarketRotator.test.ts -t 'parseAllowedMarketTypes'
+```
+
+Expected: PASS, 6 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/data-collector/src/services/MarketRotator.ts packages/data-collector/src/services/MarketRotator.test.ts
+git commit -m "feat(rotator): add parseAllowedMarketTypes helper"
+```
+
+---
+
+### Task 2: Constructor takes `liveConfig` and `shadowConfig`
+
+Adds the two-config pattern without changing rotation behavior yet. Existing tests use only the first arg, so they keep passing.
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketRotator.ts`
+- Test: `packages/data-collector/src/services/MarketRotator.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the `describe('MarketRotator', ...)` block, after the existing `beforeEach`:
+
+```typescript
+describe('constructor', () => {
+  it('accepts a separate shadow config with its own maxTracked', () => {
+    const r = new MarketRotator(
+      { maxTracked: 40 },
+      { maxTracked: 7 },
+    );
+    // We assert via the public-only side: shadow rotation pulls 7 candidates max,
+    // live pulls 40. Without invoking rotate yet, just verify construction succeeds
+    // and exposes the expected shape via getter.
+    expect(r.getLiveMaxTracked()).toBe(40);
+    expect(r.getShadowMaxTracked()).toBe(7);
+  });
+
+  it('shadow config defaults maxTracked from MAX_SHADOW_MARKETS env', () => {
+    vi.stubEnv('MAX_SHADOW_MARKETS', '15');
+    const r = new MarketRotator();
+    expect(r.getShadowMaxTracked()).toBe(15);
+    vi.unstubAllEnvs();
+  });
+
+  it('shadow config defaults maxTracked to 10 when env unset', () => {
+    vi.unstubAllEnvs();
+    const r = new MarketRotator();
+    expect(r.getShadowMaxTracked()).toBe(10);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd packages/data-collector && pnpm exec vitest run src/services/MarketRotator.test.ts -t 'constructor'
+```
+
+Expected: FAIL with `r.getLiveMaxTracked is not a function`.
+
+- [ ] **Step 3: Refactor the class**
+
+In `MarketRotator.ts`, replace the existing `private config` field, constructor, and update internal references. Specifically replace lines 54–59 (`export class MarketRotator { private config ... constructor ... }`) with:
+
+```typescript
+export class MarketRotator {
+  private liveConfig: RotationConfig;
+  private shadowConfig: RotationConfig;
+  private allowedTypes: string[];
+  // The "active" config used by helper methods that read this.config.
+  // Mutated by rotate(lane) — safe because rotateAll runs lanes sequentially.
+  private config: RotationConfig;
+
+  constructor(
+    liveConfig: Partial<RotationConfig> = {},
+    shadowConfig: Partial<RotationConfig> = {},
+  ) {
+    this.liveConfig = { ...DEFAULT_CONFIG, ...liveConfig };
+    this.shadowConfig = {
+      ...DEFAULT_CONFIG,
+      maxTracked: parseInt(process.env.MAX_SHADOW_MARKETS || '10', 10),
+      ...shadowConfig,
+    };
+    this.allowedTypes = parseAllowedMarketTypes(process.env.ALLOWED_MARKET_TYPES);
+    // Default to live config so any helper called without going through rotate()
+    // (e.g. existing tests of selectDemotions/selectPromotions) keep behaving as
+    // they did pre-refactor.
+    this.config = this.liveConfig;
+  }
+
+  getLiveMaxTracked(): number {
+    return this.liveConfig.maxTracked;
+  }
+
+  getShadowMaxTracked(): number {
+    return this.shadowConfig.maxTracked;
+  }
+```
+
+(The helper methods below — `isExtremePrice`, `selectDemotions`, etc. — keep reading `this.config` unchanged.)
+
+- [ ] **Step 4: Run all rotator tests to verify the refactor is non-breaking**
+
+```bash
+cd packages/data-collector && pnpm exec vitest run src/services/MarketRotator.test.ts
+```
+
+Expected: PASS, including the 3 new constructor tests and all preexisting tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/data-collector/src/services/MarketRotator.ts packages/data-collector/src/services/MarketRotator.test.ts
+git commit -m "feat(rotator): split config into live and shadow"
+```
+
+---
+
+### Task 3: `buildLaneClause` builder (lane-derived SQL fragment)
+
+The lane filter is encoded as a SQL fragment. Isolating it as a method makes the SQL-construction logic testable without spinning up the whole rotator.
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketRotator.ts`
+- Test: `packages/data-collector/src/services/MarketRotator.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append a new `describe` inside `describe('MarketRotator', ...)`:
+
+```typescript
+describe('buildLaneClause', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('live lane with empty allowed → "TRUE" (unrestricted, no param)', () => {
+    const r = new MarketRotator();
+    const clause = r.buildLaneClause('live', 5);
+    expect(clause).toEqual({ sql: 'TRUE', param: null });
+  });
+
+  it('shadow lane with empty allowed → "FALSE" (matches nothing, no param)', () => {
+    const r = new MarketRotator();
+    const clause = r.buildLaneClause('shadow', 5);
+    expect(clause).toEqual({ sql: 'FALSE', param: null });
+  });
+
+  it('live lane with allowed types → ANY clause with param at given index', () => {
+    vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday,event_short');
+    const r = new MarketRotator();
+    const clause = r.buildLaneClause('live', 2);
+    expect(clause.sql).toBe('market_type = ANY($2::text[])');
+    expect(clause.param).toEqual(['crypto_intraday', 'event_short']);
+  });
+
+  it('shadow lane with allowed types → NOT IN clause that also catches NULL', () => {
+    vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday,event_short');
+    const r = new MarketRotator();
+    const clause = r.buildLaneClause('shadow', 3);
+    expect(clause.sql).toBe('(market_type IS NULL OR NOT (market_type = ANY($3::text[])))');
+    expect(clause.param).toEqual(['crypto_intraday', 'event_short']);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd packages/data-collector && pnpm exec vitest run src/services/MarketRotator.test.ts -t 'buildLaneClause'
+```
+
+Expected: FAIL with `r.buildLaneClause is not a function`.
+
+- [ ] **Step 3: Implement**
+
+In `MarketRotator.ts`, add this method to the `MarketRotator` class (place it after `getShadowMaxTracked`):
+
+```typescript
+/**
+ * Build the SQL fragment that restricts a query to a lane.
+ * Returns:
+ *   - { sql: 'TRUE', param: null } when the live lane has no allowlist (backward-compat unrestricted).
+ *   - { sql: 'FALSE', param: null } when the shadow lane has no non-allowed types to observe.
+ *   - { sql: 'market_type = ANY($N::text[])', param: [...] } for live with allowlist.
+ *   - { sql: '(market_type IS NULL OR NOT (...))', param: [...] } for shadow with allowlist.
+ *
+ * The returned `param` (when non-null) must be passed at position `paramIndex` in the query parameters.
+ */
+buildLaneClause(
+  lane: 'live' | 'shadow',
+  paramIndex: number,
+): { sql: string; param: string[] | null } {
+  if (this.allowedTypes.length === 0) {
+    return { sql: lane === 'live' ? 'TRUE' : 'FALSE', param: null };
+  }
+  if (lane === 'live') {
+    return {
+      sql: `market_type = ANY($${paramIndex}::text[])`,
+      param: this.allowedTypes,
+    };
+  }
+  return {
+    sql: `(market_type IS NULL OR NOT (market_type = ANY($${paramIndex}::text[])))`,
+    param: this.allowedTypes,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd packages/data-collector && pnpm exec vitest run src/services/MarketRotator.test.ts -t 'buildLaneClause'
+```
+
+Expected: PASS, 4 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/data-collector/src/services/MarketRotator.ts packages/data-collector/src/services/MarketRotator.test.ts
+git commit -m "feat(rotator): add buildLaneClause for lane-filtered SQL"
+```
+
+---
+
+### Task 4: Refactor `rotate()` to `rotate(lane)`, swap config + apply lane clause to both queries
+
+This is the core surgery. The body of `rotate()` stays largely the same; the two SQL queries (tracked at L199, candidates at L262) gain the lane clause; `this.config` is set at the top to the lane's config.
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketRotator.ts`
+- Modify: `packages/data-collector/src/services/MarketRotator.test.ts`
+
+- [ ] **Step 1: Update existing `rotate()` test callers to pass `'live'`**
+
+In `MarketRotator.test.ts`, replace the three call sites:
+- Line ~428: `const result = await rotator.rotate();` → `const result = await rotator.rotate('live');`
+- Line ~463: `await rotator.rotate();` → `await rotator.rotate('live');`
+- Line ~497: `const result = await rotator.rotate();` → `const result = await rotator.rotate('live');`
+
+- [ ] **Step 2: Write the failing tests for lane filtering**
+
+Append a new `describe` inside `describe('MarketRotator', ...)`:
+
+```typescript
+describe('rotate(lane) — lane filtering applied to SQL', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('live lane query includes lane clause and array param when ALLOWED set', async () => {
+    vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday,event_short');
+    const r = new MarketRotator();
+
+    let trackedSql: string | null = null;
+    let trackedParams: unknown[] | null = null;
+    let candidateSql: string | null = null;
+    let candidateParams: unknown[] | null = null;
+
+    mockedQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (typeof sql === 'string' && sql.includes('tracking_status IN')) {
+        trackedSql = sql;
+        trackedParams = params ?? null;
+        return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+      }
+      if (typeof sql === 'string' && sql.includes("tracking_status = 'cold'")) {
+        candidateSql = sql;
+        candidateParams = params ?? null;
+        return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+      }
+      return { rows: [], command: 'UPDATE', rowCount: 0, oid: 0, fields: [] };
+    });
+
+    await r.rotate('live');
+
+    expect(trackedSql).toMatch(/market_type = ANY\(\$\d+::text\[\]\)/);
+    expect(trackedParams).toEqual([['crypto_intraday', 'event_short']]);
+    expect(candidateSql).toMatch(/market_type = ANY\(\$\d+::text\[\]\)/);
+    expect(candidateParams).toEqual([MIN_CANDIDATE_SCORE, ['crypto_intraday', 'event_short']]);
+  });
+
+  it('shadow lane query uses NOT-IN form including NULL', async () => {
+    vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday,event_short');
+    const r = new MarketRotator();
+
+    let trackedSql: string | null = null;
+    let candidateSql: string | null = null;
+
+    mockedQuery.mockImplementation(async (sql: string) => {
+      if (typeof sql === 'string' && sql.includes('tracking_status IN')) {
+        trackedSql = sql;
+        return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+      }
+      if (typeof sql === 'string' && sql.includes("tracking_status = 'cold'")) {
+        candidateSql = sql;
+        return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+      }
+      return { rows: [], command: 'UPDATE', rowCount: 0, oid: 0, fields: [] };
+    });
+
+    await r.rotate('shadow');
+
+    expect(trackedSql).toMatch(/market_type IS NULL OR NOT \(market_type = ANY/);
+    expect(candidateSql).toMatch(/market_type IS NULL OR NOT \(market_type = ANY/);
+  });
+
+  it('with empty ALLOWED, live runs unrestricted (TRUE clause), shadow returns no candidates (FALSE clause)', async () => {
+    vi.unstubAllEnvs();
+    const r = new MarketRotator();
+
+    let trackedSqlLive: string | null = null;
+    let trackedSqlShadow: string | null = null;
+
+    mockedQuery.mockImplementation(async (sql: string) => {
+      if (typeof sql === 'string' && sql.includes('tracking_status IN')) {
+        if (trackedSqlLive === null) trackedSqlLive = sql;
+        else trackedSqlShadow = sql;
+        return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+      }
+      return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+    });
+
+    await r.rotate('live');
+    await r.rotate('shadow');
+
+    expect(trackedSqlLive).toMatch(/AND TRUE/);
+    expect(trackedSqlShadow).toMatch(/AND FALSE/);
+  });
+
+  it('uses shadow config maxTracked for emergency-fill threshold check on shadow lane', async () => {
+    vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday');
+    // Shadow config: maxTracked=10, emergencyFillThreshold default 20.
+    // With shadow active count below threshold, expect emergency mode (no demotions).
+    const r = new MarketRotator(undefined, { maxTracked: 10 });
+
+    // 5 active shadow markets — well below emergencyFillThreshold=20
+    const trackedRows = Array.from({ length: 5 }, (_, i) =>
+      makeMarket({ id: `shadow-${i}`, market_score: 0.1, tracking_status: 'active', has_open_positions: false, bars_24h: 10 })
+    );
+    const candidateRows = Array.from({ length: 20 }, (_, i) =>
+      makeMarket({ id: `cold-${i}`, market_score: 0.5 + i * 0.01, tracking_status: 'cold' })
+    );
+
+    mockedQuery.mockImplementation(async (sql: string) => {
+      if (typeof sql === 'string' && sql.includes('tracking_status IN')) {
+        return { rows: trackedRows, command: 'SELECT', rowCount: trackedRows.length, oid: 0, fields: [] };
+      }
+      if (typeof sql === 'string' && sql.includes("tracking_status = 'cold'")) {
+        return { rows: candidateRows, command: 'SELECT', rowCount: candidateRows.length, oid: 0, fields: [] };
+      }
+      return { rows: [], command: 'UPDATE', rowCount: 0, oid: 0, fields: [] };
+    });
+
+    const result = await r.rotate('shadow');
+    expect(result.demoted).toBe(0); // emergency mode skips demotions
+    expect(result.newWarming).toBeGreaterThan(0); // emergency-fill flows new warming
+  });
+});
+```
+
+- [ ] **Step 3: Run new tests to verify they fail**
+
+```bash
+cd packages/data-collector && pnpm exec vitest run src/services/MarketRotator.test.ts -t 'rotate\(lane\)'
+```
+
+Expected: FAIL — current `rotate()` takes no argument and queries don't include lane clauses.
+
+- [ ] **Step 4: Refactor `rotate` body**
+
+In `MarketRotator.ts`, change the `rotate()` signature and body. Replace lines 189–214 (the signature and the `tracked` query) with:
+
+```typescript
+async rotate(lane: 'live' | 'shadow'): Promise<RotationResult> {
+  // Switch the active config to the lane's config. Helper methods (selectDemotions,
+  // selectPromotions, selectWarmingDemotions, computeNewWarmingSlots, isEmergencyFill)
+  // read this.config; setting it here keeps them lane-aware without changing
+  // their signatures. Safe because rotateAll() invokes lanes sequentially.
+  this.config = lane === 'live' ? this.liveConfig : this.shadowConfig;
+
+  const result: RotationResult = {
+    promoted: 0,
+    demoted: 0,
+    newWarming: 0,
+    coolingExpired: 0,
+    warmingDemoted: 0,
+  };
+
+  // Step 1: Fetch tracked markets restricted to the requested lane.
+  const trackedLane = this.buildLaneClause(lane, 1);
+  const trackedParams = trackedLane.param === null ? [] : [trackedLane.param];
+  const trackedRes = await query<MarketRow>(
+    `SELECT m.id, m.market_score, m.tracking_status,
+            m.tracking_status_changed_at, m.current_price_yes,
+            EXISTS(
+              SELECT 1 FROM paper_positions pp
+              WHERE pp.market_id = m.condition_id
+                AND pp.closed_at IS NULL
+            ) as has_open_positions,
+            (
+              SELECT COUNT(*) FROM price_history ph
+              WHERE ph.token_id = m.clob_token_id_yes
+                AND ph.time > NOW() - INTERVAL '24 hours'
+            ) as bars_24h
+     FROM markets m
+     WHERE m.tracking_status IN ('warming', 'active', 'cooling')
+       AND ${trackedLane.sql}`,
+    trackedParams,
+  );
+```
+
+The rest of the method body up to the candidate query stays the same (steps 2, 2b, 3, emergency check, etc.).
+
+Then replace the candidate query block (lines 262–274 in the original) with:
+
+```typescript
+  // Step 4: Fetch cold candidates for demotion comparison and warming fill,
+  // restricted to the requested lane.
+  const candidateLane = this.buildLaneClause(lane, 2);
+  const candidateParams: unknown[] = [MIN_CANDIDATE_SCORE];
+  if (candidateLane.param !== null) candidateParams.push(candidateLane.param);
+
+  const candidateRes = await query<MarketRow>(
+    `SELECT id, market_score, tracking_status, tracking_status_changed_at,
+            current_price_yes, false as has_open_positions, 0 as bars_24h
+     FROM markets
+     WHERE tracking_status = 'cold'
+       AND is_active = true AND is_resolved = false
+       AND clob_token_id_yes IS NOT NULL
+       AND market_score >= $1
+       AND (current_price_yes IS NULL OR (current_price_yes >= 0.05 AND current_price_yes <= 0.95))
+       AND ${candidateLane.sql}
+     ORDER BY market_score DESC
+     LIMIT 50`,
+    candidateParams,
+  );
+```
+
+Update the closing log line to include the lane:
+
+```typescript
+  logger.info(
+    {
+      lane,
+      promoted: result.promoted,
+      demoted: result.demoted,
+      newWarming: result.newWarming,
+      coolingExpired: result.coolingExpired,
+      warmingDemoted: result.warmingDemoted,
+      activeCount: active.length + result.promoted - result.demoted,
+      emergency,
+    },
+    'Market rotation complete',
+  );
+```
+
+- [ ] **Step 5: Run the full rotator test suite**
+
+```bash
+cd packages/data-collector && pnpm exec vitest run src/services/MarketRotator.test.ts
+```
+
+Expected: PASS — both the 4 new lane-filtering tests and all preexisting tests (the 3 `rotate('live')` cases keep working with the legacy callers updated in Step 1).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/data-collector/src/services/MarketRotator.ts packages/data-collector/src/services/MarketRotator.test.ts
+git commit -m "feat(rotator): rotate(lane) with parameterized SQL filter"
+```
+
+---
+
+### Task 5: `rotateAll()` orchestrator
+
+Single public entry point. Calls `rotate('live')` then `rotate('shadow')` sequentially. Returns both results.
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketRotator.ts`
+- Test: `packages/data-collector/src/services/MarketRotator.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append a new `describe` inside `describe('MarketRotator', ...)`:
+
+```typescript
+describe('rotateAll', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns separate live and shadow results', async () => {
+    vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday');
+    const r = new MarketRotator();
+
+    mockedQuery.mockResolvedValue({ rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] });
+
+    const result = await r.rotateAll();
+    expect(result).toHaveProperty('live');
+    expect(result).toHaveProperty('shadow');
+    expect(result.live).toMatchObject({ promoted: expect.any(Number), demoted: expect.any(Number) });
+    expect(result.shadow).toMatchObject({ promoted: expect.any(Number), demoted: expect.any(Number) });
+  });
+
+  it('runs lanes sequentially: live first, then shadow', async () => {
+    vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday');
+    const r = new MarketRotator();
+
+    const sqlsSeen: string[] = [];
+    mockedQuery.mockImplementation(async (sql: string) => {
+      if (typeof sql === 'string' && sql.includes('tracking_status IN')) {
+        sqlsSeen.push(sql);
+      }
+      return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+    });
+
+    await r.rotateAll();
+
+    expect(sqlsSeen).toHaveLength(2);
+    // First call is live (uses ANY directly).
+    expect(sqlsSeen[0]).toMatch(/AND market_type = ANY/);
+    // Second call is shadow (uses IS NULL OR NOT).
+    expect(sqlsSeen[1]).toMatch(/AND \(market_type IS NULL OR NOT/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd packages/data-collector && pnpm exec vitest run src/services/MarketRotator.test.ts -t 'rotateAll'
+```
+
+Expected: FAIL with `r.rotateAll is not a function`.
+
+- [ ] **Step 3: Implement**
+
+In `MarketRotator.ts`, add this method to the `MarketRotator` class (after `rotate(lane)`):
+
+```typescript
+/**
+ * Run rotation for both lanes sequentially. Live lane operates on
+ * ALLOWED_MARKET_TYPES; shadow lane operates on the complement (plus NULL).
+ * Sequential because parallelism here yields no measurable benefit and would
+ * complicate lock contention on the markets table.
+ */
+async rotateAll(): Promise<{ live: RotationResult; shadow: RotationResult }> {
+  const live = await this.rotate('live');
+  const shadow = await this.rotate('shadow');
+  return { live, shadow };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd packages/data-collector && pnpm exec vitest run src/services/MarketRotator.test.ts -t 'rotateAll'
+```
+
+Expected: PASS, 2 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/data-collector/src/services/MarketRotator.ts packages/data-collector/src/services/MarketRotator.test.ts
+git commit -m "feat(rotator): add rotateAll orchestrator"
+```
+
+---
+
+### Task 6: Wire `Scheduler` to call `rotateAll()`
+
+Single-line behavior change with a slightly extended log payload.
+
+**Files:**
+- Modify: `packages/data-collector/src/services/Scheduler.ts:344-350`
+
+- [ ] **Step 1: Update the call site**
+
+In `Scheduler.ts`, replace lines 344–350:
+
+```typescript
+    // Rotate tracked markets based on scores
+    try {
+      const rotateResult = await this.marketRotator.rotate();
+      logger.info(rotateResult, 'Market rotation complete');
+    } catch (err) {
+      logger.error({ err }, 'Market rotation failed');
+    }
+```
+
+with:
+
+```typescript
+    // Rotate tracked markets based on scores — both live and shadow lanes
+    try {
+      const rotateResult = await this.marketRotator.rotateAll();
+      logger.info(rotateResult, 'Market rotation complete (both lanes)');
+    } catch (err) {
+      logger.error({ err }, 'Market rotation failed');
+    }
+```
+
+- [ ] **Step 2: Run the existing scheduler tests to confirm no regression**
+
+```bash
+cd packages/data-collector && pnpm exec vitest run src/services/Scheduler.test.ts
+```
+
+Expected: PASS. (The Scheduler tests, per the existing `Scheduler.test.ts`, do not deeply assert on rotator output — they check that `UPDATE markets` is invoked twice. The change in this task does not affect that assertion.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/data-collector/src/services/Scheduler.ts
+git commit -m "feat(scheduler): invoke rotateAll for live + shadow lanes"
+```
+
+---
+
+### Task 7: Add `ALLOWED_MARKET_TYPES` and `MAX_SHADOW_MARKETS` to data-collector container env
+
+The rotator now lives in data-collector and reads `ALLOWED_MARKET_TYPES`. Without this, both production rotators would behave as if the allowlist were empty (live unrestricted, shadow empty) — the very deadlock we're fixing.
+
+**Files:**
+- Modify: `docker-compose.gcp.yml:65-86`
+
+- [ ] **Step 1: Add the env vars**
+
+In `docker-compose.gcp.yml`, the `data-collector` service env block (around lines 69–84). After the existing `MAX_TRACKED_MARKETS: "35"` line, append:
+
+```yaml
+      ALLOWED_MARKET_TYPES: "crypto_intraday,crypto_daily,event_financial,event_short"
+      MAX_SHADOW_MARKETS: "10"
+```
+
+The result for that service's `environment:` block should now include both vars alongside the existing ones. The value of `ALLOWED_MARKET_TYPES` MUST match the dashboard's value at line 160 — they are the operational invariant from the spec.
+
+- [ ] **Step 2: Verify the YAML parses**
+
+```bash
+docker compose -f docker-compose.gcp.yml config --quiet
+```
+
+Expected: exit 0, no output. Any output means YAML/structural error — fix before proceeding.
+
+- [ ] **Step 3: Verify the values are exposed to the rendered config**
+
+```bash
+docker compose -f docker-compose.gcp.yml config | grep -E 'ALLOWED_MARKET_TYPES|MAX_SHADOW_MARKETS' | sort -u
+```
+
+Expected output (two lines, identical values for both services):
+
+```
+      ALLOWED_MARKET_TYPES: crypto_intraday,crypto_daily,event_financial,event_short
+      MAX_SHADOW_MARKETS: "10"
+```
+
+(Three matches if the dashboard already had ALLOWED_MARKET_TYPES — which it does.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docker-compose.gcp.yml
+git commit -m "chore(deploy): wire ALLOWED_MARKET_TYPES + MAX_SHADOW_MARKETS to data-collector"
+```
+
+---
+
+### Task 8: Replace `shadow_summary` SQL in `daily-review.sh`
+
+Existing query (lines 523–532) returns total/resolved/avg_pnl per market_type with no time window. Replace with a 30-day window plus win rate, stddev, and Sharpe. The new fields enable the promotion logic added in Task 9.
+
+**Files:**
+- Modify: `scripts/daily-review.sh:523-532`
+
+- [ ] **Step 1: Replace the query**
+
+In `scripts/daily-review.sh`, replace the `shadow_summary` block (currently lines 523–532) with:
+
+```bash
+shadow_summary=$(query_json "
+  SELECT COALESCE(json_agg(row_to_json(t)), '[]') FROM (
+    SELECT market_type,
+           COUNT(*) AS total,
+           COUNT(*) FILTER (WHERE resolved_at IS NOT NULL) AS resolved,
+           ROUND(AVG(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)::numeric, 4) AS avg_pnl,
+           ROUND(
+             (COUNT(*) FILTER (WHERE resolved_at IS NOT NULL AND theoretical_pnl > 0)::numeric
+               / NULLIF(COUNT(*) FILTER (WHERE resolved_at IS NOT NULL), 0))::numeric,
+             3
+           ) AS win_rate,
+           ROUND(STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)::numeric, 4) AS pnl_stddev,
+           ROUND(
+             CASE WHEN STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL) > 0
+               THEN AVG(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)
+                    / STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)
+               ELSE 0 END::numeric,
+             3
+           ) AS sharpe
+    FROM shadow_trades
+    WHERE time >= NOW() - INTERVAL '30 days'
+    GROUP BY market_type
+  ) t;
+")
+```
+
+- [ ] **Step 2: Verify the script still parses (bash syntax check)**
+
+```bash
+bash -n scripts/daily-review.sh
+```
+
+Expected: exit 0, no output.
+
+- [ ] **Step 3: Verify the SQL is valid Postgres against the actual VM database**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"SELECT COALESCE(json_agg(row_to_json(t)), '[]') FROM ( SELECT market_type, COUNT(*) AS total, COUNT(*) FILTER (WHERE resolved_at IS NOT NULL) AS resolved, ROUND(AVG(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)::numeric, 4) AS avg_pnl, ROUND((COUNT(*) FILTER (WHERE resolved_at IS NOT NULL AND theoretical_pnl > 0)::numeric / NULLIF(COUNT(*) FILTER (WHERE resolved_at IS NOT NULL), 0))::numeric, 3) AS win_rate, ROUND(STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)::numeric, 4) AS pnl_stddev, ROUND(CASE WHEN STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL) > 0 THEN AVG(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL) / STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL) ELSE 0 END::numeric, 3) AS sharpe FROM shadow_trades WHERE time >= NOW() - INTERVAL '30 days' GROUP BY market_type ) t;\""
+```
+
+Expected: a JSON array with one object per market_type that has shadow_trades rows in the last 30 days. Fields present: `market_type`, `total`, `resolved`, `avg_pnl`, `win_rate`, `pnl_stddev`, `sharpe`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/daily-review.sh
+git commit -m "feat(daily-review): richer shadow_summary with win rate and Sharpe"
+```
+
+---
+
+### Task 9: Add promotion-recommendation block to `daily-review-prompt.md`
+
+Tells Claude (the daily auto-review consumer) how to interpret the new shadow_summary fields and when to surface a promotion recommendation. Pure documentation change.
+
+**Files:**
+- Modify: `scripts/daily-review-prompt.md` — append a subsection to the existing "Market Type Execution Gate" section.
+
+- [ ] **Step 1: Append the new subsection**
+
+In `scripts/daily-review-prompt.md`, locate the existing line "**JSON sections to use:**" (around line 120) and the three bullets that follow. Right after the bullet ending with `shadow_summary: blocked signals recorded as shadow trades`, append a new blank line and the following block:
+
+```markdown
+
+### Shadow → Live promotion recommendation
+
+`shadow_summary` is now per-`market_type` over a 30-day window with fields: `total`, `resolved`, `avg_pnl`, `win_rate`, `pnl_stddev`, `sharpe`.
+
+For each `market_type` row in `shadow_summary`, evaluate against ALL of:
+
+- `resolved >= 50` (sufficient sample size to draw a conclusion)
+- `sharpe >= 0.20` (positive risk-adjusted edge)
+- `win_rate >= 0.50`
+- The market_type is NOT already in the live `ALLOWED_MARKET_TYPES` list (`crypto_intraday,crypto_daily,event_financial,event_short`)
+
+If all four hold, include a recommendation in the issue body:
+
+> **Promotion candidate:** `<market_type>`. Over 30 days of shadow data: N=<resolved> resolved, win_rate=<win_rate>, Sharpe=<sharpe>, avg_pnl=<avg_pnl>. Consider adding to `ALLOWED_MARKET_TYPES` on the next deploy.
+
+Do NOT auto-create a PR for the env change — promotion is a manual decision tied to a deploy. The recommendation is informational only.
+
+Conversely, for any `market_type` that IS currently in `ALLOWED_MARKET_TYPES` and shows live performance over the same 30 days that contradicts the prior shadow signal (e.g. live Sharpe < 0 while shadow was > 0.20), flag it under "Possible regression — review allowlist for `<market_type>`".
+
+The thresholds (50 resolved trades, Sharpe 0.20, win_rate 0.50) are starting points, not an optimized policy. Tune by observation when this recommendation has been running for ≥4 weekly reviews.
+```
+
+- [ ] **Step 2: Verify the markdown renders cleanly**
+
+```bash
+grep -n "Shadow → Live promotion recommendation" scripts/daily-review-prompt.md
+```
+
+Expected: exactly one match.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/daily-review-prompt.md
+git commit -m "feat(daily-review): promotion recommendation logic in prompt"
+```
+
+---
+
+### Task 10: Full test suite + build sanity check
+
+A single gate before deploy. Catches anything missed by the per-task tests, especially type errors that ripple across packages.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the data-collector tests in full**
+
+```bash
+cd packages/data-collector && rtk pnpm exec vitest run
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Run a typecheck on the data-collector package**
+
+```bash
+cd packages/data-collector && rtk pnpm exec tsc --noEmit
+```
+
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Run dashboard tests as a regression net (no dashboard files were modified, but Scheduler/Rotator are imported indirectly)**
+
+```bash
+cd packages/dashboard && rtk pnpm exec vitest run
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Run the dashboard typecheck**
+
+```bash
+cd packages/dashboard && rtk pnpm exec tsc --noEmit
+```
+
+Expected: no output, exit 0.
+
+- [ ] **Step 5: No commit needed** — verification only.
+
+---
+
+### Task 11: Post-deploy smoke verification (manual, on the GCP VM)
+
+Runs after CI deploys the merged branch to the VM. Confirms the four success criteria from the spec.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Wait for CI deploy to settle (~5 min after merge)**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command "docker compose -f /home/Usuario/polymarket-trader/docker-compose.gcp.yml ps"
+```
+
+Expected: data-collector and dashboard-api containers `Up` and `healthy`. Check `git log --oneline -3` on the VM matches the merged commit.
+
+- [ ] **Step 2: Verify both lanes are rotating**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command "docker compose -f /home/Usuario/polymarket-trader/docker-compose.gcp.yml logs --since 10m data-collector 2>&1 | grep 'Market rotation complete'"
+```
+
+Expected: at least one log line with the `lane:'live'` field and one with `lane:'shadow'` within the past 10 minutes.
+
+- [ ] **Step 3: Success criterion #1 — live pool composition**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"SELECT market_type, COUNT(*) FROM markets WHERE tracking_status='active' AND market_type IN ('crypto_intraday','crypto_daily','event_short','event_financial') GROUP BY market_type ORDER BY 2 DESC;\""
+```
+
+Expected (within 6 hours of deploy): total ≥ 5 across the four allowed types.
+
+- [ ] **Step 4: Success criterion #2 — crypto price_history flowing**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"SELECT COUNT(*) FROM price_history WHERE market_id IN (SELECT id FROM markets WHERE market_type LIKE 'crypto_%') AND time > NOW() - INTERVAL '1 hour';\""
+```
+
+Expected (within 6 hours of deploy): COUNT > 0.
+
+- [ ] **Step 5: Success criterion #3 — shadow_trades still flowing**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"SELECT COUNT(*) FROM shadow_trades WHERE time > NOW() - INTERVAL '24 hours';\""
+```
+
+Expected: COUNT ≥ pre-deploy 24h baseline (record the pre-deploy value before merging for comparison).
+
+- [ ] **Step 6: Success criterion #4 — trade drought ended**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"SELECT MAX(opened_at), EXTRACT(EPOCH FROM (NOW() - MAX(opened_at)))/3600 AS hours_since_last FROM paper_positions;\""
+```
+
+Expected (within 24 hours of deploy): `hours_since_last` < 6.
+
+- [ ] **Step 7: If any criterion fails by the deadline, follow the rollback path from the spec**
+
+```bash
+git revert <merge-commit-sha> --no-edit
+git push origin main
+```
+
+CI redeploys; the rotator returns to single-pool behavior. No data migration to undo.

--- a/packages/data-collector/src/services/MarketRotator.test.ts
+++ b/packages/data-collector/src/services/MarketRotator.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { query } from '../database/connection.js';
 import {
   MarketRotator,
+  MIN_CANDIDATE_SCORE,
   type RotationConfig,
   type MarketRow,
   parseAllowedMarketTypes,
@@ -522,7 +523,7 @@ describe('MarketRotator', () => {
         return updateResult;
       });
 
-      const result = await rotator.rotate();
+      const result = await rotator.rotate('live');
 
       expect(result.coolingExpired).toBeGreaterThanOrEqual(1);
       expect(result.promoted).toBeGreaterThanOrEqual(1);
@@ -557,7 +558,7 @@ describe('MarketRotator', () => {
         return { rows: [], command: 'UPDATE', rowCount: 0, oid: 0, fields: [] };
       });
 
-      await rotator.rotate();
+      await rotator.rotate('live');
 
       expect(candidateSql).not.toBeNull();
       // Must reference current_price_yes in a filter clause
@@ -591,12 +592,123 @@ describe('MarketRotator', () => {
         return updateResult;
       });
 
-      const result = await rotator.rotate();
+      const result = await rotator.rotate('live');
 
       // No demotions in emergency mode
       expect(result.demoted).toBe(0);
       // Should fill aggressively
       expect(result.newWarming).toBeGreaterThan(0);
+    });
+  });
+
+  describe('rotate(lane) — lane filtering applied to SQL', () => {
+    beforeEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('live lane query includes lane clause and array param when ALLOWED set', async () => {
+      vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday,event_short');
+      const r = new MarketRotator();
+
+      let trackedSql: string | null = null;
+      let trackedParams: unknown[] | null = null;
+      let candidateSql: string | null = null;
+      let candidateParams: unknown[] | null = null;
+
+      mockedQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+        if (typeof sql === 'string' && sql.includes('tracking_status IN')) {
+          trackedSql = sql;
+          trackedParams = params ?? null;
+          return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+        }
+        if (typeof sql === 'string' && sql.includes("tracking_status = 'cold'")) {
+          candidateSql = sql;
+          candidateParams = params ?? null;
+          return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+        }
+        return { rows: [], command: 'UPDATE', rowCount: 0, oid: 0, fields: [] };
+      });
+
+      await r.rotate('live');
+
+      expect(trackedSql).toMatch(/market_type = ANY\(\$\d+::text\[\]\)/);
+      expect(trackedParams).toEqual([['crypto_intraday', 'event_short']]);
+      expect(candidateSql).toMatch(/market_type = ANY\(\$\d+::text\[\]\)/);
+      expect(candidateParams).toEqual([MIN_CANDIDATE_SCORE, ['crypto_intraday', 'event_short']]);
+    });
+
+    it('shadow lane query uses NOT-IN form including NULL', async () => {
+      vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday,event_short');
+      const r = new MarketRotator();
+
+      let trackedSql: string | null = null;
+      let candidateSql: string | null = null;
+
+      mockedQuery.mockImplementation(async (sql: string) => {
+        if (typeof sql === 'string' && sql.includes('tracking_status IN')) {
+          trackedSql = sql;
+          return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+        }
+        if (typeof sql === 'string' && sql.includes("tracking_status = 'cold'")) {
+          candidateSql = sql;
+          return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+        }
+        return { rows: [], command: 'UPDATE', rowCount: 0, oid: 0, fields: [] };
+      });
+
+      await r.rotate('shadow');
+
+      expect(trackedSql).toMatch(/market_type IS NULL OR NOT \(market_type = ANY/);
+      expect(candidateSql).toMatch(/market_type IS NULL OR NOT \(market_type = ANY/);
+    });
+
+    it('with empty ALLOWED, live runs unrestricted (TRUE clause), shadow returns no candidates (FALSE clause)', async () => {
+      vi.unstubAllEnvs();
+      const r = new MarketRotator();
+
+      let trackedSqlLive: string | null = null;
+      let trackedSqlShadow: string | null = null;
+
+      mockedQuery.mockImplementation(async (sql: string) => {
+        if (typeof sql === 'string' && sql.includes('tracking_status IN')) {
+          if (trackedSqlLive === null) trackedSqlLive = sql;
+          else trackedSqlShadow = sql;
+          return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+        }
+        return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+      });
+
+      await r.rotate('live');
+      await r.rotate('shadow');
+
+      expect(trackedSqlLive).toMatch(/AND TRUE/);
+      expect(trackedSqlShadow).toMatch(/AND FALSE/);
+    });
+
+    it('uses shadow config maxTracked for emergency-fill threshold check on shadow lane', async () => {
+      vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday');
+      const r = new MarketRotator(undefined, { maxTracked: 10 });
+
+      const trackedRows = Array.from({ length: 5 }, (_, i) =>
+        makeMarket({ id: `shadow-${i}`, market_score: 0.1, tracking_status: 'active', has_open_positions: false, bars_24h: 10 })
+      );
+      const candidateRows = Array.from({ length: 20 }, (_, i) =>
+        makeMarket({ id: `cold-${i}`, market_score: 0.5 + i * 0.01, tracking_status: 'cold' })
+      );
+
+      mockedQuery.mockImplementation(async (sql: string) => {
+        if (typeof sql === 'string' && sql.includes('tracking_status IN')) {
+          return { rows: trackedRows, command: 'SELECT', rowCount: trackedRows.length, oid: 0, fields: [] };
+        }
+        if (typeof sql === 'string' && sql.includes("tracking_status = 'cold'")) {
+          return { rows: candidateRows, command: 'SELECT', rowCount: candidateRows.length, oid: 0, fields: [] };
+        }
+        return { rows: [], command: 'UPDATE', rowCount: 0, oid: 0, fields: [] };
+      });
+
+      const result = await r.rotate('shadow');
+      expect(result.demoted).toBe(0); // emergency mode skips demotions
+      expect(result.newWarming).toBeGreaterThan(0); // emergency-fill flows new warming
     });
   });
 });

--- a/packages/data-collector/src/services/MarketRotator.test.ts
+++ b/packages/data-collector/src/services/MarketRotator.test.ts
@@ -711,4 +711,44 @@ describe('MarketRotator', () => {
       expect(result.newWarming).toBeGreaterThan(0); // emergency-fill flows new warming
     });
   });
+
+  describe('rotateAll', () => {
+    beforeEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('returns separate live and shadow results', async () => {
+      vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday');
+      const r = new MarketRotator();
+
+      mockedQuery.mockResolvedValue({ rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] });
+
+      const result = await r.rotateAll();
+      expect(result).toHaveProperty('live');
+      expect(result).toHaveProperty('shadow');
+      expect(result.live).toMatchObject({ promoted: expect.any(Number), demoted: expect.any(Number) });
+      expect(result.shadow).toMatchObject({ promoted: expect.any(Number), demoted: expect.any(Number) });
+    });
+
+    it('runs lanes sequentially: live first, then shadow', async () => {
+      vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday');
+      const r = new MarketRotator();
+
+      const sqlsSeen: string[] = [];
+      mockedQuery.mockImplementation(async (sql: string) => {
+        if (typeof sql === 'string' && sql.includes('tracking_status IN')) {
+          sqlsSeen.push(sql);
+        }
+        return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+      });
+
+      await r.rotateAll();
+
+      expect(sqlsSeen).toHaveLength(2);
+      // First call is live (uses ANY directly).
+      expect(sqlsSeen[0]).toMatch(/AND market_type = ANY/);
+      // Second call is shadow (uses IS NULL OR NOT).
+      expect(sqlsSeen[1]).toMatch(/AND \(market_type IS NULL OR NOT/);
+    });
+  });
 });

--- a/packages/data-collector/src/services/MarketRotator.test.ts
+++ b/packages/data-collector/src/services/MarketRotator.test.ts
@@ -81,6 +81,30 @@ describe('MarketRotator', () => {
     rotator = new MarketRotator(DEFAULT_CONFIG);
   });
 
+  describe('constructor', () => {
+    it('accepts a separate shadow config with its own maxTracked', () => {
+      const r = new MarketRotator(
+        { maxTracked: 40 },
+        { maxTracked: 7 },
+      );
+      expect(r.getLiveMaxTracked()).toBe(40);
+      expect(r.getShadowMaxTracked()).toBe(7);
+    });
+
+    it('shadow config defaults maxTracked from MAX_SHADOW_MARKETS env', () => {
+      vi.stubEnv('MAX_SHADOW_MARKETS', '15');
+      const r = new MarketRotator();
+      expect(r.getShadowMaxTracked()).toBe(15);
+      vi.unstubAllEnvs();
+    });
+
+    it('shadow config defaults maxTracked to 10 when env unset', () => {
+      vi.unstubAllEnvs();
+      const r = new MarketRotator();
+      expect(r.getShadowMaxTracked()).toBe(10);
+    });
+  });
+
   // ── selectDemotions ──────────────────────────────────────────────
 
   describe('selectDemotions', () => {

--- a/packages/data-collector/src/services/MarketRotator.test.ts
+++ b/packages/data-collector/src/services/MarketRotator.test.ts
@@ -4,6 +4,7 @@ import {
   MarketRotator,
   type RotationConfig,
   type MarketRow,
+  parseAllowedMarketTypes,
 } from './MarketRotator.js';
 
 vi.mock('../database/connection.js', () => ({
@@ -11,6 +12,42 @@ vi.mock('../database/connection.js', () => ({
 }));
 
 const mockedQuery = vi.mocked(query);
+
+describe('parseAllowedMarketTypes', () => {
+  it('returns empty array when env is undefined', () => {
+    expect(parseAllowedMarketTypes(undefined)).toEqual([]);
+  });
+
+  it('returns empty array when env is empty string', () => {
+    expect(parseAllowedMarketTypes('')).toEqual([]);
+  });
+
+  it('parses single value', () => {
+    expect(parseAllowedMarketTypes('crypto_intraday')).toEqual(['crypto_intraday']);
+  });
+
+  it('parses comma-separated values', () => {
+    expect(parseAllowedMarketTypes('crypto_intraday,crypto_daily,event_short')).toEqual([
+      'crypto_intraday',
+      'crypto_daily',
+      'event_short',
+    ]);
+  });
+
+  it('trims whitespace around values', () => {
+    expect(parseAllowedMarketTypes(' crypto_intraday , event_short ')).toEqual([
+      'crypto_intraday',
+      'event_short',
+    ]);
+  });
+
+  it('drops empty entries from trailing or duplicate commas', () => {
+    expect(parseAllowedMarketTypes('crypto_intraday,,event_short,')).toEqual([
+      'crypto_intraday',
+      'event_short',
+    ]);
+  });
+});
 
 const DEFAULT_CONFIG: RotationConfig = {
   maxTracked: 40,

--- a/packages/data-collector/src/services/MarketRotator.test.ts
+++ b/packages/data-collector/src/services/MarketRotator.test.ts
@@ -446,6 +446,42 @@ describe('MarketRotator', () => {
     });
   });
 
+  // ── buildLaneClause ──────────────────────────────────────────────
+
+  describe('buildLaneClause', () => {
+    beforeEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('live lane with empty allowed → "TRUE" (unrestricted, no param)', () => {
+      const r = new MarketRotator();
+      const clause = r.buildLaneClause('live', 5);
+      expect(clause).toEqual({ sql: 'TRUE', param: null });
+    });
+
+    it('shadow lane with empty allowed → "FALSE" (matches nothing, no param)', () => {
+      const r = new MarketRotator();
+      const clause = r.buildLaneClause('shadow', 5);
+      expect(clause).toEqual({ sql: 'FALSE', param: null });
+    });
+
+    it('live lane with allowed types → ANY clause with param at given index', () => {
+      vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday,event_short');
+      const r = new MarketRotator();
+      const clause = r.buildLaneClause('live', 2);
+      expect(clause.sql).toBe('market_type = ANY($2::text[])');
+      expect(clause.param).toEqual(['crypto_intraday', 'event_short']);
+    });
+
+    it('shadow lane with allowed types → NOT IN clause that also catches NULL', () => {
+      vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday,event_short');
+      const r = new MarketRotator();
+      const clause = r.buildLaneClause('shadow', 3);
+      expect(clause.sql).toBe('(market_type IS NULL OR NOT (market_type = ANY($3::text[])))');
+      expect(clause.param).toEqual(['crypto_intraday', 'event_short']);
+    });
+  });
+
   // ── rotate (integration with DB mock) ───────────────────────────
 
   describe('rotate()', () => {

--- a/packages/data-collector/src/services/MarketRotator.ts
+++ b/packages/data-collector/src/services/MarketRotator.ts
@@ -5,6 +5,20 @@ const logger = pino({ name: 'MarketRotator' });
 
 export const MIN_CANDIDATE_SCORE = 0.15;
 
+/**
+ * Parse the ALLOWED_MARKET_TYPES env value into a clean array.
+ * Empty / undefined / whitespace-only entries are dropped.
+ * An empty result means "no allowlist configured" — the live lane interprets
+ * this as unrestricted (backward-compat) and the shadow lane as empty.
+ */
+export function parseAllowedMarketTypes(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map(t => t.trim())
+    .filter(Boolean);
+}
+
 export interface RotationConfig {
   maxTracked: number;              // 40 (from MAX_TRACKED_MARKETS env)
   maxRotationsPerHour: number;     // 5

--- a/packages/data-collector/src/services/MarketRotator.ts
+++ b/packages/data-collector/src/services/MarketRotator.ts
@@ -66,10 +66,36 @@ const DEFAULT_CONFIG: RotationConfig = {
 };
 
 export class MarketRotator {
+  private liveConfig: RotationConfig;
+  private shadowConfig: RotationConfig;
+  private allowedTypes: string[];
+  // The "active" config used by helper methods that read this.config.
+  // Mutated by rotate(lane) — safe because rotateAll runs lanes sequentially.
   private config: RotationConfig;
 
-  constructor(config: Partial<RotationConfig> = {}) {
-    this.config = { ...DEFAULT_CONFIG, ...config };
+  constructor(
+    liveConfig: Partial<RotationConfig> = {},
+    shadowConfig: Partial<RotationConfig> = {},
+  ) {
+    this.liveConfig = { ...DEFAULT_CONFIG, ...liveConfig };
+    this.shadowConfig = {
+      ...DEFAULT_CONFIG,
+      maxTracked: parseInt(process.env.MAX_SHADOW_MARKETS || '10', 10),
+      ...shadowConfig,
+    };
+    this.allowedTypes = parseAllowedMarketTypes(process.env.ALLOWED_MARKET_TYPES);
+    // Default to live config so any helper called without going through rotate()
+    // (e.g. existing tests of selectDemotions/selectPromotions) keep behaving as
+    // they did pre-refactor.
+    this.config = this.liveConfig;
+  }
+
+  getLiveMaxTracked(): number {
+    return this.liveConfig.maxTracked;
+  }
+
+  getShadowMaxTracked(): number {
+    return this.shadowConfig.maxTracked;
   }
 
   /**

--- a/packages/data-collector/src/services/MarketRotator.ts
+++ b/packages/data-collector/src/services/MarketRotator.ts
@@ -255,7 +255,13 @@ export class MarketRotator {
    * 5. Fill warming slots from top cold candidates by score
    * 6. In emergency: bypass rotation limit, fill aggressively
    */
-  async rotate(): Promise<RotationResult> {
+  async rotate(lane: 'live' | 'shadow'): Promise<RotationResult> {
+    // Switch the active config to the lane's config. Helper methods (selectDemotions,
+    // selectPromotions, selectWarmingDemotions, computeNewWarmingSlots, isEmergencyFill)
+    // read this.config; setting it here keeps them lane-aware without changing
+    // their signatures. Safe because rotateAll() invokes lanes sequentially.
+    this.config = lane === 'live' ? this.liveConfig : this.shadowConfig;
+
     const result: RotationResult = {
       promoted: 0,
       demoted: 0,
@@ -264,7 +270,9 @@ export class MarketRotator {
       warmingDemoted: 0,
     };
 
-    // Step 1: Fetch tracked markets
+    // Step 1: Fetch tracked markets restricted to the requested lane.
+    const trackedLane = this.buildLaneClause(lane, 1);
+    const trackedParams = trackedLane.param === null ? [] : [trackedLane.param];
     const trackedRes = await query<MarketRow>(
       `SELECT m.id, m.market_score, m.tracking_status,
               m.tracking_status_changed_at, m.current_price_yes,
@@ -279,7 +287,9 @@ export class MarketRotator {
                   AND ph.time > NOW() - INTERVAL '24 hours'
               ) as bars_24h
        FROM markets m
-       WHERE m.tracking_status IN ('warming', 'active', 'cooling')`
+       WHERE m.tracking_status IN ('warming', 'active', 'cooling')
+         AND ${trackedLane.sql}`,
+      trackedParams,
     );
 
     const tracked = trackedRes.rows.map(r => ({
@@ -322,12 +332,17 @@ export class MarketRotator {
       result.promoted++;
     }
 
-    // Step 4: Fetch cold candidates for demotion comparison and warming fill.
+    // Step 4: Fetch cold candidates for demotion comparison and warming fill,
+    // restricted to the requested lane.
     // Extreme-price markets (Yes <5% or >95%) are excluded at the source:
     // MarketScorer can give them scores of 0.8+ via volume/liquidity alone, and
     // without this filter they dominate the top of the candidate ranking and
     // starve tradeable markets from all warming slots. Null price is treated as
     // non-extreme (safe default, consistent with isExtremePrice in demotion).
+    const candidateLane = this.buildLaneClause(lane, 2);
+    const candidateParams: unknown[] = [MIN_CANDIDATE_SCORE];
+    if (candidateLane.param !== null) candidateParams.push(candidateLane.param);
+
     const candidateRes = await query<MarketRow>(
       `SELECT id, market_score, tracking_status, tracking_status_changed_at,
               current_price_yes, false as has_open_positions, 0 as bars_24h
@@ -337,9 +352,10 @@ export class MarketRotator {
          AND clob_token_id_yes IS NOT NULL
          AND market_score >= $1
          AND (current_price_yes IS NULL OR (current_price_yes >= 0.05 AND current_price_yes <= 0.95))
+         AND ${candidateLane.sql}
        ORDER BY market_score DESC
        LIMIT 50`,
-      [MIN_CANDIDATE_SCORE]
+      candidateParams,
     );
 
     const candidates = candidateRes.rows.map(r => ({
@@ -381,6 +397,7 @@ export class MarketRotator {
 
     logger.info(
       {
+        lane,
         promoted: result.promoted,
         demoted: result.demoted,
         newWarming: result.newWarming,
@@ -389,7 +406,7 @@ export class MarketRotator {
         activeCount: active.length + result.promoted - result.demoted,
         emergency,
       },
-      'Market rotation complete'
+      'Market rotation complete',
     );
 
     return result;

--- a/packages/data-collector/src/services/MarketRotator.ts
+++ b/packages/data-collector/src/services/MarketRotator.ts
@@ -412,6 +412,18 @@ export class MarketRotator {
     return result;
   }
 
+  /**
+   * Run rotation for both lanes sequentially. Live lane operates on
+   * ALLOWED_MARKET_TYPES; shadow lane operates on the complement (plus NULL).
+   * Sequential because parallelism here yields no measurable benefit and would
+   * complicate lock contention on the markets table.
+   */
+  async rotateAll(): Promise<{ live: RotationResult; shadow: RotationResult }> {
+    const live = await this.rotate('live');
+    const shadow = await this.rotate('shadow');
+    return { live, shadow };
+  }
+
   private async updateStatus(marketId: string, status: string): Promise<void> {
     await query(
       `UPDATE markets SET tracking_status = $1, tracking_status_changed_at = NOW() WHERE id = $2`,

--- a/packages/data-collector/src/services/MarketRotator.ts
+++ b/packages/data-collector/src/services/MarketRotator.ts
@@ -99,6 +99,35 @@ export class MarketRotator {
   }
 
   /**
+   * Build the SQL fragment that restricts a query to a lane.
+   * Returns:
+   *   - { sql: 'TRUE', param: null } when the live lane has no allowlist (backward-compat unrestricted).
+   *   - { sql: 'FALSE', param: null } when the shadow lane has no non-allowed types to observe.
+   *   - { sql: 'market_type = ANY($N::text[])', param: [...] } for live with allowlist.
+   *   - { sql: '(market_type IS NULL OR NOT (...))', param: [...] } for shadow with allowlist.
+   *
+   * The returned `param` (when non-null) must be passed at position `paramIndex` in the query parameters.
+   */
+  buildLaneClause(
+    lane: 'live' | 'shadow',
+    paramIndex: number,
+  ): { sql: string; param: string[] | null } {
+    if (this.allowedTypes.length === 0) {
+      return { sql: lane === 'live' ? 'TRUE' : 'FALSE', param: null };
+    }
+    if (lane === 'live') {
+      return {
+        sql: `market_type = ANY($${paramIndex}::text[])`,
+        param: this.allowedTypes,
+      };
+    }
+    return {
+      sql: `(market_type IS NULL OR NOT (market_type = ANY($${paramIndex}::text[])))`,
+      param: this.allowedTypes,
+    };
+  }
+
+  /**
    * Returns true if a market's current price is in the extreme range
    * (near-resolved markets with Yes price <5% or >95%).
    * These markets are untradeable and should not occupy active slots.

--- a/packages/data-collector/src/services/Scheduler.ts
+++ b/packages/data-collector/src/services/Scheduler.ts
@@ -341,10 +341,10 @@ export class Scheduler {
       logger.error({ err }, 'Market scoring failed');
     }
 
-    // Rotate tracked markets based on scores
+    // Rotate tracked markets based on scores — both live and shadow lanes
     try {
-      const rotateResult = await this.marketRotator.rotate();
-      logger.info(rotateResult, 'Market rotation complete');
+      const rotateResult = await this.marketRotator.rotateAll();
+      logger.info(rotateResult, 'Market rotation complete (both lanes)');
     } catch (err) {
       logger.error({ err }, 'Market rotation failed');
     }

--- a/scripts/daily-review-prompt.md
+++ b/scripts/daily-review-prompt.md
@@ -104,17 +104,17 @@ There have been 12 resets (Mar-Apr 2026), mostly from price inversion bugs and a
 - **Hardcoded values**: Config that should read from env vars but has hardcoded numbers
 - **Formula asymmetry**: One service calculates a metric differently from another (e.g., peak uses equity but drawdown uses capital)
 
-## Market Type Execution Gate (deployed 2026-04-12)
+## Market Type Execution Gate (deployed 2026-04-12, two-lane rotator 2026-04-26)
 
-The system trades only crypto markets in live mode. Other market types (event_short, event_long, unclassified) have signals generated and combined, but the executor blocks the open and records a `shadow_trade` instead. Closes are never blocked.
+The executor restricts live trades to `ALLOWED_MARKET_TYPES`. Other market types have signals generated and combined, but the executor blocks the open and records a `shadow_trade` instead. Closes are never blocked. As of 2026-04-26 the data-collector's `MarketRotator` runs two lanes per tick: live (only allowed types compete for live slots) and shadow (only non-allowed types fill a small observation pool, default `MAX_SHADOW_MARKETS=10`).
 
-- **Config:** `ALLOWED_MARKET_TYPES=crypto_intraday,crypto_daily` env var on dashboard-api
+- **Config:** `ALLOWED_MARKET_TYPES=crypto_intraday,crypto_daily,event_financial,event_short` env var on dashboard-api AND data-collector (must match — operational invariant)
 - **Rejection log:** `[AutoExecutor] REJECTED ... : market_type_not_allowed (<type>)`
-- **Tables affected:** `shadow_trades` (new) — INSERT on every blocked open
+- **Tables affected:** `shadow_trades` — INSERT on every blocked open
 
 **Implications for analysis:**
-- **Closes** on event_short/event_long markets are EXPECTED behavior — they are legacy positions opened before the gate, unwinding. Do NOT flag as a bug or as the gate misbehaving.
-- **0 new opens on non-crypto markets** is the desired state. If `trades_by_type` shows opens on blocked types AFTER the deploy, the gate is broken — investigate which code path bypassed it.
+- **Closes** on non-allowed types are EXPECTED behavior — they are legacy positions opened before the gate, unwinding. Do NOT flag as a bug or as the gate misbehaving.
+- **0 new opens on non-allowed types** is the desired state. If `trades_by_type` shows opens on a market_type NOT in the allowlist above AFTER the deploy, the gate is broken — investigate which code path bypassed it.
 - **Shadow trades** in `shadow_summary` show what the system would have traded. They accumulate over time and resolve when the underlying market resolves. Used for offline evaluation of when blocked types might be worth enabling.
 
 **JSON sections to use:**

--- a/scripts/daily-review-prompt.md
+++ b/scripts/daily-review-prompt.md
@@ -122,6 +122,27 @@ The system trades only crypto markets in live mode. Other market types (event_sh
 - `category_performance`: cumulative win_rate / Sharpe / prior per market_type
 - `shadow_summary`: blocked signals recorded as shadow trades
 
+### Shadow → Live promotion recommendation
+
+`shadow_summary` is now per-`market_type` over a 30-day window with fields: `total`, `resolved`, `avg_pnl`, `win_rate`, `pnl_stddev`, `sharpe`.
+
+For each `market_type` row in `shadow_summary`, evaluate against ALL of:
+
+- `resolved >= 50` (sufficient sample size to draw a conclusion)
+- `sharpe >= 0.20` (positive risk-adjusted edge)
+- `win_rate >= 0.50`
+- The market_type is NOT already in the live `ALLOWED_MARKET_TYPES` list (`crypto_intraday,crypto_daily,event_financial,event_short`)
+
+If all four hold, include a recommendation in the issue body:
+
+> **Promotion candidate:** `<market_type>`. Over 30 days of shadow data: N=<resolved> resolved, win_rate=<win_rate>, Sharpe=<sharpe>, avg_pnl=<avg_pnl>. Consider adding to `ALLOWED_MARKET_TYPES` on the next deploy.
+
+Do NOT auto-create a PR for the env change — promotion is a manual decision tied to a deploy. The recommendation is informational only.
+
+Conversely, for any `market_type` that IS currently in `ALLOWED_MARKET_TYPES` and shows live performance over the same 30 days that contradicts the prior shadow signal (e.g. live Sharpe < 0 while shadow was > 0.20), flag it under "Possible regression — review allowlist for `<market_type>`".
+
+The thresholds (50 resolved trades, Sharpe 0.20, win_rate 0.50) are starting points, not an optimized policy. Tune by observation when this recommendation has been running for ≥4 weekly reviews.
+
 ## Step 0: Check Existing Work
 
 Before creating any issues or PRs, check what already exists:

--- a/scripts/daily-review.sh
+++ b/scripts/daily-review.sh
@@ -525,8 +525,22 @@ shadow_summary=$(query_json "
     SELECT market_type,
            COUNT(*) AS total,
            COUNT(*) FILTER (WHERE resolved_at IS NOT NULL) AS resolved,
-           ROUND(AVG(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)::numeric, 2) AS avg_pnl
+           ROUND(AVG(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)::numeric, 4) AS avg_pnl,
+           ROUND(
+             (COUNT(*) FILTER (WHERE resolved_at IS NOT NULL AND theoretical_pnl > 0)::numeric
+               / NULLIF(COUNT(*) FILTER (WHERE resolved_at IS NOT NULL), 0))::numeric,
+             3
+           ) AS win_rate,
+           ROUND(STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)::numeric, 4) AS pnl_stddev,
+           ROUND(
+             CASE WHEN STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL) > 0
+               THEN AVG(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)
+                    / STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)
+               ELSE 0 END::numeric,
+             3
+           ) AS sharpe
     FROM shadow_trades
+    WHERE time >= NOW() - INTERVAL '30 days'
     GROUP BY market_type
   ) t;
 ")


### PR DESCRIPTION
## Summary

Splits the market tracking pool into two parallel lanes to break the closed loop trapping crypto markets in cold:

- **Live lane** (`MAX_TRACKED_MARKETS=40`): only `ALLOWED_MARKET_TYPES` (`crypto_intraday,crypto_daily,event_financial,event_short`). Operates trades.
- **Shadow lane** (`MAX_SHADOW_MARKETS=10`): only NON-allowed types (event_long today, future types). Observes via `shadow_trades` for promotion decisions.

Lane membership is **derived dynamically** in each `MarketRotator` query from `ALLOWED_MARKET_TYPES` env — no schema change, no startup hook, no realignment job. The env var is the single source of truth.

Resolves issues #131 and #132 (96h+ trade drought from event_long crowding the live ranking).

## Why the existing setup deadlocks

The pool today: 31 event_long / 1 event_short / 1 event_financial / 0 crypto. 91% of slots get rejected by the executor. ALLOWED_MARKET_TYPES already excludes event_long since 2026-04-12, but the rotator ranks all types together by `market_score DESC` and event_long always wins. After this PR, the live rotator considers only allowed types — crypto and event_short candidates flow naturally.

## Architecture

| Component | Change |
|---|---|
| `MarketRotator.ts` | New `parseAllowedMarketTypes`, `buildLaneClause`, dual `liveConfig`+`shadowConfig`, `rotate(lane)`, `rotateAll()` |
| `Scheduler.ts:346` | One-line: `rotate()` → `rotateAll()` |
| `docker-compose.gcp.yml` | `ALLOWED_MARKET_TYPES` and `MAX_SHADOW_MARKETS=10` added to data-collector container (matches dashboard-api) |
| `ClobCollector.ts` | **Zero change** — its existing `tracking_status IN (warming/active/cooling)` filter naturally serves both lanes once shadow markets get promoted |
| `SignalEngine.ts` | **Zero change** — lane-agnostic |
| `AutoSignalExecutor.ts` | **Zero change** — existing market-type gate at L462-481 already inserts `shadow_trade` for non-allowed signals without open positions |
| `scripts/daily-review.sh` | `shadow_summary` SQL enriched with `win_rate`, `pnl_stddev`, `sharpe` over 30-day window |
| `scripts/daily-review-prompt.md` | New "Shadow → Live promotion recommendation" block (resolved≥50, sharpe≥0.20, win_rate≥0.50). Stale `ALLOWED_MARKET_TYPES` value at line 111 also corrected |

## Backward compat

When `ALLOWED_MARKET_TYPES` is unset/empty: live lane uses `AND TRUE` (unrestricted, original behavior); shadow lane uses `AND FALSE` (empty). No-op for environments that don't enable the gate.

## Test plan

- [x] `pnpm exec vitest run packages/data-collector/src` → 232/232 PASS
- [x] `pnpm exec vitest run packages/dashboard/src` → 222 PASS + 14 skipped
- [x] `pnpm exec tsc -p packages/data-collector/tsconfig.json --noEmit` → clean
- [x] `pnpm exec tsc -p packages/dashboard/tsconfig.json --noEmit` → clean
- [x] `docker compose -f docker-compose.gcp.yml config --quiet` → valid
- [x] Final code review: 1 blocker fixed (stale ALLOWED_MARKET_TYPES doc value), all other findings non-blocking

## Post-merge verification (24h)

After CI deploys to VM, confirm via SQL on the VM:
- [ ] `SELECT COUNT(*) FROM markets WHERE tracking_status='active' AND market_type IN ('crypto_intraday','crypto_daily','event_short','event_financial')` ≥ 5
- [ ] `SELECT COUNT(*) FROM price_history WHERE market_id IN (SELECT id FROM markets WHERE market_type LIKE 'crypto_%') AND time > NOW() - INTERVAL '1 hour'` > 0
- [ ] `SELECT COUNT(*) FROM shadow_trades WHERE time > NOW() - INTERVAL '24 hours'` ≥ pre-deploy baseline
- [ ] `SELECT EXTRACT(EPOCH FROM (NOW() - MAX(opened_at)))/3600 FROM paper_positions` < 6 (drought ends)

Spec: `docs/plans/2026-04-25-shadow-pool-design.md`. Plan: `docs/plans/2026-04-25-shadow-pool-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Introduced shadow trading lanes: observe non-approved market types before enabling them for live trading
  * Market type allowlisting controls which types can execute live trades
  * Enhanced daily review metrics for shadow trades including win rate, Sharpe ratio, and volatility analysis

* **Documentation**
  * Added design and implementation plans for shadow pool strategy

* **Tests**
  * Added comprehensive test coverage for lane-aware market rotation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->