### PR TITLE
fix: CodeRabbit follow-up — scope legacy reads + filter per-type sync

### DIFF
--- a/packages/dashboard/src/api/routes.ts
+++ b/packages/dashboard/src/api/routes.ts
@@ -1823,7 +1823,9 @@ export async function registerRoutes(
              VALUES ($1, $2, $3, true, 0.6, NOW())
              ON CONFLICT (signal_type, market_type) DO UPDATE SET
                weight = EXCLUDED.weight,
-               updated_at = NOW()`,
+               is_enabled = EXCLUDED.is_enabled,
+               min_confidence = EXCLUDED.min_confidence,
+               updated_at = EXCLUDED.updated_at`,
             [signalType, '__global__', weight]
           );
         }

--- a/packages/dashboard/src/database/repositories.ts
+++ b/packages/dashboard/src/database/repositories.ts
@@ -149,14 +149,14 @@ export interface SignalWeight {
 export const signalWeightsRepo = {
   async getAll(): Promise<SignalWeight[]> {
     const result = await query<SignalWeight>(
-      'SELECT * FROM signal_weights ORDER BY signal_type'
+      `SELECT * FROM signal_weights WHERE market_type = '__global__' ORDER BY signal_type`
     );
     return result.rows;
   },
 
   async get(signalType: string): Promise<SignalWeight | null> {
     const result = await query<SignalWeight>(
-      'SELECT * FROM signal_weights WHERE signal_type = $1',
+      `SELECT * FROM signal_weights WHERE signal_type = $1 AND market_type = '__global__'`,
       [signalType]
     );
     return result.rows[0] ?? null;
@@ -194,14 +194,14 @@ export const signalWeightsRepo = {
   },
 
   /**
-   * Get all per-type weights, grouped by market_type. Excludes '__global__' rows.
-   * Returns { market_type → { signal_type → weight } }.
+   * Get all per-type weights, grouped by market_type. Excludes '__global__' rows
+   * and disabled rows (is_enabled = false). Returns { market_type → { signal_type → weight } }.
    */
   async getAllPerType(): Promise<Record<string, Record<string, number>>> {
     const result = await query<{ signal_type: string; market_type: string; weight: number }>(
       `SELECT signal_type, market_type, weight
        FROM signal_weights
-       WHERE market_type != '__global__'`
+       WHERE market_type != '__global__' AND is_enabled = true`
     );
     const map: Record<string, Record<string, number>> = {};
     for (const row of result.rows) {

--- a/packages/dashboard/src/services/SignalEngine.ts
+++ b/packages/dashboard/src/services/SignalEngine.ts
@@ -316,11 +316,23 @@ export class SignalEngine extends EventEmitter {
 
       // Sync per-type weights from DB. Fills combiner.typeWeights, which is the
       // authoritative source for runtime weight lookup on known market types.
+      // getAllPerType already drops is_enabled = false rows; we still drop
+      // signal types without an active generator instance to mirror the global
+      // sync (line 290 above).
       try {
         const perTypeWeights = await signalWeightsRepo.getAllPerType();
-        this.combiner.setTypeWeights(perTypeWeights);
+        const filtered: Record<string, Record<string, number>> = {};
+        for (const [marketType, generators] of Object.entries(perTypeWeights)) {
+          for (const [signalType, weight] of Object.entries(generators)) {
+            if (this.signals.has(signalType)) {
+              if (!filtered[marketType]) filtered[marketType] = {};
+              filtered[marketType][signalType] = weight;
+            }
+          }
+        }
+        this.combiner.setTypeWeights(filtered);
         console.log(
-          `[SignalEngine] Synced typeWeights from database: ${Object.keys(perTypeWeights).length} types`
+          `[SignalEngine] Synced typeWeights from database: ${Object.keys(filtered).length} types`
         );
       } catch (err) {
         console.error('[SignalEngine] Failed to sync per-type weights:', err);


### PR DESCRIPTION
## Summary

Bundles 3 high-impact CodeRabbit findings from PR #140 that survived the schema migration. Defers 5 lower-priority findings to separate issues (see below).

### Fixed in this PR

1. **`signalWeightsRepo.getAll()` / `.get()` not scoped to `__global__`** — after the compound PK change, these legacy readers returned mixed rows across types. Impact: `AutoSignalExecutor` (sizing used a random per-type weight), `SignalEngine.syncWeightsFromDatabase` global path (last-row-wins overwrite of weightMap), `/api/signals/weights` endpoint (returned 67 rows instead of 12), `SignalLearningService`. Fix: both methods now filter `WHERE market_type = '__global__'`.

2. **`PUT /api/signals/weights` ON CONFLICT only reset `weight + updated_at`** — leaves stale `is_enabled = false` / raised `min_confidence` after a manual update. Violates the project's documented rule (CLAUDE.md: \"ON CONFLICT upserts must reset all relevant fields\"). Fix: also reset `is_enabled` and `min_confidence` from EXCLUDED.

3. **SignalEngine per-type sync didn't filter `is_enabled` / `this.signals.has(...)`** — global sync filters both, per-type forwarded everything. Disabled or unknown signal rows could land in `combiner.typeWeights` and drive runtime weights. Fix: `getAllPerType()` now filters `is_enabled = true` at the DB level; SignalEngine drops unknown signal types at the runtime level (mirrors global sync line 290).

### Deferred (separate follow-up issues recommended)

- **#4 BacktestService.createSignals only generates 3 of 11 generators** — predates this PR; backtests treat 8 weights as no-ops, so Optuna can't meaningfully tune them. Needs new signal generators or pruning the param space.
- **#6 `bestSharpePerType` lost on restart** — `__legacy__` fallback resets per-type ratchet on every dashboard restart; OOS gate is the real guard but still allows marginal regressions. Needs persistent per-type rehydration from `optimization_runs`.
- **#7 `updateStrategy` redeploys shared strategy 5× per cycle, last-in wins** — per-type weight writes are correct, but the global threshold deploy (minEdge/minConfidence + executor config) gets clobbered by whichever type processes last. Needs decoupling weight write from threshold deploy.
- **#8 `runGridOptimization` ignores `marketType`** — only fires when Optuna offline (rare on production), so low priority.
- **#1 docs backticks** — cosmetic.

## Test plan

- [x] `pnpm tsc --noEmit` — 0 errors.
- [x] `pnpm vitest run packages/dashboard/src/services packages/dashboard/src/database` — 222/222 pass (14 skipped baseline).
- [ ] Post-deploy: confirm `AutoSignalExecutor` sizing uses the correct global weight (no longer random) and `/api/signals/weights` returns 12 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)