### PR TITLE
fix(optimizer): once-per-cycle global threshold deploy (closes #145)

### DIFF
--- a/docs/plans/2026-04-29-update-strategy-global-thresholds-design.md
+++ b/docs/plans/2026-04-29-update-strategy-global-thresholds-design.md
@@ -1,0 +1,123 @@
+# Update strategy — extract global threshold deploy from per-type loop (closes #145)
+
+**Status**: Spec, awaiting user review.
+**Branch**: `fix/update-strategy-global-thresholds`.
+
+## Goal
+
+Decouple the global-threshold deploy from the per-type weight-write inside `updateStrategy`. Today both happen in the same method called once per market_type in the per-type loop, so the executor's runtime `minEdge` / `minConfidence` are clobbered by whichever type processes last and passes OOS — order-dependent and fragile. The fix selects the highest-Sharpe winner across the cycle and deploys global thresholds exactly once.
+
+Spec context: `docs/plans/2026-04-28-per-type-optimizer-design.md` introduced the per-type loop. CodeRabbit caught this gap as an "outside-diff" finding; it was deferred as issue #145.
+
+## Empirical justification
+
+Today's first per-type cycle (2026-04-29 02:04 UTC):
+- crypto_intraday/crypto_daily: skipped (no data)
+- event_financial: applied (Sharpe 0.07) ✓
+- event_short: rejected (IS Sharpe ≤ 0)
+- event_long: rejected (trades < 20)
+
+Only event_financial's `updateStrategy` ran, so its thresholds drove the executor by accident. After PR #150 lowered the OOS `minTrades` floor for event_long to 5, multiple types may now pass in the same cycle. With the current code, the loop order (`crypto_intraday → crypto_daily → event_financial → event_short → event_long`) determines which type's thresholds win — last-passing type clobbers earlier ones. Not a current-day problem (only event_financial passes), but load-bearing the moment it changes.
+
+## Design
+
+### Split `updateStrategy(result, marketType)` into two phases
+
+**Phase A — per-type writes (stays in the per-type loop)**
+
+These operations are either explicitly per-type or idempotent. Keep them inside `updateStrategy`:
+
+1. Sanity checks (sharpe > 8, trades < 5, totalReturn < −0.1).
+2. OOS gate (`_lastOOSResult.passed`).
+3. `state.bestSharpePerType[marketType] = result.sharpe`.
+4. `optimization_runs UPDATE WHERE status='running'` (idempotent — first call updates, subsequent calls find no rows).
+5. `direction_multiplier` enforcement to −1.0 (idempotent — same value every call).
+6. Per-type weight writes via `signalWeightsRepo.updatePerType(...)` (the `WEIGHT_PARAM_MAP` loop).
+
+`updateStrategy` returns `{ wasApplied: boolean }`. `wasApplied = true` iff phase A ran to completion (i.e., OOS passed + sanity checks passed).
+
+**Phase B — global threshold deploy (new method, runs ONCE after the loop)**
+
+New `applyGlobalThresholds(result, marketType)`:
+
+1. Extract `minEdge` and `minConfidence` from `result.params`.
+2. Stop currently-running strategies via `${dashboardApiUrl}/api/strategies` API.
+3. Create new combo strategy with the new thresholds.
+4. Update `tradingAutomation.executor.config` runtime.
+
+The `marketType` argument is informational only (logged for traceability — "deployed global thresholds from event_financial winner").
+
+### Caller refactor in `runIncrementalOptimization` and `runFullOptimization`
+
+```typescript
+const winners: Array<{ marketType: string; result: OptimizationResult }> = [];
+
+for (const marketType of MARKET_TYPES) {
+  // ... existing loop body that runs Optuna, OOS, calls updateStrategy ...
+  const { wasApplied } = await this.updateStrategy(best, marketType);
+  if (wasApplied) {
+    winners.push({ marketType, result: best });
+  }
+}
+
+// Apply global thresholds ONCE per cycle, with the winner type
+if (winners.length > 0) {
+  const globalWinner = winners.reduce((a, b) =>
+    a.result.sharpe > b.result.sharpe ? a : b,
+  );
+  console.log(
+    `[OptimizationScheduler] Cycle winner: ${globalWinner.marketType} (Sharpe ${globalWinner.result.sharpe.toFixed(3)}, ${winners.length} types qualified)`,
+  );
+  await this.applyGlobalThresholds(globalWinner.result, globalWinner.marketType);
+}
+```
+
+Identical pattern for `runFullOptimization`.
+
+### Why this is the right line for the split
+
+| Operation | Per-type or global? | Why |
+|---|---|---|
+| Per-type weights | Per-type | Different value per type by design — stays in loop |
+| `bestSharpePerType[marketType]` | Per-type | Indexed by type — stays in loop |
+| `direction_multiplier=-1.0` | Idempotent | Same value every call → no clobber. Keep in updateStrategy for simplicity. |
+| `optimization_runs UPDATE` | Idempotent | First call clears `status=running` → subsequent are no-ops. Keep in updateStrategy. |
+| `minEdge`/`minConfidence` extraction | Type-specific values | Different per type → MUST move to global, MUST pick a winner |
+| Stop/start combo strategy | Global state mutation | One executor — last-writer-wins → MUST be once-per-cycle |
+| Executor `updateConfig` | Global state mutation | Same — once-per-cycle |
+
+## Tests
+
+`packages/dashboard/src/services/OptimizationScheduler.test.ts`:
+
+1. **Single qualifying type**: mock loop with one type passing OOS → assert `applyGlobalThresholds` invoked exactly once with that type's result.
+2. **Multiple qualifying types**: mock 2-3 types passing with different Sharpes → assert `applyGlobalThresholds` invoked exactly ONCE with the highest-Sharpe winner.
+3. **No qualifying types**: all types fail OOS → assert `applyGlobalThresholds` is NOT invoked.
+4. **Direction multiplier still enforced per-type call**: existing test `'always enforces direction_multiplier to -1.0 after a successful optimization'` continues to pass without modification (it calls `updateStrategy` directly, which still does the enforcement).
+5. **Per-type weights still written**: per-type loop still calls `signalWeightsRepo.updatePerType` for each generator (existing behaviour).
+
+## Acceptance criteria
+
+(a) Tests above all pass; `pnpm tsc -p packages/dashboard/tsconfig.json --noEmit` clean.
+
+(b) Post-deploy log evidence: dashboard-api logs include `[OptimizationScheduler] Cycle winner: <market_type> (Sharpe ...)` after each per-type cycle that has at least one qualifying type. With current data only event_financial qualifies, so the log fires with that type. After PR #150 lowered the minTrades floor for event_long, event_long may also start passing — at which point the log line confirms the deterministic winner selection.
+
+## Out of scope
+
+- Per-type minEdge/minConfidence (i.e., the executor reads thresholds keyed by `signal.marketType`). That is the architecturally correct fix; it requires a separate executor refactor and is documented in the issue body as the alternative path. Not in this PR.
+- Tie-breaking when two types have identical Sharpe — JavaScript `reduce` keeps the first encountered. Documented in code comment but not test-asserted (vanishingly unlikely in practice).
+
+## Files touched
+
+| Path | Change |
+|---|---|
+| `packages/dashboard/src/services/OptimizationScheduler.ts` | Modify `updateStrategy` to return `{ wasApplied }` and remove global-threshold block. Add new `applyGlobalThresholds` method. Modify `runIncrementalOptimization` and `runFullOptimization` to track winners and call `applyGlobalThresholds` once. |
+| `packages/dashboard/src/services/OptimizationScheduler.test.ts` | Add 3 tests for winner selection and global deploy behaviour. |
+
+No DB migrations, no env vars, no schema changes.
+
+## Risks
+
+- **Breaking change to `updateStrategy` return type**: existing callers (only the loop in this file) need to read `{ wasApplied }`. The existing test that calls `updateStrategy` directly with a single arg ignores the return value, so it remains compatible.
+- **`applyGlobalThresholds` uses `dashboardApiUrl`**: the strategy stop/start API roundtrip can fail. Existing code already wraps it in try/catch — preserved verbatim.
+- **`getTradingAutomation().getExecutor().updateConfig` is a runtime mutation**: after this PR it fires once per cycle instead of up to 5 times. If the executor cached values per-type (it doesn't), behaviour would change. Verified: executor stores a single `{ minStrength, minConfidence }` config — last-writer-wins is preserved, just deterministic now.

--- a/packages/dashboard/src/services/OptimizationScheduler.test.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.test.ts
@@ -274,3 +274,101 @@ describe('runGridOptimization marketType filter (#146)', () => {
     expect(preloadedArg).toBe(filteredData);
   });
 });
