### PR TITLE
fix(optimizer): persist bestSharpePerType across restarts (closes #144)

### DIFF
--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -429,6 +429,21 @@ async function main(): Promise<void> {
       `);
       console.log('signal_weights.consensus_discount_floor row ensured');
 
+      // Issue #144: persist per-type bestSharpe ratchet across restarts.
+      // Without this column, loadState rebuilds bestSharpePerType as
+      // { __legacy__: <last_overall_score> } and every real market_type
+      // falls back to 0 on the next cycle. Mirror init/026_*.sql.
+      try {
+        await query(`
+          ALTER TABLE optimization_service_state
+            ADD COLUMN IF NOT EXISTS best_sharpe_per_type JSONB NOT NULL DEFAULT '{}'::jsonb;
+        `);
+        console.log('[server] optimization_service_state.best_sharpe_per_type column ensured');
+      } catch (err) {
+        console.error('[server] best_sharpe_per_type migration failed:', err);
+        throw err;
+      }
+
       // Check for blocking autovacuum every 15 minutes
       setInterval(async () => {
         try {

--- a/packages/dashboard/src/services/OptimizationScheduler.test.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.test.ts
@@ -38,6 +38,7 @@ vi.mock('../utils/vmHealth.js', () => ({
 }));
 
 import { signalWeightsRepo } from '../database/repositories.js';
+import { query } from '../database/index.js';
 import { OptimizationScheduler, getOosMinTrades, OOS_MIN_TRADES_PER_TYPE } from './OptimizationScheduler.js';
 
 describe('OptimizationScheduler', () => {
@@ -147,5 +148,74 @@ describe('getOosMinTrades', () => {
     expect(getOosMinTrades('event_long')).toBe(5);
     process.env.OPTIMIZER_MIN_TRADES_EVENT_LONG = '-3';
     expect(getOosMinTrades('event_long')).toBe(5);
+  });
+});
+
+describe('bestSharpePerType persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(query).mockResolvedValue({ rows: [] } as any);
+  });
+
+  it('saveState writes bestSharpePerType as JSONB to optimization_service_state', async () => {
+    const scheduler = new OptimizationScheduler();
+    (scheduler as any).state.bestSharpePerType = {
+      event_financial: 0.42,
+      event_long: 0.11,
+    };
+
+    await (scheduler as any).saveState();
+
+    const stateUpsertCall = vi.mocked(query).mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('optimization_service_state'),
+    );
+    expect(stateUpsertCall).toBeDefined();
+    const params = stateUpsertCall?.[1] as unknown[];
+    // Last param is the JSON payload — assert it carries the per-type map.
+    const jsonParam = params.find(
+      (p) => typeof p === 'string' && p.includes('event_financial'),
+    );
+    expect(jsonParam).toBe(JSON.stringify({ event_financial: 0.42, event_long: 0.11 }));
+  });
+
+  it('loadState restores bestSharpePerType from optimization_service_state row', async () => {
+    const persisted = { event_financial: 0.55, event_short: 0.18 };
+    vi.mocked(query).mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM optimization_runs')) {
+        return { rows: [{ best_params: { foo: 1 }, best_score: 0.99, completed_at: new Date('2026-04-28') }] } as any;
+      }
+      if (sql.includes('FROM optimization_service_state')) {
+        return {
+          rows: [{
+            last_incremental_run_at: null,
+            last_full_run_at: null,
+            best_sharpe_per_type: persisted,
+          }],
+        } as any;
+      }
+      return { rows: [] } as any;
+    });
+
+    const scheduler = new OptimizationScheduler();
+    await (scheduler as any).loadState();
+
+    expect((scheduler as any).state.bestSharpePerType).toEqual(persisted);
+  });
+
+  it('loadState falls back to { __legacy__: best_score } when persisted column is absent or empty', async () => {
+    vi.mocked(query).mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM optimization_runs')) {
+        return { rows: [{ best_params: { foo: 1 }, best_score: 0.42, completed_at: new Date() }] } as any;
+      }
+      if (sql.includes('FROM optimization_service_state')) {
+        return { rows: [{ last_incremental_run_at: null, last_full_run_at: null, best_sharpe_per_type: {} }] } as any;
+      }
+      return { rows: [] } as any;
+    });
+
+    const scheduler = new OptimizationScheduler();
+    await (scheduler as any).loadState();
+
+    expect((scheduler as any).state.bestSharpePerType).toEqual({ __legacy__: 0.42 });
   });
 });

--- a/packages/dashboard/src/services/OptimizationScheduler.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.ts
@@ -1042,8 +1042,12 @@ export class OptimizationScheduler {
         }
       }
 
-      const stateResult = await query<{ last_incremental_run_at: Date | null; last_full_run_at: Date | null }>(`
-        SELECT last_incremental_run_at, last_full_run_at
+      const stateResult = await query<{
+        last_incremental_run_at: Date | null;
+        last_full_run_at: Date | null;
+        best_sharpe_per_type: Record<string, number> | null;
+      }>(`
+        SELECT last_incremental_run_at, last_full_run_at, best_sharpe_per_type
         FROM optimization_service_state
         WHERE id = 'main'
       `);
@@ -1052,6 +1056,11 @@ export class OptimizationScheduler {
         const state = stateResult.rows[0];
         this.state.lastIncrementalAt = state.last_incremental_run_at;
         this.state.lastFullAt = state.last_full_run_at || this.state.lastFullAt;
+        // Restore per-type ratchet if populated; otherwise keep the legacy
+        // fallback assigned above. Empty {} is treated as "not yet populated".
+        if (state.best_sharpe_per_type && Object.keys(state.best_sharpe_per_type).length > 0) {
+          this.state.bestSharpePerType = state.best_sharpe_per_type;
+        }
       }
 
       console.log('[OptimizationScheduler] Loaded state:', {
@@ -1070,17 +1079,19 @@ export class OptimizationScheduler {
 
     try {
       await query(`
-        INSERT INTO optimization_service_state (id, is_running, last_incremental_run_at, last_full_run_at, updated_at)
-        VALUES ('main', $1, $2, $3, NOW())
+        INSERT INTO optimization_service_state (id, is_running, last_incremental_run_at, last_full_run_at, best_sharpe_per_type, updated_at)
+        VALUES ('main', $1, $2, $3, $4::jsonb, NOW())
         ON CONFLICT (id) DO UPDATE SET
-          is_running = $1,
-          last_incremental_run_at = $2,
-          last_full_run_at = $3,
-          updated_at = NOW()
+          is_running = EXCLUDED.is_running,
+          last_incremental_run_at = EXCLUDED.last_incremental_run_at,
+          last_full_run_at = EXCLUDED.last_full_run_at,
+          best_sharpe_per_type = EXCLUDED.best_sharpe_per_type,
+          updated_at = EXCLUDED.updated_at
       `, [
         this.state.isRunning,
         this.state.lastIncrementalAt,
         this.state.lastFullAt,
+        JSON.stringify(this.state.bestSharpePerType),
       ]);
     } catch (error) {
       console.error('[OptimizationScheduler] Failed to save state:', error);

--- a/packages/data-collector/src/database/init/026_optimization_state_per_type_ratchet.sql
+++ b/packages/data-collector/src/database/init/026_optimization_state_per_type_ratchet.sql
@@ -1,0 +1,10 @@
+-- 026_optimization_state_per_type_ratchet.sql
+-- Persists per-market-type best Sharpe across restarts so the optimizer's
+-- per-type ratchet (introduced in PR #140) survives dashboard restarts.
+-- Without this column, loadState() rebuilds bestSharpePerType as
+-- { __legacy__: <last_overall_best_score> }, leaving every real market_type
+-- at fallback 0 — the next cycle can then apply a marginal candidate
+-- without comparing against the actual prior per-type high. See issue #144.
+
+ALTER TABLE optimization_service_state
+  ADD COLUMN IF NOT EXISTS best_sharpe_per_type JSONB NOT NULL DEFAULT '{}'::jsonb;


### PR DESCRIPTION
## Summary

Closes #144. Adds a `best_sharpe_per_type JSONB` column to `optimization_service_state` and threads it through `saveState`/`loadState` so the per-type ratchet introduced in PR #140 survives dashboard restarts.

## Why

PR #140 made the ratchet check `priorBest = state.bestSharpePerType[marketType] ?? 0`. After every restart, `loadState` rebuilt `bestSharpePerType` as `{ __legacy__: <last overall best_score> }` — every real market_type fell back to `0`, so the next cycle applied any non-negative Sharpe candidate, regardless of whether it was actually better than the previously-deployed per-type weights.

Restarts happen on every CI deploy, OOM kill, or manual restart — easily daily. The OOS gate is the coarse filter; the ratchet was meant to be the fine filter that's now load-bearing across restarts.

## Implementation

- **Schema**: new column `best_sharpe_per_type JSONB NOT NULL DEFAULT '{}'::jsonb`. Migration delivered both as `init/026_optimization_state_per_type_ratchet.sql` (fresh deploys) and as a post-init hook in `server.ts` (existing VM volume), mirroring the per-type signal_weights pattern from PR #140.
- **`saveState`**: writes `JSON.stringify(bestSharpePerType)` on every UPSERT. Switched to `EXCLUDED.<col>` form for clarity.
- **`loadState`**: reads the new column; if non-empty, restores it; if empty (default state on first deploy), keeps the legacy `{ __legacy__: best_score }` fallback so the bootstrap behavior is unchanged for the very first cycle after migration.

## Test plan

- [x] `pnpm vitest run packages/dashboard/src/services/OptimizationScheduler.test.ts` — 11/11 pass (3 new tests: round-trip JSON write, ratchet restore from persisted row, legacy fallback when column empty).
- [x] `pnpm tsc --noEmit` — 0 errors.
- [ ] Post-deploy: verify VM applied the migration via `\d optimization_service_state` and confirm next per-type cycle's `saveState` populates the column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)