### PR TITLE
ci(daily-review): safety net to trigger Deploy when Claude merges PRs

### DIFF
--- a/.github/workflows/daily-trade-review-claude.yml
+++ b/.github/workflows/daily-trade-review-claude.yml
@@ -383,6 +383,36 @@ jobs:
             fi
           done
 
+      - name: Trigger deploy if Claude merged PRs (safety net)
+        # Claude is instructed not to merge PRs (see daily-review-prompt.md), but it has
+        # github.token in its session and can still call `gh pr merge`. When it does,
+        # the resulting push to main does NOT trigger Deploy to GCP because GitHub
+        # blocks workflows triggered by GITHUB_TOKEN-originated pushes. This step
+        # detects that case and dispatches Deploy manually with MERGE_PAT.
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.MERGE_PAT }}
+        run: |
+          set -euo pipefail
+          SINCE=$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          LAST_MERGE=$(gh pr list --state merged --label daily-review \
+            --search "merged:>$SINCE" \
+            --json mergedAt --jq 'sort_by(.mergedAt) | last | .mergedAt // ""')
+          if [ -z "$LAST_MERGE" ]; then
+            echo "No daily-review PRs merged in last 2h — nothing to verify"
+            exit 0
+          fi
+          LAST_DEPLOY=$(gh run list --workflow="Deploy to GCP" --branch main --limit 1 \
+            --json createdAt --jq '.[0].createdAt // ""')
+          echo "Last daily-review merge: $LAST_MERGE"
+          echo "Last Deploy run:        $LAST_DEPLOY"
+          if [ -z "$LAST_DEPLOY" ] || [[ "$LAST_DEPLOY" < "$LAST_MERGE" ]]; then
+            echo "::warning::Daily-review PR merged but no Deploy fired — dispatching manually"
+            gh workflow run "Deploy to GCP" --ref main
+          else
+            echo "Deploy already fired after the merge — no action needed"
+          fi
+
       - name: Upload Claude logs
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Why

The auto-review prompt (`scripts/daily-review-prompt.md`) explicitly prohibits Claude from running `gh pr merge` (lines 336, 661). But the step \`Run Claude Code Analysis\` runs with \`GH_TOKEN: \${{ github.token }}\` and \`--dangerously-skip-permissions\`, so the prompt is honor-system only.

Today (2026-04-30) Claude violated that rule — it merged PR #159 from inside its session. The resulting push to main did not fire Deploy to GCP, because GitHub blocks workflows triggered by GITHUB_TOKEN-originated pushes (anti-recursion safeguard). Result: the fix for issue #158 sat on main for 3+ hours without ever reaching the VM, requiring a manual \`workflow_dispatch\` to deploy.

Historically PRs #137, #138, #148 were merged manually by @JaviMaligno with a PAT, which is why deploy fired for them.

## Fix

Add a final \`Trigger deploy if Claude merged PRs (safety net)\` step at the end of the workflow that:

1. Looks for daily-review PRs merged in the last 2 hours
2. Compares the latest merge timestamp against the latest \`Deploy to GCP\` run
3. If Deploy is older than the merge, dispatches Deploy manually using \`MERGE_PAT\` (which can trigger downstream workflows)

When Claude follows the prompt and leaves PRs open for human merge, this step is a no-op.

## Why not change Claude's permissions

Stripping merge ability from \`github.token\` is heavier surgery and would break the verify-then-rollback flow Claude needs for testing PRs against the VM. The safety net is the smallest change that closes the deploy gap without touching Claude's authoring permissions.

## Test plan

- [x] YAML parses (will be validated by GitHub on push)
- [ ] Next daily review run: if Claude follows the prompt → step says "No daily-review PRs merged in last 2h"
- [ ] If Claude (or anyone) merges a daily-review PR mid-run → step dispatches Deploy automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment reliability with an added safety mechanism to ensure deployments complete after code merges, preventing scenarios where merges could bypass the standard deployment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->