### PR TITLE
fix(direction-policy): perMarketType clamp on fixed [-1, +1] domain

### DIFF
--- a/packages/dashboard/src/services/DirectionMultiplierPolicy.test.ts
+++ b/packages/dashboard/src/services/DirectionMultiplierPolicy.test.ts
@@ -106,13 +106,30 @@ describe('sanitizeDirectionMultiplierPolicy — perMarketType', () => {
     expect(result.perMarketType).toEqual({ event_financial: 1, crypto_intraday: -1 });
   });
 
-  it('clamps perMarketType values to [minMultiplier, maxMultiplier]', () => {
+  it('clamps perMarketType values to fixed [-1, +1] domain (independent of policy min/max)', () => {
     const result = sanitizeDirectionMultiplierPolicy({
       ...baseInput,
       perMarketType: { event_financial: 5, crypto_intraday: -10 },
     });
+    // Fixed PER_TYPE_DOMAIN clamps to [-1, +1] regardless of baseInput.minMultiplier=-1.25.
     expect(result.perMarketType?.event_financial).toBe(1);
-    expect(result.perMarketType?.crypto_intraday).toBe(-1.25);
+    expect(result.perMarketType?.crypto_intraday).toBe(-1);
+  });
+
+  it('preserves perMarketType=+1 even when policy.maxMultiplier is 0.25 (legacy default)', () => {
+    // Production regression: legacy default (DEFAULT_MAX_MULTIPLIER=0.25) is sized for the
+    // segment-multiplier domain. The +1 bootstrap from PR #163 was being silently
+    // truncated to 0.25 in runtime (observed 2026-05-01 after PR #166 deploy).
+    // perMarketType MUST clamp on its own categorical-{-1,+1} contract, not the policy's.
+    const result = sanitizeDirectionMultiplierPolicy({
+      global: -1,
+      minMultiplier: -1.5,
+      maxMultiplier: 0.25,
+      segments: [],
+      perMarketType: { event_financial: 1, crypto_intraday: -1 },
+    });
+    expect(result.perMarketType?.event_financial).toBe(1);
+    expect(result.perMarketType?.crypto_intraday).toBe(-1);
   });
 
   it('drops NaN and Infinity entries from perMarketType', () => {

--- a/packages/dashboard/src/services/DirectionMultiplierPolicy.ts
+++ b/packages/dashboard/src/services/DirectionMultiplierPolicy.ts
@@ -117,12 +117,20 @@ export function sanitizeDirectionMultiplierPolicy(
         }))
     : [];
 
+  // perMarketType uses a fixed [-1, +1] domain because its contract is categorical {-1, +1}
+  // (enforced upstream by PER_TYPE_PARAMETER_SPACE / REFINEMENT_PARAM_SPACE regression tests).
+  // Clamping to the policy's [minMultiplier, maxMultiplier] would silently truncate the
+  // legitimate +1 bootstrap to 0.25 when policy.maxMultiplier is the legacy default
+  // (DEFAULT_MAX_MULTIPLIER=0.25, sized for the segment-multiplier domain). This was
+  // observed in production after PR #166 deploy: event_financial signals showed
+  // multiplier=0.25 instead of +1.
+  const PER_TYPE_DOMAIN = { minMultiplier: -1.0, maxMultiplier: 1.0 };
   let perMarketType: Record<string, number> | undefined;
   if (policy?.perMarketType && typeof policy.perMarketType === 'object') {
     const filtered: Record<string, number> = {};
     for (const [marketType, value] of Object.entries(policy.perMarketType)) {
       if (typeof value === 'number' && Number.isFinite(value)) {
-        filtered[marketType] = clampDirectionMultiplier(value, { minMultiplier, maxMultiplier });
+        filtered[marketType] = clampDirectionMultiplier(value, PER_TYPE_DOMAIN);
       }
     }
     if (Object.keys(filtered).length > 0) {


### PR DESCRIPTION
Production sanity bug. event_financial=+1 was silently clamped to +0.25 because sanitizeDirectionMultiplierPolicy used policy.maxMultiplier (legacy default 0.25, sized for segments) for the perMarketType clamp. Per-type values are categorical {-1, +1} and must clamp on their own domain.

Symptom: dashboard-api logs showed multiplier=0.25 for event_financial signals after PR #166 deploy, even though signal_weights row had +1.

The C1 fix from PR #163's review never made it to main during the squash. This PR re-applies it correctly with a regression test.

## Test plan

- [x] tsc clean
- [x] 840 monorepo tests pass (+1 new vs 839 baseline)
- [x] New regression test: perMarketType=+1 with policy.maxMultiplier=0.25 → preserved as +1
- [ ] Post-deploy: event_financial signals should now show multiplier=1, not 0.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where market-type-specific direction multiplier values were being incorrectly clamped to policy-wide limits, preventing legitimate default values from being retained during sanitization.

* **Tests**
  * Added regression test to ensure multiplier values are properly preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->