### PR TITLE
fix(direction-resolver): honor perMarketType policy entries

### DIFF
--- a/packages/dashboard/src/services/DirectionResolver.test.ts
+++ b/packages/dashboard/src/services/DirectionResolver.test.ts
@@ -58,6 +58,99 @@ describe('DirectionResolver — segment match', () => {
   });
 });
 
+describe('DirectionResolver — perMarketType match', () => {
+  // perMarketType priority: segment > perMarketType > exploration / global.
+  // Without this branch, perMarketType is silently bypassed because
+  // resolveDirectionMultiplier returns segmentId=null on perMarketType match,
+  // and the resolver previously used segmentId !== null as the only "use base.multiplier" trigger.
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('returns perMarketType[type] with reason=per_type when no segment matches and a per-type entry exists', async () => {
+    const policy: DirectionMultiplierPolicy = {
+      global: -1.0,
+      minMultiplier: -1.25,
+      maxMultiplier: 1.0,
+      segments: [],
+      perMarketType: { event_financial: 1, crypto_intraday: -1 },
+    };
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: stubConfig,
+      rng: () => 0.05,  // would normally trigger exploration; perMarketType must win
+      paperPositionsRepo: stubRepo as any,
+      logger,
+    });
+
+    const result = await resolver.resolve({
+      marketType: 'event_financial',
+      currentPrice: 0.5,
+      endDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    });
+
+    expect(result.multiplier).toBe(1);
+    expect(result.reason).toBe('per_type');
+    expect(result.wasExploration).toBe(false);
+    expect(result.segmentId).toBeNull();
+  });
+
+  it('falls through to global when perMarketType has no entry for the type and rng misses epsilon', async () => {
+    const policy: DirectionMultiplierPolicy = {
+      global: -1.0, minMultiplier: -1.25, maxMultiplier: 1.0, segments: [],
+      perMarketType: { event_financial: 1 },
+    };
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: stubConfig,
+      rng: () => 0.5,  // > epsilon, so global path
+      paperPositionsRepo: stubRepo as any,
+      logger,
+    });
+
+    const result = await resolver.resolve({
+      marketType: 'event_long',
+      currentPrice: 0.5,
+      endDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    });
+
+    expect(result.multiplier).toBe(-1);
+    expect(result.reason).toBe('global');
+  });
+
+  it('segment match still wins over perMarketType', async () => {
+    const policy: DirectionMultiplierPolicy = {
+      global: -1.0,
+      minMultiplier: -1.25,
+      maxMultiplier: 1.0,
+      segments: [{
+        id: 'event_financial-40to60-medium',
+        multiplier: -1.25,
+        marketTypes: ['event_financial'],
+        priceRange: { min: 0.4, max: 0.6 },
+        durationBands: ['medium'],
+      }],
+      perMarketType: { event_financial: 1 },  // perMarketType says +1 — segment must override
+    };
+    const resolver = new DirectionResolver({
+      policyProvider: async () => policy,
+      explorationConfig: stubConfig,
+      rng: () => 0.5,
+      paperPositionsRepo: stubRepo as any,
+      logger,
+    });
+
+    const result = await resolver.resolve({
+      marketType: 'event_financial',
+      currentPrice: 0.5,
+      endDate: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000),
+    });
+
+    expect(result.multiplier).toBe(-1.25);
+    expect(result.reason).toBe('segment');
+    expect(result.segmentId).toBe('event_financial-40to60-medium');
+  });
+});
+
 describe('DirectionResolver — exploration sampling', () => {
   const policy: DirectionMultiplierPolicy = {
     global: -1.0, minMultiplier: -1.25, maxMultiplier: 1.0, segments: [],

--- a/packages/dashboard/src/services/DirectionResolver.ts
+++ b/packages/dashboard/src/services/DirectionResolver.ts
@@ -4,7 +4,7 @@ import {
   type DirectionMultiplierPolicy,
 } from './DirectionMultiplierPolicy.js';
 
-export type DirectionResolveReason = 'segment' | 'global' | 'exploration' | 'breaker_tripped';
+export type DirectionResolveReason = 'segment' | 'per_type' | 'global' | 'exploration' | 'breaker_tripped';
 
 export interface DirectionResolution {
   multiplier: number;
@@ -106,7 +106,27 @@ export class DirectionResolver {
       };
     }
 
-    // Segment miss — consider exploration.
+    // Per-market-type match: priority between segment and exploration.
+    // resolveDirectionMultiplier already applied the perMarketType lookup and
+    // returned its value via `base.multiplier` (with segmentId=null). We MUST
+    // honor it here — without this branch, the multiplier is discarded and the
+    // resolver falls through to exploration/global, silently overriding the
+    // per-type policy. Exploration is for "no information" cases; perMarketType
+    // is information.
+    const perTypeMultiplier = context.marketType
+      ? policy.perMarketType?.[context.marketType]
+      : undefined;
+    if (perTypeMultiplier !== undefined && Number.isFinite(perTypeMultiplier)) {
+      return {
+        multiplier: perTypeMultiplier,
+        contextKey: base.contextKey,
+        segmentId: null,
+        wasExploration: false,
+        reason: 'per_type',
+      };
+    }
+
+    // Segment miss AND no per-type match — consider exploration.
     // Kill switch: DIRECTION_EXPLORATION_EPSILON=0 makes `roll < epsilon` always false → global fallthrough.
     if (await this.isBreakerTripped()) {
       return {


### PR DESCRIPTION
## Why

PR #163 added the perMarketType layer to `DirectionMultiplierPolicy` and `resolveDirectionMultiplier()`. PR #165 disabled the LearningService and wiped its segments[] so the resolver would fall through to perMarketType. Both deployed correctly.

But verification today revealed the perMarketType layer **never reached runtime**. Production logs showed event_financial signals using:

\`\`\`
multiplier: 0.7525  (exploration random sample)
multiplier: 0.7693  (exploration random sample)
multiplier: -1       (policy.global)
\`\`\`

Never +1.

## Root cause

\`DirectionResolver.resolve()\` (line 95-141) only respects \`base.multiplier\` when \`base.segmentId !== null\` (segment match). When the per-type branch in \`resolveDirectionMultiplier()\` returns \`{multiplier: perType, segmentId: null}\`, the resolver discards that multiplier and enters the exploration/global path.

This wasn't caught by the previous review because:
- The unit tests for \`resolveDirectionMultiplier\` (the pure function) pass — it correctly returns perMarketType when matched.
- The \`DirectionResolver\` (the wrapper) was tested for segment match, exploration, and breaker — but not for perMarketType match.

## Fix

Add an explicit \`per_type\` branch between segment match and exploration in \`DirectionResolver.resolve()\`. Priority becomes:

\`\`\`
segment > per_type > exploration > global
\`\`\`

New \`reason='per_type'\` surfaces the path in resolution metadata.

3 new tests assert the priority order:
- perMarketType wins over exploration when no segment matches
- segment match still wins over perMarketType
- absent perMarketType entry → falls through to global

## Test plan

- [x] \`pnpm tsc --noEmit\` clean.
- [x] 839 monorepo tests pass (+3 new vs 836 baseline post-PR #165).
- [x] All 12 DirectionResolver tests pass (existing 9 + 3 new).
- [ ] Post-deploy: \`docker logs polymarket-dashboard-api | grep 'Direction multiplier updated' | grep event_financial\` should show only \`-1\` and \`1\` for event_financial — never intermediate values like 0.27, 0.75, etc.
- [ ] Post-deploy: \`paper_positions.applied_direction_multiplier = 1\` for new event_financial trades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)