+
+describe('applyGlobalThresholds — once per cycle, max-Sharpe winner (#145)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(query).mockResolvedValue({ rows: [] } as any);
+  });
+
+  it('updateStrategy returns wasApplied=true when OOS passes', async () => {
+    const scheduler = new OptimizationScheduler();
+    (scheduler as any)._lastOOSResult = {
+      passed: true,
+      sharpeOOS: 0.5,
+      drawdownOOS: 0.1,
+      tradesOOS: 30,
+      winRateOOS: 0.5,
+      marketsEvaluated: 10,
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: vi.fn() }));
+
+    const result = await (scheduler as any).updateStrategy(
+      { params: {}, sharpe: 0.5, totalReturn: 0.05, trades: 30 },
+      'event_financial',
+    );
+
+    expect(result.wasApplied).toBe(true);
+  });
+
+  it('updateStrategy returns wasApplied=false when OOS fails', async () => {
+    const scheduler = new OptimizationScheduler();
+    (scheduler as any)._lastOOSResult = {
+      passed: false,
+      sharpeOOS: 0,
+      drawdownOOS: 0,
+      tradesOOS: 0,
+      winRateOOS: 0,
+      marketsEvaluated: 0,
+      reason: 'low Sharpe',
+    };
+
+    const result = await (scheduler as any).updateStrategy(
+      { params: {}, sharpe: 0.5, totalReturn: 0.05, trades: 30 },
+      'event_financial',
+    );
+
+    expect(result.wasApplied).toBe(false);
+  });
+
+  it('updateStrategy returns wasApplied=false when totalReturn < -0.1', async () => {
+    const scheduler = new OptimizationScheduler();
+    (scheduler as any)._lastOOSResult = { passed: true };
+
+    const result = await (scheduler as any).updateStrategy(
+      { params: {}, sharpe: 0.5, totalReturn: -0.5, trades: 30 },
+      'event_financial',
+    );
+
+    expect(result.wasApplied).toBe(false);
+  });
+
+  it('updateStrategy no longer touches global executor config or strategy API', async () => {
+    const scheduler = new OptimizationScheduler();
+    (scheduler as any)._lastOOSResult = {
+      passed: true,
+      sharpeOOS: 0.5,
+      drawdownOOS: 0.1,
+      tradesOOS: 30,
+      winRateOOS: 0.5,
+      marketsEvaluated: 10,
+    };
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: false, json: vi.fn() });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await (scheduler as any).updateStrategy(
+      { params: {}, sharpe: 0.5, totalReturn: 0.05, trades: 30 },
+      'event_financial',
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('applyGlobalThresholds calls strategy API and updates executor config', async () => {
+    const scheduler = new OptimizationScheduler();
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ data: { strategies: [] } }) })
+      .mockResolvedValueOnce({ ok: true, json: vi.fn().mockResolvedValue({ data: { id: 'new-strat' } }) })
+      .mockResolvedValueOnce({ ok: true });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await (scheduler as any).applyGlobalThresholds(
+      { params: { 'combiner.minCombinedStrength': 0.3, 'combiner.minCombinedConfidence': 0.5 }, sharpe: 0.5, totalReturn: 0.05, trades: 30 },
+      'event_financial',
+    );
+
+    expect(fetchSpy).toHaveBeenCalled();
+    // 1st GET strategies, 2nd POST create, 3rd POST start
+    expect(fetchSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/dashboard/src/services/OptimizationScheduler.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.ts
@@ -325,6 +325,8 @@ export class OptimizationScheduler {
     console.log('[OptimizationScheduler] Starting incremental optimization (per-type)...');
     this.state.currentRunType = 'incremental';
 
+    const winners: Array<{ marketType: string; result: OptimizationResult }> = [];
+
     try {
       for (const marketType of MARKET_TYPES) {
         console.log(`[OptimizationScheduler] === ${marketType} ===`);
@@ -343,11 +345,20 @@ export class OptimizationScheduler {
           const priorBest = this.state.bestSharpePerType[marketType] ?? 0;
           if (best.sharpe >= priorBest) {
             console.log(`[OptimizationScheduler] ${marketType}: better params Sharpe ${best.sharpe.toFixed(2)} vs ${priorBest.toFixed(2)}`);
-            await this.updateStrategy(best, marketType);
+            const { wasApplied } = await this.updateStrategy(best, marketType);
+            if (wasApplied) winners.push({ marketType, result: best });
           }
         } catch (err) {
           console.error(`[OptimizationScheduler] ${marketType} failed:`, err);
         }
+      }
+
+      // #145 fix: deploy global thresholds ONCE per cycle with the max-Sharpe winner.
+      // Pre-fix this ran inside updateStrategy per-type → last-in wins on minEdge/minConfidence.
+      if (winners.length > 0) {
+        const winner = winners.reduce((a, b) => a.result.sharpe > b.result.sharpe ? a : b);
+        console.log(`[OptimizationScheduler] Cycle winner: ${winner.marketType} (Sharpe ${winner.result.sharpe.toFixed(3)}, ${winners.length} types qualified)`);
+        await this.applyGlobalThresholds(winner.result, winner.marketType);
       }
 
       this.state.lastIncrementalAt = new Date();
@@ -363,6 +374,8 @@ export class OptimizationScheduler {
   private async runFullOptimization(): Promise<void> {
     console.log('[OptimizationScheduler] Starting full optimization (per-type)...');
     this.state.currentRunType = 'full';
+
+    const winners: Array<{ marketType: string; result: OptimizationResult }> = [];
 
     try {
       for (const marketType of MARKET_TYPES) {
@@ -382,11 +395,19 @@ export class OptimizationScheduler {
           const priorBest = this.state.bestSharpePerType[marketType] ?? 0;
           if (best.sharpe >= priorBest) {
             console.log(`[OptimizationScheduler] ${marketType}: better params Sharpe ${best.sharpe.toFixed(2)} vs ${priorBest.toFixed(2)}`);
-            await this.updateStrategy(best, marketType);
+            const { wasApplied } = await this.updateStrategy(best, marketType);
+            if (wasApplied) winners.push({ marketType, result: best });
           }
         } catch (err) {
           console.error(`[OptimizationScheduler] ${marketType} failed:`, err);
         }
+      }
+
+      // #145 fix: deploy global thresholds ONCE per cycle with the max-Sharpe winner.
+      if (winners.length > 0) {
+        const winner = winners.reduce((a, b) => a.result.sharpe > b.result.sharpe ? a : b);
+        console.log(`[OptimizationScheduler] Cycle winner: ${winner.marketType} (Sharpe ${winner.result.sharpe.toFixed(3)}, ${winners.length} types qualified)`);
+        await this.applyGlobalThresholds(winner.result, winner.marketType);
       }
 
       this.state.lastFullAt = new Date();
@@ -832,9 +853,15 @@ export class OptimizationScheduler {
   private _lastOOSResult: OOSValidationResult | null = null;
 
   // ============================================================
-  // Strategy update
+  // Strategy update — Phase A: per-type writes (idempotent globals + per-type weights)
+  //
+  // Returns { wasApplied } so the caller can collect winners and invoke
+  // applyGlobalThresholds() ONCE per cycle with the highest-Sharpe winner.
+  // Pre-#145 this method also redeployed the global combo strategy and updated
+  // executor.config; that block now lives in applyGlobalThresholds. See
+  // docs/plans/2026-04-29-update-strategy-global-thresholds-design.md.
   // ============================================================
-  private async updateStrategy(result: OptimizationResult, marketType: string): Promise<void> {
+  private async updateStrategy(result: OptimizationResult, marketType: string): Promise<{ wasApplied: boolean }> {
     // Basic sanity checks
     if (result.sharpe > 8) {
       console.log(`[OptimizationScheduler] Extremely high Sharpe ${result.sharpe.toFixed(2)}, proceeding with caution`);
@@ -844,7 +871,7 @@ export class OptimizationScheduler {
     }
     if (result.totalReturn < -0.1) {
       console.log(`[OptimizationScheduler] Negative return (${(result.totalReturn * 100).toFixed(1)}%), skipping deployment`);
-      return;
+      return { wasApplied: false };
     }
 
     // OOS Validation Gate (already ran in runOOSAndPersist)
@@ -854,11 +881,11 @@ export class OptimizationScheduler {
       if (oosResult) {
         console.log(`[OptimizationScheduler] OOS metrics: Sharpe=${oosResult.sharpeOOS.toFixed(2)}, DD=${(oosResult.drawdownOOS * 100).toFixed(1)}%, Trades=${oosResult.tradesOOS}, WR=${(oosResult.winRateOOS * 100).toFixed(1)}%`);
       }
-      return;
+      return { wasApplied: false };
     }
 
     console.log(`[OptimizationScheduler] OOS validation PASSED: Sharpe=${oosResult.sharpeOOS.toFixed(2)}, Trades=${oosResult.tradesOOS}`);
-    console.log('[OptimizationScheduler] Deploying optimized strategy...');
+    console.log(`[OptimizationScheduler] Persisting per-type weights for ${marketType}...`);
 
     // Update local state
     this.state.bestParams = result.params;
@@ -925,6 +952,18 @@ export class OptimizationScheduler {
       }
     }
 
+    return { wasApplied: true };
+  }
+
+  // ============================================================
+  // Strategy update — Phase B: global threshold deploy
+  //
+  // Runs ONCE per cycle in runIncrementalOptimization / runFullOptimization,
+  // with the highest-Sharpe winner across the per-type loop. Pre-#145 this
+  // ran inside updateStrategy and was clobbered by whichever type processed
+  // last. See docs/plans/2026-04-29-update-strategy-global-thresholds-design.md.
+  // ============================================================
+  private async applyGlobalThresholds(result: OptimizationResult, marketType: string): Promise<void> {
     // Extract minEdge/minConfidence (works for both Optuna and grid params)
     const minEdge = result.params['combiner.minCombinedStrength']
       ?? result.params.minEdge
@@ -932,6 +971,8 @@ export class OptimizationScheduler {
     const minConfidence = result.params['combiner.minCombinedConfidence']
       ?? result.params.minConfidence
       ?? DEFAULT_BEST_PARAMS.minConfidence;
+
+    console.log(`[OptimizationScheduler] Applying global thresholds from ${marketType} winner: minEdge=${minEdge}, minConfidence=${minConfidence}`);
 
     // Update active strategy via API
     try {
@@ -983,7 +1024,7 @@ export class OptimizationScheduler {
         }
       }
     } catch (error) {
-      console.error('[OptimizationScheduler] Failed to update strategy:', error);
+      console.error('[OptimizationScheduler] Failed to apply global thresholds:', error);
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #145. Splits \`updateStrategy\` so the global combo-strategy redeploy + executor.config update runs **once per cycle** with the highest-Sharpe winner across all qualifying types — instead of being clobbered by whichever type processed last in the per-type loop.

## Why

Post-PR #140 the optimizer runs Optuna per market_type (5 types/cycle). Per-type weight writes are correct. But \`updateStrategy\` *also* stopped/started the shared combo strategy and pushed each type's \`minEdge\` / \`minConfidence\` to the executor — meaning the runtime thresholds reflected whichever type processed *last and passed OOS*. With PR #150 lowering the OOS \`minTrades\` floor for event_long to 5, multiple types may pass per cycle, making the loop-order dependency load-bearing.

Today only event_financial passes OOS, so the bug works by accident. This change makes it deterministic before it bites.

## Architecture

- \`updateStrategy(result, marketType)\` → returns \`{ wasApplied: boolean }\`. Now does only per-type / idempotent work: per-type weight writes, \`direction_multiplier\` enforcement, \`optimization_runs UPDATE\`. Removed the strategy-stop/start + executor.updateConfig block.
- New \`applyGlobalThresholds(result, marketType)\` — extracts \`minEdge\` / \`minConfidence\`, stops/starts the combo strategy, updates \`executor.config\`. Identical behaviour to the removed block.
- \`runIncrementalOptimization\` / \`runFullOptimization\`: collect winners from \`updateStrategy\` returns; after the loop, pick \`reduce((a,b) => a.sharpe > b.sharpe ? a : b)\` and call \`applyGlobalThresholds\` exactly once.

Spec: \`docs/plans/2026-04-29-update-strategy-global-thresholds-design.md\`.

## Test plan

- [x] \`pnpm vitest run packages/dashboard/src\` — 262/262 pass (5 new tests + 257 baseline).
- [x] \`pnpm tsc --noEmit -p packages/dashboard/tsconfig.json\` — 0 errors.
- [ ] Post-deploy: dashboard logs include \`[OptimizationScheduler] Cycle winner: <market_type> (Sharpe ..., N types qualified)\` after each per-type cycle. With current data only event_financial qualifies.

## Out of scope

Per-type \`minEdge\`/\`minConfidence\` (executor reads thresholds keyed by \`signal.marketType\` at runtime). Architecturally correct fix; requires executor refactor; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design specification for optimization scheduler improvements.

* **Tests**
  * Introduced test cases for strategy deployment validation and threshold application logic.

* **Refactor**
  * Optimized scheduler orchestration for clearer separation between per-type and global operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->