### PR TITLE
fix(direction-multiplier): default-disable LearningService + wipe segments (PR-2)

### DIFF
--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -11,6 +11,7 @@ import { initializeDatabase, closeDatabase, healthCheck, isDatabaseConfigured, q
 import { signalWeightsRepo, tradingConfigRepo, paperPositionsRepo } from './database/repositories.js';
 import { initializeOptimizationScheduler } from './services/OptimizationScheduler.js';
 import { initializeDirectionMultiplierLearningService } from './services/DirectionMultiplierLearningService.js';
+import { wipeDirectionMultiplierSegments } from './services/wipeDirectionMultiplierSegments.js';
 import { initializeSignalEngine } from './services/SignalEngine.js';
 import { DirectionResolver } from './services/DirectionResolver.js';
 import {
@@ -580,14 +581,28 @@ async function main(): Promise<void> {
         console.warn('Failed to load optimized params, using defaults:', error);
       }
 
-      // Initialize SignalEngine with optimized parameters
-      const directionMultiplierLearning = initializeDirectionMultiplierLearningService({
-        enabled: process.env.ENABLE_DIRECTION_MULTIPLIER_LEARNING !== 'false',
-        evaluationIntervalMs: parseInt(process.env.DIRECTION_MULTIPLIER_LEARNING_INTERVAL_MS || String(6 * 60 * 60 * 1000), 10),
-        lookbackDays: parseInt(process.env.DIRECTION_MULTIPLIER_LEARNING_LOOKBACK_DAYS || '30', 10),
-      });
-      await directionMultiplierLearning.start();
-      console.log('DirectionMultiplierLearningService started');
+      // DirectionMultiplierLearningService is now opt-in (default OFF). The
+      // per-type optimizer (PR #163) supersedes its segment-based learning;
+      // any segments[] persisted by previous runs would otherwise win priority
+      // over the per-type values. When disabled we wipe segments[] so the
+      // resolver falls through to perMarketType (composed from signal_weights).
+      const learningEnabled = process.env.ENABLE_DIRECTION_MULTIPLIER_LEARNING === 'true';
+      if (learningEnabled) {
+        const directionMultiplierLearning = initializeDirectionMultiplierLearningService({
+          enabled: true,
+          evaluationIntervalMs: parseInt(process.env.DIRECTION_MULTIPLIER_LEARNING_INTERVAL_MS || String(6 * 60 * 60 * 1000), 10),
+          lookbackDays: parseInt(process.env.DIRECTION_MULTIPLIER_LEARNING_LOOKBACK_DAYS || '30', 10),
+        });
+        await directionMultiplierLearning.start();
+        console.log('DirectionMultiplierLearningService started (legacy mode, ENABLE_DIRECTION_MULTIPLIER_LEARNING=true)');
+      } else {
+        try {
+          await wipeDirectionMultiplierSegments();
+          console.log('DirectionMultiplierLearningService disabled — segments[] wiped, per-type policy active');
+        } catch (err) {
+          console.error('Failed to wipe direction_multiplier_policy.segments:', err);
+        }
+      }
 
       // Cached policy provider (60s TTL) — avoids querying trading_config on every signal resolve
       let cachedPolicy: { data: DirectionMultiplierPolicy; fetchedAt: number } | null = null;

--- a/packages/dashboard/src/services/wipeDirectionMultiplierSegments.test.ts
+++ b/packages/dashboard/src/services/wipeDirectionMultiplierSegments.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../database/repositories.js', () => ({
+  tradingConfigRepo: {
+    get: vi.fn(),
+    set: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+import { tradingConfigRepo } from '../database/repositories.js';
+import { wipeDirectionMultiplierSegments } from './wipeDirectionMultiplierSegments.js';
+
+describe('wipeDirectionMultiplierSegments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('wipes segments when existing policy has populated segments', async () => {
+    (tradingConfigRepo.get as any).mockResolvedValueOnce({
+      global: -1,
+      minMultiplier: -1.25,
+      maxMultiplier: 1,
+      segments: [
+        { id: 'seg-1', multiplier: 0.68, marketTypes: ['event_financial'] },
+        { id: 'seg-2', multiplier: 0.27, marketTypes: ['event_financial'] },
+      ],
+    });
+
+    await wipeDirectionMultiplierSegments();
+
+    expect(tradingConfigRepo.set).toHaveBeenCalledTimes(1);
+    const [key, value] = (tradingConfigRepo.set as any).mock.calls[0];
+    expect(key).toBe('direction_multiplier_policy');
+    expect(value.segments).toEqual([]);
+    expect(value.global).toBe(-1);
+    expect(value.minMultiplier).toBe(-1.25);
+    expect(value.maxMultiplier).toBe(1);
+  });
+
+  it('preserves perMarketType when present', async () => {
+    (tradingConfigRepo.get as any).mockResolvedValueOnce({
+      global: -1,
+      segments: [{ id: 'seg-1', multiplier: 0.5 }],
+      perMarketType: { event_financial: 1, crypto_intraday: -1 },
+    });
+
+    await wipeDirectionMultiplierSegments();
+
+    const [, value] = (tradingConfigRepo.set as any).mock.calls[0];
+    expect(value.perMarketType).toEqual({ event_financial: 1, crypto_intraday: -1 });
+  });
+
+  it('uses defaults when existing policy is null', async () => {
+    (tradingConfigRepo.get as any).mockResolvedValueOnce(null);
+
+    await wipeDirectionMultiplierSegments();
+
+    expect(tradingConfigRepo.set).toHaveBeenCalledTimes(1);
+    const [, value] = (tradingConfigRepo.set as any).mock.calls[0];
+    expect(value.segments).toEqual([]);
+    expect(value.global).toBe(-1.0);
+  });
+
+  it('skips the write when segments is already empty (idempotent no-op)', async () => {
+    (tradingConfigRepo.get as any).mockResolvedValueOnce({
+      global: -1,
+      minMultiplier: -1.25,
+      maxMultiplier: 1,
+      segments: [],
+    });
+
+    await wipeDirectionMultiplierSegments();
+
+    expect(tradingConfigRepo.set).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/services/wipeDirectionMultiplierSegments.ts
+++ b/packages/dashboard/src/services/wipeDirectionMultiplierSegments.ts
@@ -1,0 +1,42 @@
+import { tradingConfigRepo } from '../database/repositories.js';
+import {
+  DEFAULT_DIRECTION_MULTIPLIER_POLICY,
+  type DirectionMultiplierPolicy,
+} from './DirectionMultiplierPolicy.js';
+
+/**
+ * Idempotent wipe of `direction_multiplier_policy.segments[]` in trading_config.
+ *
+ * Why: when the DirectionMultiplierLearningService is disabled, any previously
+ * persisted segments would still be picked up by `resolveDirectionMultiplier()`
+ * and given priority over the new `perMarketType` values composed from
+ * `signal_weights`. This helper ensures the resolver falls through to the
+ * per-type layer (or the global fallback) by leaving segments empty.
+ *
+ * Preserves `global`, `minMultiplier`, `maxMultiplier`, and `perMarketType`
+ * if present. Only `segments` is wiped.
+ */
+export async function wipeDirectionMultiplierSegments(): Promise<void> {
+  const existing = await tradingConfigRepo.get<DirectionMultiplierPolicy>(
+    'direction_multiplier_policy'
+  );
+
+  const next: DirectionMultiplierPolicy = {
+    global: existing?.global ?? DEFAULT_DIRECTION_MULTIPLIER_POLICY.global,
+    minMultiplier: existing?.minMultiplier ?? DEFAULT_DIRECTION_MULTIPLIER_POLICY.minMultiplier,
+    maxMultiplier: existing?.maxMultiplier ?? DEFAULT_DIRECTION_MULTIPLIER_POLICY.maxMultiplier,
+    segments: [],
+    ...(existing?.perMarketType ? { perMarketType: existing.perMarketType } : {}),
+  };
+
+  // Skip the write when the policy is already in the wiped state.
+  if (existing && Array.isArray(existing.segments) && existing.segments.length === 0) {
+    return;
+  }
+
+  await tradingConfigRepo.set(
+    'direction_multiplier_policy',
+    next,
+    'wipe_segments_after_dm_per_type_migration'
+  );
+}


### PR DESCRIPTION
## Why

PR #163 (dm per-type) shipped yesterday with an explicit out-of-scope: \"deprecating DirectionMultiplierLearningService\" was scheduled as PR-2 in +1 week. Within minutes of that deploy, the issue manifested in production logs:

\`\`\`
[multiplier:-1, contextKey: event_financial|40to60|long]   ← global fallback
[multiplier:0.273, contextKey: event_financial|60to80|long]   ← LearningService segment match
[multiplier:0.682, contextKey: event_financial|20to40|long]   ← LearningService segment match
[multiplier:0.636, contextKey: event_financial|40to60|long]   ← LearningService segment match
\`\`\`

The resolver priority (segment > perMarketType > global) meant LearningService segments[] populated from pre-deploy data were **overriding the per-type +1 bootstrap** for event_financial. Net effect: the entire fix from PR #163 was being masked.

Pulling PR-2 forward to close this loop.

## Changes

- \`server.ts\`: \`ENABLE_DIRECTION_MULTIPLIER_LEARNING\` flips from \"default true (must explicitly disable)\" to \"default false (must explicitly enable)\". The opt-in keeps a path back to legacy behavior if anyone wants it.
- New \`wipeDirectionMultiplierSegments.ts\`: when service is disabled at startup, wipes \`direction_multiplier_policy.segments=[]\` in trading_config. Preserves \`global\`, \`minMultiplier\`, \`maxMultiplier\`, \`perMarketType\`. Idempotent (skips write when already empty).
- 4 unit tests: wipe when populated, preserve perMarketType, defaults on null policy, no-op when empty.

## Test plan

- [x] tsc clean across packages/dashboard
- [x] 836 monorepo tests pass (+4 new from this PR, baseline was 832)
- [ ] Post-deploy: \`docker logs polymarket-dashboard-api | grep 'segments\[\] wiped'\` — should appear once per restart.
- [ ] Post-deploy: trades on event_financial should now show \`applied_direction_multiplier=1.0\` (verifying that perMarketType layer is now reaching runtime instead of being shadowed by segments).

## What this does NOT do

PR-3 in the original spec (delete the service entirely, remove the legacy schema) is still future work. This PR keeps the service code intact behind the env var; future ops can flip it back on if they have a strong reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)