### PR TITLE
fix(infra): VM external IP after billing restoration

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -185,11 +185,11 @@ jobs:
           dashboard_ok=false
           collector_ok=false
           for i in $(seq 1 24); do
-            if [ "$dashboard_ok" = false ] && curl -sf http://34.148.24.147:3001/health > /dev/null 2>&1; then
+            if [ "$dashboard_ok" = false ] && curl -sf http://34.26.216.167:3001/health > /dev/null 2>&1; then
               echo "Dashboard API healthy after $((i * 5))s"
               dashboard_ok=true
             fi
-            if [ "$collector_ok" = false ] && curl -sf http://34.148.24.147:10000/health > /dev/null 2>&1; then
+            if [ "$collector_ok" = false ] && curl -sf http://34.26.216.167:10000/health > /dev/null 2>&1; then
               echo "Data collector healthy after $((i * 5))s"
               collector_ok=true
             fi

--- a/packages/dashboard/frontend/vercel.json
+++ b/packages/dashboard/frontend/vercel.json
@@ -3,6 +3,6 @@
   "outputDirectory": "dist",
   "framework": "vite",
   "rewrites": [
-    { "source": "/api/:path*", "destination": "http://34.148.24.147:3001/api/:path*" }
+    { "source": "/api/:path*", "destination": "http://34.26.216.167:3001/api/:path*" }
   ]
 }


### PR DESCRIPTION
## Why

The VM's ephemeral external IP (34.148.24.147) was released by GCP when the billing account was closed (free trial expired). After re-enabling billing and restarting the VM, GCP assigned a new IP (34.26.216.167).

The new IP is now reserved as a static address (polymarket-vm-ip in us-east1), so future VM restarts will retain it.

## Changes

- .github/workflows/deploy-gcp.yml — health check curl URLs (×2)
- packages/dashboard/frontend/vercel.json — API rewrite destination

## Verified

- Both /health endpoints respond on the new IP from external network.
- 5 bootstrap rows landed in signal_weights for direction_multiplier (event_financial=+1, others=-1).

## Out of scope

Four historical docs in docs/plans/ still reference the old IP. They are not updated since they are point-in-time records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated backend infrastructure endpoints for dashboard and data collector services
* Health check monitoring now probes refreshed service instances while maintaining existing polling behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->