### PR TITLE
fix(optimizer): per-type OOS minTrades floor (closes #147)

### DIFF
--- a/packages/dashboard/src/services/OptimizationScheduler.test.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.test.ts
@@ -38,7 +38,7 @@ vi.mock('../utils/vmHealth.js', () => ({
 }));
 
 import { signalWeightsRepo } from '../database/repositories.js';
-import { OptimizationScheduler } from './OptimizationScheduler.js';
+import { OptimizationScheduler, getOosMinTrades, OOS_MIN_TRADES_PER_TYPE } from './OptimizationScheduler.js';
 
 describe('OptimizationScheduler', () => {
   beforeEach(() => {
@@ -96,5 +96,56 @@ describe('OptimizationScheduler', () => {
       -1.0,
       expect.stringMatching(/^optimization-\d{4}-\d{2}-\d{2}$/),
     );
+  });
+});
+
+describe('getOosMinTrades', () => {
+  const ENV_KEYS = [
+    'OPTIMIZER_MIN_TRADES_CRYPTO_INTRADAY',
+    'OPTIMIZER_MIN_TRADES_CRYPTO_DAILY',
+    'OPTIMIZER_MIN_TRADES_EVENT_FINANCIAL',
+    'OPTIMIZER_MIN_TRADES_EVENT_SHORT',
+    'OPTIMIZER_MIN_TRADES_EVENT_LONG',
+    'OPTIMIZER_MIN_TRADES_UNKNOWN_TYPE',
+  ];
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  it('event_long floor is 5 (was 20 — was rejecting positive IS Sharpe with 7 trades)', () => {
+    expect(getOosMinTrades('event_long')).toBe(5);
+  });
+
+  it('crypto_intraday floor is 30 (high-frequency, 4-day OOS expected to deliver more)', () => {
+    expect(getOosMinTrades('crypto_intraday')).toBe(30);
+  });
+
+  it('all 5 known market types have a per-type floor', () => {
+    expect(Object.keys(OOS_MIN_TRADES_PER_TYPE).sort()).toEqual([
+      'crypto_daily',
+      'crypto_intraday',
+      'event_financial',
+      'event_long',
+      'event_short',
+    ]);
+  });
+
+  it('unknown market_type falls back to legacy default 20', () => {
+    expect(getOosMinTrades('unknown_type')).toBe(20);
+  });
+
+  it('OPTIMIZER_MIN_TRADES_<TYPE> env var overrides the per-type default', () => {
+    process.env.OPTIMIZER_MIN_TRADES_EVENT_LONG = '8';
+    expect(getOosMinTrades('event_long')).toBe(8);
+  });
+
+  it('ignores invalid env values (non-numeric, zero, negative)', () => {
+    process.env.OPTIMIZER_MIN_TRADES_EVENT_LONG = 'abc';
+    expect(getOosMinTrades('event_long')).toBe(5);
+    process.env.OPTIMIZER_MIN_TRADES_EVENT_LONG = '0';
+    expect(getOosMinTrades('event_long')).toBe(5);
+    process.env.OPTIMIZER_MIN_TRADES_EVENT_LONG = '-3';
+    expect(getOosMinTrades('event_long')).toBe(5);
   });
 });

--- a/packages/dashboard/src/services/OptimizationScheduler.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.ts
@@ -110,7 +110,8 @@ const OOS_SAFETY_FLOOR = {
   minSharpe: -1.0,
   /** Maximum OOS drawdown — reject catastrophic */
   maxDrawdown: 0.50,
-  /** Minimum trades in OOS for statistical signal */
+  /** Legacy default minimum trades for unknown market types. Per-type values
+   *  in OOS_MIN_TRADES_PER_TYPE override this. */
   minTrades: 20,
   /** Minimum distinct markets evaluated — prevents apply on tiny universes
    *  where local maxima are statistically meaningless. Triggered by the
@@ -118,6 +119,33 @@ const OOS_SAFETY_FLOOR = {
    *  direction_multiplier=+1.0208 (causing 13.5% drawdown). */
   minMarkets: parseInt(process.env.OPTIMIZER_MIN_MARKETS_FOR_APPLY || '8', 10),
 };
+
+/** Per-market-type OOS minimum-trade floors. Reflect realistic trade counts
+ *  per OOS window (4 days) given each type's holding-time distribution.
+ *  Empirically: event_long observed 7 trades / 4d window (rejected by the old
+ *  uniform floor of 20 even with positive IS Sharpe 0.113); event_financial
+ *  observed 34 trades / 4d window. See issue #147 — proper fix is adaptive
+ *  thresholds derived from per-type historical trade-count distributions. */
+export const OOS_MIN_TRADES_PER_TYPE: Record<string, number> = {
+  crypto_intraday: 30,
+  crypto_daily: 20,
+  event_financial: 15,
+  event_short: 10,
+  event_long: 5,
+};
+
+/** Resolves the OOS min-trade floor for a given market_type, honoring the
+ *  OPTIMIZER_MIN_TRADES_<TYPE> env override. Falls back to OOS_SAFETY_FLOOR.minTrades
+ *  for unknown types. Invalid env values (non-numeric, ≤ 0) are ignored. */
+export function getOosMinTrades(marketType: string): number {
+  const envKey = `OPTIMIZER_MIN_TRADES_${marketType.toUpperCase()}`;
+  const envVal = process.env[envKey];
+  if (envVal !== undefined) {
+    const parsed = parseInt(envVal, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return OOS_MIN_TRADES_PER_TYPE[marketType] ?? OOS_SAFETY_FLOOR.minTrades;
+}
 
 const MARKET_TYPES = ['crypto_intraday', 'crypto_daily', 'event_financial', 'event_short', 'event_long'] as const;
 type MarketType = typeof MARKET_TYPES[number];
@@ -700,8 +728,9 @@ export class OptimizationScheduler {
       if (marketsEvaluated < OOS_SAFETY_FLOOR.minMarkets) {
         return { passed: false, sharpeOOS: oosScore, drawdownOOS: metrics.maxDrawdown, tradesOOS: trades, winRateOOS: metrics.winRate, marketsEvaluated, reason: `Markets ${marketsEvaluated} < ${OOS_SAFETY_FLOOR.minMarkets} (universe too small to apply)` };
       }
-      if (trades < OOS_SAFETY_FLOOR.minTrades) {
-        return { passed: false, sharpeOOS: oosScore, drawdownOOS: metrics.maxDrawdown, tradesOOS: trades, winRateOOS: metrics.winRate, marketsEvaluated, reason: `Trades ${trades} < ${OOS_SAFETY_FLOOR.minTrades}` };
+      const minTradesForType = getOosMinTrades(marketType);
+      if (trades < minTradesForType) {
+        return { passed: false, sharpeOOS: oosScore, drawdownOOS: metrics.maxDrawdown, tradesOOS: trades, winRateOOS: metrics.winRate, marketsEvaluated, reason: `Trades ${trades} < ${minTradesForType} (${marketType} min)` };
       }
       if (oosScore < OOS_SAFETY_FLOOR.minSharpe) {
         return { passed: false, sharpeOOS: oosScore, drawdownOOS: metrics.maxDrawdown, tradesOOS: trades, winRateOOS: metrics.winRate, marketsEvaluated, reason: `OOS Sharpe ${oosScore.toFixed(3)} < ${OOS_SAFETY_FLOOR.minSharpe}` };


### PR DESCRIPTION
## Summary

Closes #147. Replaces the uniform OOS minTrades floor of 20 with per-type values, honoring `OPTIMIZER_MIN_TRADES_<TYPE>` env overrides.

## Why

Today's per-type cycle (post-#140) caught the regression: `event_long` produced a **positive IS Sharpe of 0.113** but was blocked by the OOS gate because it only generated 7 trades over the 4-day window. event_long markets have multi-day holding times, so 7 trades is normal there. The uniform floor was calibrated for the global universe pre-per-type and doesn't fit anymore.

## Floors picked

| market_type | new floor | rationale |
|---|---|---|
| crypto_intraday | 30 | high-frequency, ample 4d window |
| crypto_daily | 20 | legacy default — moderate frequency |
| event_financial | 15 | empirical 34 trades observed, leaves headroom |
| event_short | 10 | moderate |
| event_long | **5** | empirical 7 trades — was blocked at 20 |

Each is overridable via `OPTIMIZER_MIN_TRADES_<TYPE>` env (mirrors `OPTIMIZER_MIN_MARKETS_FOR_APPLY`). Unknown types fall back to the legacy 20.

## Pragmatic vs principled

This is the pragmatic patch. The principled fix — adaptive thresholds derived from per-type historical trade-count distributions — needs schema changes and is tracked as the long-term direction in #147.

## Test plan

- [x] `pnpm vitest run packages/dashboard/src/services/OptimizationScheduler.test.ts` — 8/8 pass (6 new tests for the helper + 2 preexisting).
- [x] `pnpm tsc --noEmit` — 0 errors.
- [ ] Post-deploy: next per-type cycle for `event_long` (within 6h) should pass the OOS gate if it produces ≥5 trades and Sharpe survives the decay-adjusted threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Out-of-sample validation now applies market-type-specific minimum trade thresholds instead of a uniform global requirement
  * Environment variables can override per-type minimums for custom configurations
  * Error messages now include the specific market type and threshold that triggered validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->