### PR TITLE
fix(optimizer): runGridOptimization filters by marketType (closes #146)

### DIFF
--- a/packages/dashboard/src/services/OptimizationScheduler.test.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.test.ts
@@ -219,3 +219,58 @@ describe('bestSharpePerType persistence', () => {
     expect((scheduler as any).state.bestSharpePerType).toEqual({ __legacy__: 0.42 });
   });
 });
+
+describe('runGridOptimization marketType filter (#146)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(query).mockResolvedValue({ rows: [] } as any);
+  });
+
+  it('preloads filtered data once per cycle via fetchHistoricalData(start, end, undefined, marketType)', async () => {
+    const scheduler = new OptimizationScheduler();
+    const filteredData = [{ marketId: 'm1' }, { marketId: 'm2' }] as any[];
+    const fetchSpy = vi.fn().mockResolvedValue(filteredData);
+    const runBacktestSpy = vi.fn().mockResolvedValue({
+      result: {
+        metrics: { sharpeRatio: 0.3, totalReturn: 0.05, maxDrawdown: 0.1 },
+        trades: [],
+      },
+    });
+    (scheduler as any).backtestService = {
+      fetchHistoricalData: fetchSpy,
+      runBacktest: runBacktestSpy,
+    };
+    (scheduler as any).backtestDelayMs = 0;
+
+    await (scheduler as any).runGridOptimization(2, 'incremental', 'event_long');
+
+    // Preloaded once with marketType='event_long'
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const args = fetchSpy.mock.calls[0];
+    expect(args[2]).toBeUndefined();          // marketIds
+    expect(args[3]).toBe('event_long');       // marketType
+  });
+
+  it('passes preloaded filtered data to runBacktest as second argument', async () => {
+    const scheduler = new OptimizationScheduler();
+    const filteredData = [{ marketId: 'm1' }] as any[];
+    const fetchSpy = vi.fn().mockResolvedValue(filteredData);
+    const runBacktestSpy = vi.fn().mockResolvedValue({
+      result: {
+        metrics: { sharpeRatio: 0.2, totalReturn: 0.04, maxDrawdown: 0.1 },
+        trades: [],
+      },
+    });
+    (scheduler as any).backtestService = {
+      fetchHistoricalData: fetchSpy,
+      runBacktest: runBacktestSpy,
+    };
+    (scheduler as any).backtestDelayMs = 0;
+
+    await (scheduler as any).runGridOptimization(1, 'incremental', 'crypto_daily');
+
+    expect(runBacktestSpy).toHaveBeenCalled();
+    const [, preloadedArg] = runBacktestSpy.mock.calls[0];
+    expect(preloadedArg).toBe(filteredData);
+  });
+});

--- a/packages/dashboard/src/services/OptimizationScheduler.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.ts
@@ -594,7 +594,14 @@ export class OptimizationScheduler {
 
     const shuffled = paramCombos.sort(() => Math.random() - 0.5).slice(0, iterations);
 
-    console.log(`[OptimizationScheduler] Running ${shuffled.length} grid-search backtests...`);
+    console.log(`[OptimizationScheduler] Running ${shuffled.length} grid-search backtests for ${marketType}...`);
+
+    // Preload filtered training data once per cycle (mirrors the Optuna path).
+    // Without this filter the grid path would backtest the full universe and
+    // write the result into a per-type row, producing meaningless per-type
+    // weights when Optuna is offline. See issue #146.
+    const preloadedData: MarketData[] = await this.backtestService.fetchHistoricalData(startDate, endDate, undefined, marketType);
+    console.log(`[OptimizationScheduler] Preloaded ${preloadedData.length} markets for ${marketType}`);
 
     for (let i = 0; i < shuffled.length; i++) {
       const params = shuffled[i];
@@ -616,7 +623,7 @@ export class OptimizationScheduler {
             minStrength: params.minEdge,
             minConfidence: params.minConfidence,
           },
-        });
+        }, preloadedData);
 
         if (backtest.result && backtest.result.metrics) {
           const result = {


### PR DESCRIPTION
## Summary

Closes #146. `runGridOptimization` now preloads training data filtered by `marketType` and passes the preloaded data to every `runBacktest` call, mirroring what the Optuna path already does (introduced in PR #140).

## Why

When `OPTIMIZER_URL` is unset (Optuna offline / Render server down), the optimizer falls back to grid search. Pre-fix, the grid path accepted the new `marketType` parameter (added in PR #140) but never used it. Every per-type loop iteration backtested the full universe and wrote the result into a per-type row — silently producing meaningless per-type weights.

Production impact today is low (the VM has `OPTIMIZER_URL` set and Optuna is healthy), but the bug becomes load-bearing the moment Optuna goes down.

## Side benefit

The grid path previously made the BacktestService re-fetch data for every iteration (N backtests × N DB fetches). With preload, a single fetch per cycle is reused — same pattern as the Optuna path.

## Test plan

- [x] `pnpm vitest run packages/dashboard/src/services/OptimizationScheduler.test.ts` — 13/13 pass (2 new tests: fetchHistoricalData receives marketType; runBacktest receives preloaded data).
- [x] `pnpm tsc --noEmit` — 0 errors.
- [ ] Post-deploy: not directly observable while Optuna is up. If Optuna goes down, `[OptimizationScheduler] Preloaded N markets for <marketType>` should appear in dashboard-api logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)