### PR TITLE
feat(scorer): shadow as additive dimension via category_performance_shadow + haircut

### DIFF
--- a/docs/plans/2026-05-01-shadow-haircut-scorer-integration-design.md
+++ b/docs/plans/2026-05-01-shadow-haircut-scorer-integration-design.md
@@ -1,94 +1,152 @@
-# Shadow Haircut Scorer Integration — Design Spec
+# Two-Source Type Expected Value: Shadow Dimension Added to MarketScorer
 
 **Date:** 2026-05-01
 **Branch:** `feat/shadow-haircut-scorer-integration`
 **Status:** approved, ready for plan
+**Scope:** purely additive. `category_performance` (live) and `MarketScorer.typeExpectedValue` are **unchanged**. A new dimension `shadowExpectedValue` is added with its own table and writer.
 
 ---
 
 ## 1. Problem
 
-`event_short` shadow Sharpe is **+2.03** (n=444 resolved) but its `category_performance.sharpe_ratio` is **+0.13** (n=419 historic live trades, mostly pre-fixes). The `MarketScorer.typeExpectedValue` dimension (weight 0.17) reads exclusively from live data, so event_short's strong shadow validation never reaches the score that drives `MarketRotator` candidate ranking.
+`event_short` has shadow Sharpe **+2.03** (n=444 resolved) but its `category_performance.sharpe_ratio` is **+0.13** (n=419 historic live trades, mostly pre-fix). The `MarketScorer.typeExpectedValue` dimension reads only live data, so event_short's strong shadow validation never reaches the score that drives `MarketRotator` candidate ranking.
 
-Net result: `event_short` has 14 cold candidates with `market_score >= 0.6` but only 2 markets in `tracking_status='active'`. `event_financial` dominates the top-50 candidates query (28/50) because its raw scoring is structurally higher (more volume/liquidity) — not because its signals are more correct.
+Today: event_short has 14 cold candidates with `market_score >= 0.6` but only 2 markets in active. event_financial dominates (23 active) because its raw scoring is structurally higher (volume/liquidity), not because its signals are more correct.
 
-Today's data (2026-05-01) confirms the bias is asymmetric per type:
+The asymmetry is real: shadow has labeled event_short as the strongest available signal (Sharpe 2.03, 88.5% WR), but the scorer is blind to that.
 
-| type | live Sharpe (all-time) | shadow Sharpe | n_live | n_shadow_resolved |
-|---|---|---|---|---|
-| event_long | +0.17 | −0.99 | 1317 | 333 |
-| event_short | +0.13 | +2.03 | 419 | 444 |
-| event_financial | +0.23 | (0 resolved) | 201 | 0 |
+## 2. Empirical analysis of the shadow/live gap
 
-The all-time live numbers are not representative of the current regime: event_long was removed from `ALLOWED_MARKET_TYPES` after shadow flagged it; event_short is starved by the rotator; event_financial has live recent flow but historical Sharpe predates dm-per-type fixes.
+The original "16x ratio" reported in `memory/project_shadow_execution_realism.md` (event_short shadow 2.03 / live 0.13 all-time) conflated two effects: (a) regime change between live's historic sample and shadow's recent sample, and (b) execution-realism gap (absent fees, slippage, early exits, risk gates).
 
-## 2. Solution
+Time-matched analysis (2026-05-01, shadow's epoch 2026-04-13 → 2026-04-21):
 
-Modify `MarketPerformanceTracker.updateCategoryPriors()` to compute `category_performance.sharpe_ratio` per market_type using a routing rule:
+| type | live n | live Sharpe | shadow n | shadow Sharpe | ratio |
+|---|---|---|---|---|---|
+| event_long | 16 | -0.33 | 333 | -0.99 | 0.33 |
+| event_short | 1 | (insufficient) | 444 | +2.03 | unobservable |
 
-1. **Live recent (preferred)**: if `live_n_recent >= 30` (closed positions in last 7 days), use the time-windowed live Sharpe.
-2. **Shadow with empirical haircut (fallback)**: if `shadow_n_resolved >= 30`, use `shadow_sharpe × 0.33`.
-3. **Insufficient evidence**: skip the upsert. The row falls back to the seed/prior state, and `MarketScorer.typeExpectedValue` returns its neutral 0.5 default when `n_trades < 5`.
+Decomposition by component:
 
-The 0.33 haircut is the time-matched live/shadow Sharpe ratio observed for `event_long` in the shadow's epoch (2026-04-13 to 2026-04-21, n_live=16, n_shadow=333). It approximates the absent-fees-and-slippage gap. The sample is small; the haircut is a **working hypothesis** to validate post-deploy, not a calibrated constant. Documented in `memory/project_shadow_execution_realism.md`.
+| Component | Magnitude | Source |
+|---|---|---|
+| **Fees** | <0.1% of avg_pnl per trade. **Negligible.** | Measured directly: shadow Sharpe with vs without fee subtraction differs in the 4th decimal. avg_fee_round_trip event_short = $0.28 vs avg_pnl $383. |
+| **Slippage** | Variable, not measured | Per `OrderBookExecutionSimulator`, depends on book depth. |
+| **Early exits** | Live closes via stop-loss / signal-driven; shadow holds to resolution. **Probably the largest contributor.** | Structural — not a simple scaling factor. |
+| **Risk gates** | Live rejects via SHORT gate, concentration gate, near-expiry gate; shadow does not. | Structural — affects which trades are even taken. |
+| **Position sizing** | Live respects `MaxPositionSizePct`; shadow uses `theoretical_size` unconstrained. | Structural — affects per-trade variance. |
 
-The MarketScorer integration is unchanged: `typeExpectedValue` reads `category_performance.sharpe_ratio` and `n_trades` as today; only the writer changes.
+**Conclusion**: a single multiplicative haircut on shadow Sharpe is conceptually weak because the gap is dominated by structural differences, not by fees. Better to **separate live and shadow as distinct evidence streams** with their own weights, each contributing what they're good at.
 
-## 3. Architecture / Data flow
+## 3. Solution: shadow as additive dimension
+
+Add a new dimension `shadowExpectedValue` to `MarketScorer.compositeScore`:
+
+| Dimension | Source | Weight | Change |
+|---|---|---|---|
+| `tradeability` | unchanged | 0.21 → 0.1995 | rescaled |
+| `liquidity` | unchanged | 0.17 → 0.1615 | rescaled |
+| `volatility` | unchanged | 0.15 → 0.1425 | rescaled |
+| `ttr` | unchanged | 0.08 → 0.0760 | rescaled |
+| `dataQuality` | unchanged | 0.10 → 0.0950 | rescaled |
+| `typeExpectedValue` | `category_performance` (live, **all-time**, unchanged) | 0.17 → 0.1615 | rescaled |
+| `realizedVolatility` | unchanged | 0.12 → 0.1140 | rescaled |
+| **`shadowExpectedValue`** | `category_performance_shadow` (new) | **0.05** | **NEW** |
+
+All other dimensions are scaled by `0.95` factor so the total still sums to 1.0. The data sources and formulas of every other dimension are unchanged.
+
+`typeExpectedValue` keeps reading `category_performance` exactly as today (all-time live data, no time window). Even when sample is historic and pre-fix, that evidence is preserved as one input. `shadowExpectedValue` adds the recent-regime signal via shadow data, downweighted to reflect its theoretical-execution nature.
+
+### Why no time window on live
+
+The previous draft proposed a 7-day window on live to "force regime-current data". Concrete numbers showed this would actually penalise event_short (it would lose its current 0.749 typeEV → 0.5 neutral, and the 0.05-weight shadow boost wouldn't compensate). The keep-historical-live design is purely additive: shadow boosts event_short on top of its existing live evidence, instead of replacing it.
+
+If a future regime change makes long-tail historical evidence misleading, that's a separate spec — out of scope here.
+
+### Why 0.05 weight for shadow
+
+Sized so the addition is meaningful but cannot dominate. Concretely:
+
+- event_short composite contribution before: typeEV 0.749 × 0.17 = **0.127**
+- event_short composite contribution after: typeEV 0.749 × 0.1615 + shadowEV 1.0 × 0.05 = 0.121 + 0.050 = **0.171**
+- Net delta: **+0.044** to event_short's composite score.
+- event_financial (no shadow data) goes from 0.138 → 0.131 (slight rescale-down because its weight share dropped). Net delta: **−0.007**.
+- **Spread between the two flips**: event_short was 0.011 below event_financial; now event_short is 0.040 above. Sufficient to enter the rotator's top-50 candidates.
+
+If validation suggests 0.05 is too low (event_short still starved) or too high (other types over-promoted), follow-up PR adjusts. Weight is **not** env-tunable: changing scoring weights at runtime is too risky for a single env knob; it requires deliberate review.
+
+## 4. Architecture / Data flow
 
 ```
 Scheduler (daily 02:45 UTC)
     ↓
 computeMarketPriors()
-    ↓
-updateCategoryPriors()  ← refactored
-    ├── Query 1: live recent Sharpe per type
-    │       paper_positions JOIN markets
-    │       WHERE closed_at > NOW() - INTERVAL '<window> days'
-    │       GROUP BY market_type
-    ├── Query 2: shadow Sharpe per type
-    │       shadow_trades
-    │       WHERE resolved_at IS NOT NULL
-    │       GROUP BY market_type
-    └── JS-side merge per market_type:
-            if live.n >= MIN_LIVE_RECENT_N
-                → upsert { sharpe: live.sharpe, n: live.n }
-            elif shadow.n >= MIN_SHADOW_N
-                → upsert { sharpe: shadow.sharpe * SHADOW_HAIRCUT, n: shadow.n }
-            else
-                → skip upsert (row unchanged; reads default to neutral)
-    ↓
-resolveShadowTrades()  (unchanged)
-    ↓ (~6h later, next scoring run)
-MarketScorer.scoreAllMarkets() → typeExpectedValue() → market_score
-    ↓ (every rotation cycle)
-MarketRotator picks top-50 candidates
+    ├── updateCategoryPriors()         ← UNCHANGED. Writes category_performance from live trades.
+    ├── updateShadowCategoryPerformance()  ← NEW. Writes category_performance_shadow with haircut.
+    └── resolveShadowTrades()          ← unchanged
+    ↓ (~30 min later, scoring run)
+MarketScorer.scoreAllMarkets()
+    ├── Loads category_performance        (live, existing)
+    ├── Loads category_performance_shadow (NEW)
+    ├── For each market:
+    │     typeEV    = typeExpectedValue(live_row.sharpe, live_row.n_trades)        ← unchanged formula
+    │     shadowEV  = shadowExpectedValue(shadow_row.sharpe, shadow_row.n_trades)  ← new dim
+    │     composite = weighted_sum(all_dims)                                       ← +0.05 shadow weight
+    └── UPDATE markets.market_score
+    ↓ (next rotation cycle)
+MarketRotator picks top-50 candidates by market_score
 ```
 
-Single function changed (`updateCategoryPriors`); no new services, no schedule changes, no schema changes.
+`updateCategoryPriors` is untouched. Only one new writer (`updateShadowCategoryPerformance`), one new MarketScorer method (`shadowExpectedValue`), and the dim added to the composite weighted sum.
 
-## 4. Concrete SQL queries
+## 5. Schema
 
-### 4.1 Live recent
+### 5.1 Migration `029_category_performance_shadow.sql` (new)
+
+```sql
+CREATE TABLE IF NOT EXISTS category_performance_shadow (
+  market_type     VARCHAR(20)  PRIMARY KEY,
+  win_rate        DOUBLE PRECISION,
+  avg_pnl         DOUBLE PRECISION,
+  sharpe_ratio    DOUBLE PRECISION,
+  n_trades        INTEGER NOT NULL DEFAULT 0,
+  prior           DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+  haircut_applied DOUBLE PRECISION NOT NULL DEFAULT 0.33,
+  updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Bootstrap: empty. updateShadowCategoryPerformance fills it on first daily run.
+```
+
+`haircut_applied` is stored per-row so daily review can audit what haircut was used at write time, even if `SHADOW_HAIRCUT` env var changes later.
+
+### 5.2 Runtime startup hook (mirrors PR #163 pattern)
+
+`bootstrapShadowCategoryPerformanceTable()` runs on dashboard-api startup, idempotent `CREATE TABLE IF NOT EXISTS`. Same try/catch shape as `bootstrapDirectionMultiplierRows`. Required because init/*.sql only fires on first volume creation, and the production VM volume already exists.
+
+## 6. Concrete SQL queries
+
+### 6.1 Live (unchanged from current `updateCategoryPriors`)
 
 ```sql
 SELECT m.market_type,
-       COUNT(*) AS n_trades,
-       AVG(p.realized_pnl) AS avg_pnl,
-       (CASE WHEN STDDEV(p.realized_pnl) > 0
-             THEN AVG(p.realized_pnl) / STDDEV(p.realized_pnl)
-             ELSE 0 END) AS sharpe_ratio,
-       AVG(CASE WHEN p.realized_pnl > 0 THEN 1.0 ELSE 0.0 END) AS win_rate
+       COUNT(*)::text AS n_trades,
+       AVG(CASE WHEN p.realized_pnl > 0 THEN 1.0 ELSE 0.0 END)::text AS win_rate,
+       AVG(p.realized_pnl)::text AS avg_pnl,
+       CASE WHEN STDDEV(p.realized_pnl) > 0
+            THEN (AVG(p.realized_pnl) / STDDEV(p.realized_pnl))::text
+            ELSE '0' END AS sharpe_ratio
 FROM paper_positions p
 JOIN markets m ON p.market_id = m.id
 WHERE p.closed_at IS NOT NULL
   AND p.realized_pnl IS NOT NULL
   AND m.market_type IS NOT NULL
-  AND p.closed_at > NOW() - (INTERVAL '1 day' * $1)   -- $1 = CATEGORY_LIVE_RECENT_DAYS
 GROUP BY m.market_type
 ```
 
-### 4.2 Shadow
+No changes — this is the existing query already used by `updateCategoryPriors`.
+
+### 6.2 Shadow (new query in `updateShadowCategoryPerformance`)
 
 ```sql
 SELECT market_type,
@@ -96,183 +154,250 @@ SELECT market_type,
        AVG(theoretical_pnl) AS avg_pnl,
        (CASE WHEN STDDEV(theoretical_pnl) > 0
              THEN AVG(theoretical_pnl) / STDDEV(theoretical_pnl)
-             ELSE 0 END) AS sharpe_ratio,
+             ELSE 0 END) AS raw_sharpe,
        AVG(CASE WHEN theoretical_pnl > 0 THEN 1.0 ELSE 0.0 END) AS win_rate
 FROM shadow_trades
 WHERE resolved_at IS NOT NULL
   AND theoretical_pnl IS NOT NULL
 GROUP BY market_type
+HAVING COUNT(*) >= $1                                  -- $1 = CATEGORY_MIN_SHADOW_N
 ```
 
-No epoch filter on shadow (we use whatever resolved data exists; resolution timestamps are inherently recent because resolution requires market end_date to pass).
+The TS code computes `effective_sharpe = raw_sharpe * SHADOW_HAIRCUT` before upserting into `category_performance_shadow`.
 
-## 5. Constants and env vars
+## 7. MarketScorer changes
+
+### 7.1 New static method
 
 ```typescript
-const CATEGORY_LIVE_RECENT_DAYS = parseInt(process.env.CATEGORY_LIVE_RECENT_DAYS ?? '7', 10);
-const MIN_LIVE_RECENT_N = parseInt(process.env.CATEGORY_MIN_LIVE_RECENT_N ?? '30', 10);
-const MIN_SHADOW_N = parseInt(process.env.CATEGORY_MIN_SHADOW_N ?? '30', 10);
+/**
+ * Shadow Expected Value dimension. Mirrors typeExpectedValue but reads
+ * the haircut-adjusted shadow Sharpe. Returns 0.5 (neutral) when shadow
+ * data is insufficient.
+ */
+static shadowExpectedValue(
+  effectiveSharpe: number | null,
+  nTrades: number,
+  K: number = SCORER_SHRINKAGE_K,
+  MIN_N: number = 5,
+): number {
+  if (!Number.isFinite(K)) K = SCORER_SHRINKAGE_K;
+  if (effectiveSharpe === null || nTrades < MIN_N) return 0.5;
+  const shrunk = (effectiveSharpe * nTrades) / (nTrades + K);
+  return clamp01((shrunk + 1) / 1.5);
+}
+```
+
+Identical formula to the existing `typeExpectedValue`, only differs in data source. Reusing the same shrinkage and mapping keeps the two dimensions on a comparable [0, 1] scale.
+
+### 7.2 Updated WEIGHTS
+
+```typescript
+export const WEIGHTS = {
+  tradeability:       0.1995,  // 0.21 × 0.95
+  liquidity:          0.1615,  // 0.17 × 0.95
+  volatility:         0.1425,  // 0.15 × 0.95
+  ttr:                0.0760,  // 0.08 × 0.95
+  dataQuality:        0.0950,  // 0.10 × 0.95
+  typeExpectedValue:  0.1615,  // 0.17 × 0.95 (formula unchanged; only weight rescales)
+  realizedVolatility: 0.1140,  // 0.12 × 0.95
+  shadowExpectedValue: 0.0500, // NEW
+} as const;
+// Total: 1.0000
+```
+
+A unit test verifies the sum is exactly 1.0 within float tolerance.
+
+### 7.3 Updated `compositeScore`
+
+Add the new dimension to the weighted sum, following the same null-handling pattern as the other always-present dimensions:
+
+```typescript
+weightedSum += dims.shadowExpectedValue * weights.shadowExpectedValue;
+totalWeight += weights.shadowExpectedValue;
+```
+
+When `dims.shadowExpectedValue` is `0.5` neutral (no shadow data), the dimension contributes 0.025 to numerator and 0.05 to denominator — net effect on composite is zero relative drag (it adds equal weight to both sides, leaving normalized score unchanged). This is intentional: types without shadow data are not penalised.
+
+### 7.4 New `loadAllCategoryMetrics`
+
+Replaces the single-source `loadCategoryMetrics`:
+
+```typescript
+static async loadAllCategoryMetrics(): Promise<{
+  live:   Map<string, { sharpe: number | null; n: number }>;
+  shadow: Map<string, { sharpe: number | null; n: number }>;
+}> {
+  // Two queries via Promise.all, both wrapped in try/catch.
+  // Empty maps on any error → both EVs default to 0.5 (neutral).
+}
+```
+
+Old `loadCategoryMetrics` is deleted; nothing else uses it.
+
+### 7.5 `scoreAllMarkets` integration
+
+Where Pass 1 currently calls `MarketScorer.typeExpectedValue(...)` per market_type, also call `MarketScorer.shadowExpectedValue(...)` with the matching shadow row, and pass both into the dimensions object. Same pattern in Pass 2 (enrich tracked).
+
+## 8. Constants & env vars
+
+```typescript
+const CATEGORY_MIN_SHADOW_N = parseInt(process.env.CATEGORY_MIN_SHADOW_N ?? '30', 10);
 const SHADOW_HAIRCUT = parseFloat(process.env.SHADOW_HAIRCUT ?? '0.33');
 ```
 
-All four are env-tunable. If post-deploy validation shows the haircut needs adjustment per type, this stays simple — operator changes the env var, no redeploy needed for the core formula. Per-type haircuts are out of scope (see §10).
+`shadowExpectedValue` weight `0.05` is **not** env-tunable. Changing dimension weights is a deliberate scoring decision that goes through code review.
 
-The user noted that 7 days may be too long or too short — this is the parameter most likely to need tuning. Operator can lower to 5 or 10 days based on observed type sample sizes.
+`SHADOW_HAIRCUT=0.33` is the working empirical estimate from `memory/project_shadow_execution_realism.md`. Sample is small (n_live=16 in time-matched comparison); operator can adjust based on daily review's `implied_haircut` metric (§10).
 
-## 6. Bootstrap behavior
+## 9. Bootstrap behavior
 
-Immediate, no phased migration. The daily 02:45 UTC run that follows the deploy will recompute per type:
+Daily 02:45 UTC run after deploy populates:
 
-| type | pre-deploy `category_performance` | expected post-deploy | notes |
-|---|---|---|---|
-| event_short | sharpe=0.13, n=419, prior=1.06 | sharpe=0.67 (=2.03·0.33), n=444, prior≈1.4 | shadow source; the desired effect |
-| event_financial | sharpe=0.23, n=201 | depends on 7-day live count | likely live source if n_recent ≥ 30 |
-| event_long | sharpe=0.17, n=1317 | sharpe=−0.33 (=−0.99·0.33), n=333, prior≈0.6 | shadow source; correct because allowlist excludes |
-| crypto_intraday | sharpe=0.28, n=8 | row skipped if both n_live<30 and n_shadow<30 | falls back to neutral via MIN_N gate in typeEV |
-| crypto_daily | sharpe=−1.02, n=4 | row skipped | same |
+| type | live (existing) | shadow (new) | typeEV | shadowEV | composite contribution |
+|---|---|---|---|---|---|
+| event_short | sharpe=0.13, n=419 | sharpe=2.03×0.33=0.67, n=444 | 0.749 | ~1.0 | 0.121 + 0.050 = **0.171** |
+| event_financial | sharpe=0.23, n=201 | shadow has 0 resolved | 0.812 | 0.5 (neutral) | 0.131 + 0.025 = **0.156** |
+| event_long | sharpe=0.17, n=1317 | sharpe=−0.99×0.33=−0.33, n=333 | 0.778 | ~0.46 | 0.126 + 0.023 = **0.149** |
+| crypto_intraday | sharpe=0.28, n=8 (insufficient) | shadow has 0 resolved | 0.5 (neutral) | 0.5 (neutral) | 0.081 + 0.025 = **0.106** |
+| crypto_daily | sharpe=−1.02, n=4 (insufficient) | shadow has 0 resolved | 0.5 (neutral) | 0.5 (neutral) | 0.081 + 0.025 = **0.106** |
 
-**No DELETE statements** — rows for types with insufficient evidence are simply not upserted. Their stale `sharpe_ratio` value is preserved but irrelevant because `typeExpectedValue` returns 0.5 when `n_trades < 5`.
+Key effects:
+- **event_short overtakes event_financial in scoring contribution** (0.171 vs 0.156) for the first time.
+- **event_long** stays scored but lower — fine because allowlist excludes it from the live executor.
+- **crypto_***: no change (no shadow data, no live sample). Still gated by Crypto Data Gap upstream.
 
-## 7. Daily review validation query
+The pool composition should shift: event_short candidates rise in the top-50 ranking, displacing some event_financial candidates over the next 1-2 rotation cycles.
 
-To monitor whether the 0.33 haircut is behaving as expected, the daily review's prompt (`scripts/daily-review-prompt.md`) gains a new section:
+## 10. Daily review validation query
+
+Updates to `scripts/daily-review-prompt.md` add:
 
 ```sql
--- Compare effective vs realized Sharpe per shadow-sourced type
-WITH live_recent AS (
-  SELECT m.market_type,
-         COUNT(*) AS n_live,
-         CASE WHEN STDDEV(p.realized_pnl) > 0
-              THEN AVG(p.realized_pnl) / STDDEV(p.realized_pnl)
-              ELSE NULL END AS live_sharpe
-  FROM paper_positions p JOIN markets m ON p.market_id = m.id
-  WHERE p.closed_at > NOW() - INTERVAL '7 days'
-    AND p.realized_pnl IS NOT NULL
-  GROUP BY m.market_type
-),
-shadow AS (
-  SELECT market_type,
-         COUNT(*) AS n_shadow,
-         CASE WHEN STDDEV(theoretical_pnl) > 0
-              THEN AVG(theoretical_pnl) / STDDEV(theoretical_pnl)
-              ELSE NULL END AS shadow_sharpe
-  FROM shadow_trades
-  WHERE resolved_at IS NOT NULL
-  GROUP BY market_type
-)
 SELECT cp.market_type,
-       cp.sharpe_ratio AS effective_sharpe,
-       cp.n_trades,
-       l.live_sharpe AS live_recent_sharpe_actual,
-       l.n_live,
-       s.shadow_sharpe AS shadow_sharpe_raw,
-       s.n_shadow,
-       -- Inferred source by matching n:
-       CASE WHEN cp.n_trades = l.n_live THEN 'live'
-            WHEN cp.n_trades = s.n_shadow THEN 'shadow'
-            ELSE 'unknown' END AS source,
-       -- If shadow source AND live has data, compute the implied haircut:
-       CASE WHEN cp.n_trades = s.n_shadow AND l.n_live >= 5
-            THEN ROUND((l.live_sharpe / NULLIF(s.shadow_sharpe, 0))::numeric, 3)
-            ELSE NULL END AS implied_haircut
+       cp.sharpe_ratio AS live_sharpe,
+       cp.n_trades AS live_n,
+       cps.sharpe_ratio AS shadow_effective_sharpe,
+       cps.n_trades AS shadow_n,
+       cps.haircut_applied,
+       -- Implied haircut: if we know live_sharpe (recent stable signal), what would the
+       -- haircut have to be for shadow_effective to match it?
+       CASE
+         WHEN cp.n_trades >= 30 AND cps.n_trades >= 30 AND cps.sharpe_ratio != 0
+         THEN ROUND(
+           (cp.sharpe_ratio / NULLIF(cps.sharpe_ratio / cps.haircut_applied, 0))::numeric,
+           3
+         )
+         ELSE NULL
+       END AS implied_haircut
 FROM category_performance cp
-LEFT JOIN live_recent l ON l.market_type = cp.market_type
-LEFT JOIN shadow s ON s.market_type = cp.market_type
+LEFT JOIN category_performance_shadow cps ON cps.market_type = cp.market_type
 ORDER BY cp.market_type;
 ```
 
-Daily review interpretation rules (added to prompt):
-- For each `source='shadow'` row with `implied_haircut` available, alert if `|implied_haircut − 0.33| > 0.20`.
-- After ≥5 shadow-source types accumulate ≥30 live trades each (informally, after 1–2 weeks of shadow-driven promotion), recommend revisiting the haircut value.
+Daily review interpretation rules:
+- For each row with both live and shadow data ≥30 trades, the `implied_haircut` should be in `[0.15, 0.55]` (approximately the 0.33 ± 0.20 band). Outside that band → flag for per-type haircut consideration.
+- For types with shadow data but no live data (e.g. event_short until rotation pulls it in), the shadow signal is the only evidence — note in review that we are operating on shadow-only.
+- Sign disagreement (live positive, shadow negative or vice versa) is a regime-divergence flag — surface for human review.
 
-## 8. Test plan
-
-### 8.1 Unit tests for `updateCategoryPriors`
-
-Mock `query` to return live/shadow rows, assert the upsert calls match expected source-routing decisions.
-
-```typescript
-// Test 1: live ≥ 30 wins over shadow
-//   live: n=50, sharpe=0.5
-//   shadow: n=400, sharpe=2.0
-//   → upsert with sharpe=0.5, n=50
-
-// Test 2: live < 30, shadow ≥ 30 → shadow with haircut
-//   live: n=10, sharpe=0.1
-//   shadow: n=400, sharpe=2.0
-//   → upsert with sharpe=0.66, n=400
-
-// Test 3: live < 30, shadow < 30 → no upsert for that type
-//   live: n=5, shadow: n=10
-//   → upsert NOT called for that market_type
-
-// Test 4: env override of SHADOW_HAIRCUT
-//   process.env.SHADOW_HAIRCUT = '0.5'
-//   shadow sharpe 2.0 → upsert sharpe=1.0
-
-// Test 5: env override of CATEGORY_LIVE_RECENT_DAYS
-//   passed as parameter to query
-
-// Test 6: no live and no shadow → no upsert at all (no rows in either query)
-```
-
-### 8.2 SQL syntax test
-
-The two queries are concrete strings. Test them by mocking `query` and asserting:
-- The SQL contains `INTERVAL '1 day' *` parameterised input.
-- The shadow query has no time filter beyond `resolved_at IS NOT NULL`.
-
-### 8.3 Integration smoke
-
-The daily review query (§7) runs against a fresh seed of paper_positions + shadow_trades; assert it returns rows with sane `source` inference.
-
-## 9. Files touched
+## 11. Files touched
 
 ```
-packages/data-collector/src/services/MarketPerformanceTracker.ts                [refactor updateCategoryPriors]
-packages/data-collector/src/services/MarketPerformanceTracker.test.ts           [+6 tests for routing]
-scripts/daily-review-prompt.md                                                   [+haircut validation section]
-docs/plans/2026-05-01-shadow-haircut-scorer-integration-design.md               [this spec]
+packages/data-collector/src/database/init/029_category_performance_shadow.sql       [new schema]
+packages/data-collector/src/services/MarketPerformanceTracker.ts                    [+updateShadowCategoryPerformance; updateCategoryPriors unchanged]
+packages/data-collector/src/services/MarketPerformanceTracker.test.ts               [+tests for new writer + haircut env]
+packages/data-collector/src/services/MarketScorer.ts                                [+shadowExpectedValue method; rescaled WEIGHTS; updated compositeScore; new loadAllCategoryMetrics]
+packages/data-collector/src/services/MarketScorer.test.ts                           [+tests for new dim, weight invariants, two-source composite]
+packages/dashboard/src/services/bootstrapShadowCategoryPerformance.ts               [new — runtime startup hook]
+packages/dashboard/src/services/bootstrapShadowCategoryPerformance.test.ts          [new — unit test for SQL string]
+packages/dashboard/src/server.ts                                                    [+wire bootstrap hook]
+scripts/daily-review-prompt.md                                                      [+shadow validation section]
+docs/plans/2026-05-01-shadow-haircut-scorer-integration-design.md                   [this spec]
 ```
 
-No schema migration. No new files. No env vars added to docker-compose by default (operator opts in if non-default values needed).
+Estimated scope: 5 files modified + 4 files new. Total ≈ 300 LOC, dominated by tests. Single PR.
 
-Estimated scope: 1 file refactored + 1 test file extended + 1 prompt updated + 1 doc. ~150 LOC mostly tests.
+## 12. Test plan
 
-## 10. Non-goals / Out of scope
+### 12.1 Unit tests
 
-- **Per-type haircuts**: a single global haircut is a deliberate simplification. If post-deploy review shows event_short and event_long need different haircuts, a follow-up PR introduces a per-type override map (e.g. `SHADOW_HAIRCUT_EVENT_SHORT`).
-- **Shadow execution-realism fix at the source**: applying realistic fees/slippage to `shadow_trades.theoretical_pnl` (option 1 in `project_shadow_execution_realism.md`) remains deferred. The haircut here treats the symptom, not the cause. That work is multi-session.
-- **Adaptive haircut**: feedback-loop where the haircut auto-adjusts from observed live/shadow ratios. Mentioned in §7 as "after ≥5 types validate, revisit". Not implemented now.
-- **Bootstrapping new types**: types that newly enter shadow-tracked but have <30 shadow_resolved fall back to neutral. They will rise organically as shadow accumulates resolutions. No special-case bootstrap logic.
+- **`MarketScorer.shadowExpectedValue`**: same coverage as existing `typeExpectedValue` tests (boundary cases, MIN_N=5, NaN handling, K shrinkage, clamp to [0, 1]).
+- **`MarketScorer.WEIGHTS`**: assert sum equals 1.0 within float tolerance.
+- **`MarketScorer.compositeScore`**: 
+    - shadowEV present → contributes 0.05 weight to weighted sum.
+    - shadowEV null → renormalises remaining dims (existing optional-dim pattern).
+    - shadowEV 0.5 (neutral) on a type with no shadow data → composite identical to no-shadow-dim baseline within float tolerance.
+- **`MarketPerformanceTracker.updateShadowCategoryPerformance`**:
+    - Applies haircut to raw shadow Sharpe before upsert.
+    - Stores `haircut_applied` per row.
+    - Skips upsert when `n_trades < CATEGORY_MIN_SHADOW_N`.
+    - Honors `SHADOW_HAIRCUT` env var override.
+- **`bootstrapShadowCategoryPerformance`**: SQL contains `CREATE TABLE IF NOT EXISTS category_performance_shadow`; idempotent.
 
-## 11. Validation post-deploy
+### 12.2 Regression
 
-Immediate (within ~30 minutes after first 02:45 UTC run after deploy):
+- Existing `MarketScorer` tests pass with the rescaled WEIGHTS (existing tests should not assert weights individually; if they do, update them to the new values).
+- Existing `MarketPerformanceTracker.computePrior` tests unchanged (the prior formula is reused for both writers).
+
+### 12.3 Smoke (post-deploy)
+
+§10 daily review query returns rows for both tables, with `implied_haircut` computed where both have ≥30 trades.
+
+## 13. Validation post-deploy
+
+### 13.1 Immediate (within 1 hour after first 02:45 UTC daily run)
 
 ```sql
--- Confirm category_performance reflects the new logic
-SELECT market_type, sharpe_ratio, n_trades, prior, updated_at::timestamp(0)
-FROM category_performance
-ORDER BY market_type;
--- Expected: event_short row updated_at recent; sharpe_ratio ≈ 0.67
+SELECT * FROM category_performance_shadow ORDER BY market_type;
+```
+Expected: rows for `event_long` and `event_short` (the two types with shadow_resolved ≥ 30); `haircut_applied = 0.33`; `sharpe_ratio` = raw_shadow_Sharpe × 0.33.
+
+### 13.2 After 24 hours
+
+Pool composition shift:
+
+```sql
+SELECT m.market_type,
+       COUNT(*) FILTER (WHERE m.tracking_status = 'active') AS active,
+       COUNT(*) FILTER (WHERE m.tracking_status = 'cold' AND m.market_score >= 0.6) AS cold_top
+FROM markets m
+WHERE m.is_active = true AND m.is_resolved = false
+GROUP BY m.market_type ORDER BY m.market_type;
 ```
 
-After 24 hours:
-- Run the §7 daily review query manually.
-- Verify `event_short` is `source=shadow` with `effective_sharpe ≈ 0.67`.
-- Verify `MarketScorer` next run produces higher `market_score` for event_short candidates (compare top-50 distribution before/after).
+Compare with pre-deploy snapshot. **Expected: event_short active count rises from 2 toward 5+** as the rotator promotes high-shadow-EV candidates over the next 2-3 rotation cycles.
 
-After 1 week:
-- `event_short` should have ≥30 live trades (assuming rotation now promotes its candidates).
-- Daily review reports `implied_haircut` for `event_short`. If consistently in [0.13, 0.53] (±0.20 of 0.33), haircut OK. Otherwise adjust `SHADOW_HAIRCUT` env var.
+### 13.3 Tuning levers if event_short still starved after 48h
 
-## 12. Risks and mitigations
+In order of preference:
+
+1. **Lower `SHADOW_HAIRCUT=0.20`** — assumes the gap is larger than estimated; shadow gets more aggressive penalty. Reduces event_short shadowEV but only marginally given the big margin. Probably wrong direction.
+2. **Raise `SHADOW_HAIRCUT=0.50`** — assumes shadow over-estimates less than thought; event_short shadowEV stays clamped at 1.0 but shadow contributions for other types get larger. Indirect.
+3. **Follow-up PR raising `shadowExpectedValue` weight** from `0.05` to `0.08–0.10`. The most direct lever if shadow is empirically reliable but underweighted. Requires fresh review.
+4. **Reopen rotator-side z-score-per-type spec**. Last resort because it conflicts with the merit-based-only rule (`feedback_no_diversity_quota.md`).
+
+### 13.4 After 1 week
+
+- Run §10 daily review query.
+- If `implied_haircut` for event_short is consistently in `[0.15, 0.55]`, the universal 0.33 is roughly right. Keep.
+- If consistently outside that band, open follow-up PR for per-type haircut overrides (e.g. `SHADOW_HAIRCUT_EVENT_SHORT`).
+- If event_short live now has ≥30 trades over 7d (rotation working), live is the dominant signal via typeEV; shadow continues as secondary.
+
+## 14. Risks and mitigations
 
 | Risk | Mitigation |
 |---|---|
-| Haircut 0.33 too generous → event_short over-promoted, live performs worse than expected | Daily review validation alerts when implied haircut diverges. Operator lowers `SHADOW_HAIRCUT` env var, no redeploy. Worst case: revert via env `SHADOW_HAIRCUT=0` (effectively disable shadow contribution). |
-| Haircut 0.33 too conservative → event_short still doesn't enter pool | Operator raises `SHADOW_HAIRCUT` env var. Or lower `MIN_LIVE_RECENT_N` so live data with smaller sample takes over. |
-| `event_long` enters pool via shadow | Won't happen: `ALLOWED_MARKET_TYPES` excludes event_long at the executor; the rotator's live lane already filters to allowed types. shadow score change for event_long is harmless. |
-| Sample size n_live=16 is too small to defend 0.33 | Acknowledged in spec §1 and `project_shadow_execution_realism.md`. Validation plan in §7 corrects within 1–2 weeks. |
-| 7-day window misses recent shadow validation | Operator raises `CATEGORY_LIVE_RECENT_DAYS` to 10 or 14 if observation shows too many types falling to shadow path |
+| Universal `SHADOW_HAIRCUT=0.33` poorly calibrated for some types | Daily review surfaces `implied_haircut` per type; per-type override is documented follow-up |
+| Live `category_performance` includes pre-fix historical data that skews typeEV positively for types that have since changed regime | This is preserved deliberately. The shadow dim adds the recent-regime signal; if a type's live history is stale-positive, the shadow data is the corrective signal. event_long demonstrates: typeEV stays positive (0.778) because of historical strong sample, but shadowEV drags it down (0.46) reflecting current adversity. |
+| `0.05` shadow weight too low to move event_short out of starvation | Pre-computed (§9): event_short's composite contribution rises from 0.127 to 0.171, overtaking event_financial's 0.156 by 0.015. Sufficient margin. If post-deploy shows otherwise, §13.3 step 3 raises the weight |
+| Schema migration fails on production | Boot helper in dashboard-api startup, wrapped in try/catch, won't block boot if it fails. Same pattern as PR #163 |
+| event_long enters live executor pool via shadow | Won't happen: `ALLOWED_MARKET_TYPES` excludes event_long downstream. shadow can't bypass that |
+| Shadow data is missing for new types (crypto_*) | They get `shadowEV=0.5` neutral — no penalty, no boost. Composite unchanged for those types. |
+
+## 15. Non-goals / Out of scope
+
+- **Per-type shadow haircuts** (`SHADOW_HAIRCUT_EVENT_SHORT` etc): deliberately deferred. Universal haircut first; per-type override only after data justifies.
+- **Adaptive haircut** that auto-adjusts from live/shadow ratios over time: deferred.
+- **Modeling shadow execution-realism at the source** (subtract simulated stop-loss exits, risk gate rejections, slippage): out of scope. The two-dimension architecture sidesteps this by treating shadow as a separate, downweighted evidence stream.
+- **Time-windowing live data** (`category_performance` over last N days): considered and rejected (§3 rationale). Live history is preserved in full.
+- **Rotator-side z-score-per-type**: explicitly not done in this spec. Last-resort fallback if the scorer change alone is insufficient (§13.3 step 4).

--- a/docs/plans/2026-05-01-shadow-haircut-scorer-integration-design.md
+++ b/docs/plans/2026-05-01-shadow-haircut-scorer-integration-design.md
@@ -1,0 +1,278 @@
+# Shadow Haircut Scorer Integration — Design Spec
+
+**Date:** 2026-05-01
+**Branch:** `feat/shadow-haircut-scorer-integration`
+**Status:** approved, ready for plan
+
+---
+
+## 1. Problem
+
+`event_short` shadow Sharpe is **+2.03** (n=444 resolved) but its `category_performance.sharpe_ratio` is **+0.13** (n=419 historic live trades, mostly pre-fixes). The `MarketScorer.typeExpectedValue` dimension (weight 0.17) reads exclusively from live data, so event_short's strong shadow validation never reaches the score that drives `MarketRotator` candidate ranking.
+
+Net result: `event_short` has 14 cold candidates with `market_score >= 0.6` but only 2 markets in `tracking_status='active'`. `event_financial` dominates the top-50 candidates query (28/50) because its raw scoring is structurally higher (more volume/liquidity) — not because its signals are more correct.
+
+Today's data (2026-05-01) confirms the bias is asymmetric per type:
+
+| type | live Sharpe (all-time) | shadow Sharpe | n_live | n_shadow_resolved |
+|---|---|---|---|---|
+| event_long | +0.17 | −0.99 | 1317 | 333 |
+| event_short | +0.13 | +2.03 | 419 | 444 |
+| event_financial | +0.23 | (0 resolved) | 201 | 0 |
+
+The all-time live numbers are not representative of the current regime: event_long was removed from `ALLOWED_MARKET_TYPES` after shadow flagged it; event_short is starved by the rotator; event_financial has live recent flow but historical Sharpe predates dm-per-type fixes.
+
+## 2. Solution
+
+Modify `MarketPerformanceTracker.updateCategoryPriors()` to compute `category_performance.sharpe_ratio` per market_type using a routing rule:
+
+1. **Live recent (preferred)**: if `live_n_recent >= 30` (closed positions in last 7 days), use the time-windowed live Sharpe.
+2. **Shadow with empirical haircut (fallback)**: if `shadow_n_resolved >= 30`, use `shadow_sharpe × 0.33`.
+3. **Insufficient evidence**: skip the upsert. The row falls back to the seed/prior state, and `MarketScorer.typeExpectedValue` returns its neutral 0.5 default when `n_trades < 5`.
+
+The 0.33 haircut is the time-matched live/shadow Sharpe ratio observed for `event_long` in the shadow's epoch (2026-04-13 to 2026-04-21, n_live=16, n_shadow=333). It approximates the absent-fees-and-slippage gap. The sample is small; the haircut is a **working hypothesis** to validate post-deploy, not a calibrated constant. Documented in `memory/project_shadow_execution_realism.md`.
+
+The MarketScorer integration is unchanged: `typeExpectedValue` reads `category_performance.sharpe_ratio` and `n_trades` as today; only the writer changes.
+
+## 3. Architecture / Data flow
+
+```
+Scheduler (daily 02:45 UTC)
+    ↓
+computeMarketPriors()
+    ↓
+updateCategoryPriors()  ← refactored
+    ├── Query 1: live recent Sharpe per type
+    │       paper_positions JOIN markets
+    │       WHERE closed_at > NOW() - INTERVAL '<window> days'
+    │       GROUP BY market_type
+    ├── Query 2: shadow Sharpe per type
+    │       shadow_trades
+    │       WHERE resolved_at IS NOT NULL
+    │       GROUP BY market_type
+    └── JS-side merge per market_type:
+            if live.n >= MIN_LIVE_RECENT_N
+                → upsert { sharpe: live.sharpe, n: live.n }
+            elif shadow.n >= MIN_SHADOW_N
+                → upsert { sharpe: shadow.sharpe * SHADOW_HAIRCUT, n: shadow.n }
+            else
+                → skip upsert (row unchanged; reads default to neutral)
+    ↓
+resolveShadowTrades()  (unchanged)
+    ↓ (~6h later, next scoring run)
+MarketScorer.scoreAllMarkets() → typeExpectedValue() → market_score
+    ↓ (every rotation cycle)
+MarketRotator picks top-50 candidates
+```
+
+Single function changed (`updateCategoryPriors`); no new services, no schedule changes, no schema changes.
+
+## 4. Concrete SQL queries
+
+### 4.1 Live recent
+
+```sql
+SELECT m.market_type,
+       COUNT(*) AS n_trades,
+       AVG(p.realized_pnl) AS avg_pnl,
+       (CASE WHEN STDDEV(p.realized_pnl) > 0
+             THEN AVG(p.realized_pnl) / STDDEV(p.realized_pnl)
+             ELSE 0 END) AS sharpe_ratio,
+       AVG(CASE WHEN p.realized_pnl > 0 THEN 1.0 ELSE 0.0 END) AS win_rate
+FROM paper_positions p
+JOIN markets m ON p.market_id = m.id
+WHERE p.closed_at IS NOT NULL
+  AND p.realized_pnl IS NOT NULL
+  AND m.market_type IS NOT NULL
+  AND p.closed_at > NOW() - (INTERVAL '1 day' * $1)   -- $1 = CATEGORY_LIVE_RECENT_DAYS
+GROUP BY m.market_type
+```
+
+### 4.2 Shadow
+
+```sql
+SELECT market_type,
+       COUNT(*) AS n_trades,
+       AVG(theoretical_pnl) AS avg_pnl,
+       (CASE WHEN STDDEV(theoretical_pnl) > 0
+             THEN AVG(theoretical_pnl) / STDDEV(theoretical_pnl)
+             ELSE 0 END) AS sharpe_ratio,
+       AVG(CASE WHEN theoretical_pnl > 0 THEN 1.0 ELSE 0.0 END) AS win_rate
+FROM shadow_trades
+WHERE resolved_at IS NOT NULL
+  AND theoretical_pnl IS NOT NULL
+GROUP BY market_type
+```
+
+No epoch filter on shadow (we use whatever resolved data exists; resolution timestamps are inherently recent because resolution requires market end_date to pass).
+
+## 5. Constants and env vars
+
+```typescript
+const CATEGORY_LIVE_RECENT_DAYS = parseInt(process.env.CATEGORY_LIVE_RECENT_DAYS ?? '7', 10);
+const MIN_LIVE_RECENT_N = parseInt(process.env.CATEGORY_MIN_LIVE_RECENT_N ?? '30', 10);
+const MIN_SHADOW_N = parseInt(process.env.CATEGORY_MIN_SHADOW_N ?? '30', 10);
+const SHADOW_HAIRCUT = parseFloat(process.env.SHADOW_HAIRCUT ?? '0.33');
+```
+
+All four are env-tunable. If post-deploy validation shows the haircut needs adjustment per type, this stays simple — operator changes the env var, no redeploy needed for the core formula. Per-type haircuts are out of scope (see §10).
+
+The user noted that 7 days may be too long or too short — this is the parameter most likely to need tuning. Operator can lower to 5 or 10 days based on observed type sample sizes.
+
+## 6. Bootstrap behavior
+
+Immediate, no phased migration. The daily 02:45 UTC run that follows the deploy will recompute per type:
+
+| type | pre-deploy `category_performance` | expected post-deploy | notes |
+|---|---|---|---|
+| event_short | sharpe=0.13, n=419, prior=1.06 | sharpe=0.67 (=2.03·0.33), n=444, prior≈1.4 | shadow source; the desired effect |
+| event_financial | sharpe=0.23, n=201 | depends on 7-day live count | likely live source if n_recent ≥ 30 |
+| event_long | sharpe=0.17, n=1317 | sharpe=−0.33 (=−0.99·0.33), n=333, prior≈0.6 | shadow source; correct because allowlist excludes |
+| crypto_intraday | sharpe=0.28, n=8 | row skipped if both n_live<30 and n_shadow<30 | falls back to neutral via MIN_N gate in typeEV |
+| crypto_daily | sharpe=−1.02, n=4 | row skipped | same |
+
+**No DELETE statements** — rows for types with insufficient evidence are simply not upserted. Their stale `sharpe_ratio` value is preserved but irrelevant because `typeExpectedValue` returns 0.5 when `n_trades < 5`.
+
+## 7. Daily review validation query
+
+To monitor whether the 0.33 haircut is behaving as expected, the daily review's prompt (`scripts/daily-review-prompt.md`) gains a new section:
+
+```sql
+-- Compare effective vs realized Sharpe per shadow-sourced type
+WITH live_recent AS (
+  SELECT m.market_type,
+         COUNT(*) AS n_live,
+         CASE WHEN STDDEV(p.realized_pnl) > 0
+              THEN AVG(p.realized_pnl) / STDDEV(p.realized_pnl)
+              ELSE NULL END AS live_sharpe
+  FROM paper_positions p JOIN markets m ON p.market_id = m.id
+  WHERE p.closed_at > NOW() - INTERVAL '7 days'
+    AND p.realized_pnl IS NOT NULL
+  GROUP BY m.market_type
+),
+shadow AS (
+  SELECT market_type,
+         COUNT(*) AS n_shadow,
+         CASE WHEN STDDEV(theoretical_pnl) > 0
+              THEN AVG(theoretical_pnl) / STDDEV(theoretical_pnl)
+              ELSE NULL END AS shadow_sharpe
+  FROM shadow_trades
+  WHERE resolved_at IS NOT NULL
+  GROUP BY market_type
+)
+SELECT cp.market_type,
+       cp.sharpe_ratio AS effective_sharpe,
+       cp.n_trades,
+       l.live_sharpe AS live_recent_sharpe_actual,
+       l.n_live,
+       s.shadow_sharpe AS shadow_sharpe_raw,
+       s.n_shadow,
+       -- Inferred source by matching n:
+       CASE WHEN cp.n_trades = l.n_live THEN 'live'
+            WHEN cp.n_trades = s.n_shadow THEN 'shadow'
+            ELSE 'unknown' END AS source,
+       -- If shadow source AND live has data, compute the implied haircut:
+       CASE WHEN cp.n_trades = s.n_shadow AND l.n_live >= 5
+            THEN ROUND((l.live_sharpe / NULLIF(s.shadow_sharpe, 0))::numeric, 3)
+            ELSE NULL END AS implied_haircut
+FROM category_performance cp
+LEFT JOIN live_recent l ON l.market_type = cp.market_type
+LEFT JOIN shadow s ON s.market_type = cp.market_type
+ORDER BY cp.market_type;
+```
+
+Daily review interpretation rules (added to prompt):
+- For each `source='shadow'` row with `implied_haircut` available, alert if `|implied_haircut − 0.33| > 0.20`.
+- After ≥5 shadow-source types accumulate ≥30 live trades each (informally, after 1–2 weeks of shadow-driven promotion), recommend revisiting the haircut value.
+
+## 8. Test plan
+
+### 8.1 Unit tests for `updateCategoryPriors`
+
+Mock `query` to return live/shadow rows, assert the upsert calls match expected source-routing decisions.
+
+```typescript
+// Test 1: live ≥ 30 wins over shadow
+//   live: n=50, sharpe=0.5
+//   shadow: n=400, sharpe=2.0
+//   → upsert with sharpe=0.5, n=50
+
+// Test 2: live < 30, shadow ≥ 30 → shadow with haircut
+//   live: n=10, sharpe=0.1
+//   shadow: n=400, sharpe=2.0
+//   → upsert with sharpe=0.66, n=400
+
+// Test 3: live < 30, shadow < 30 → no upsert for that type
+//   live: n=5, shadow: n=10
+//   → upsert NOT called for that market_type
+
+// Test 4: env override of SHADOW_HAIRCUT
+//   process.env.SHADOW_HAIRCUT = '0.5'
+//   shadow sharpe 2.0 → upsert sharpe=1.0
+
+// Test 5: env override of CATEGORY_LIVE_RECENT_DAYS
+//   passed as parameter to query
+
+// Test 6: no live and no shadow → no upsert at all (no rows in either query)
+```
+
+### 8.2 SQL syntax test
+
+The two queries are concrete strings. Test them by mocking `query` and asserting:
+- The SQL contains `INTERVAL '1 day' *` parameterised input.
+- The shadow query has no time filter beyond `resolved_at IS NOT NULL`.
+
+### 8.3 Integration smoke
+
+The daily review query (§7) runs against a fresh seed of paper_positions + shadow_trades; assert it returns rows with sane `source` inference.
+
+## 9. Files touched
+
+```
+packages/data-collector/src/services/MarketPerformanceTracker.ts                [refactor updateCategoryPriors]
+packages/data-collector/src/services/MarketPerformanceTracker.test.ts           [+6 tests for routing]
+scripts/daily-review-prompt.md                                                   [+haircut validation section]
+docs/plans/2026-05-01-shadow-haircut-scorer-integration-design.md               [this spec]
+```
+
+No schema migration. No new files. No env vars added to docker-compose by default (operator opts in if non-default values needed).
+
+Estimated scope: 1 file refactored + 1 test file extended + 1 prompt updated + 1 doc. ~150 LOC mostly tests.
+
+## 10. Non-goals / Out of scope
+
+- **Per-type haircuts**: a single global haircut is a deliberate simplification. If post-deploy review shows event_short and event_long need different haircuts, a follow-up PR introduces a per-type override map (e.g. `SHADOW_HAIRCUT_EVENT_SHORT`).
+- **Shadow execution-realism fix at the source**: applying realistic fees/slippage to `shadow_trades.theoretical_pnl` (option 1 in `project_shadow_execution_realism.md`) remains deferred. The haircut here treats the symptom, not the cause. That work is multi-session.
+- **Adaptive haircut**: feedback-loop where the haircut auto-adjusts from observed live/shadow ratios. Mentioned in §7 as "after ≥5 types validate, revisit". Not implemented now.
+- **Bootstrapping new types**: types that newly enter shadow-tracked but have <30 shadow_resolved fall back to neutral. They will rise organically as shadow accumulates resolutions. No special-case bootstrap logic.
+
+## 11. Validation post-deploy
+
+Immediate (within ~30 minutes after first 02:45 UTC run after deploy):
+
+```sql
+-- Confirm category_performance reflects the new logic
+SELECT market_type, sharpe_ratio, n_trades, prior, updated_at::timestamp(0)
+FROM category_performance
+ORDER BY market_type;
+-- Expected: event_short row updated_at recent; sharpe_ratio ≈ 0.67
+```
+
+After 24 hours:
+- Run the §7 daily review query manually.
+- Verify `event_short` is `source=shadow` with `effective_sharpe ≈ 0.67`.
+- Verify `MarketScorer` next run produces higher `market_score` for event_short candidates (compare top-50 distribution before/after).
+
+After 1 week:
+- `event_short` should have ≥30 live trades (assuming rotation now promotes its candidates).
+- Daily review reports `implied_haircut` for `event_short`. If consistently in [0.13, 0.53] (±0.20 of 0.33), haircut OK. Otherwise adjust `SHADOW_HAIRCUT` env var.
+
+## 12. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Haircut 0.33 too generous → event_short over-promoted, live performs worse than expected | Daily review validation alerts when implied haircut diverges. Operator lowers `SHADOW_HAIRCUT` env var, no redeploy. Worst case: revert via env `SHADOW_HAIRCUT=0` (effectively disable shadow contribution). |
+| Haircut 0.33 too conservative → event_short still doesn't enter pool | Operator raises `SHADOW_HAIRCUT` env var. Or lower `MIN_LIVE_RECENT_N` so live data with smaller sample takes over. |
+| `event_long` enters pool via shadow | Won't happen: `ALLOWED_MARKET_TYPES` excludes event_long at the executor; the rotator's live lane already filters to allowed types. shadow score change for event_long is harmless. |
+| Sample size n_live=16 is too small to defend 0.33 | Acknowledged in spec §1 and `project_shadow_execution_realism.md`. Validation plan in §7 corrects within 1–2 weeks. |
+| 7-day window misses recent shadow validation | Operator raises `CATEGORY_LIVE_RECENT_DAYS` to 10 or 14 if observation shows too many types falling to shadow path |

--- a/docs/plans/2026-05-01-shadow-haircut-scorer-integration-plan.md
+++ b/docs/plans/2026-05-01-shadow-haircut-scorer-integration-plan.md
@@ -1,0 +1,1343 @@
+# Shadow Haircut Scorer Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `shadowExpectedValue` dimension (weight 0.05) to `MarketScorer` fed by a new `category_performance_shadow` table, computed from `shadow_trades` resolved with empirical haircut 0.33. Live `category_performance` and `typeExpectedValue` remain untouched (purely additive).
+
+**Architecture:** Two parallel writers in `computeMarketPriors()`: existing `updateCategoryPriors` (live) + new `updateShadowCategoryPerformance` (shadow with haircut applied). MarketScorer loads both per-type metric maps and contributes them to the composite score. All other dimensions are rescaled by `0.95` so weights still sum to 1.0.
+
+**Tech Stack:** TypeScript + Vitest, pnpm monorepo. PostgreSQL/TimescaleDB. Spec: `docs/plans/2026-05-01-shadow-haircut-scorer-integration-design.md`.
+
+---
+
+## File Structure
+
+| Path | Change | Responsibility |
+|---|---|---|
+| `packages/data-collector/src/database/init/029_category_performance_shadow.sql` | Create | Idempotent `CREATE TABLE IF NOT EXISTS` for new table |
+| `packages/dashboard/src/services/bootstrapShadowCategoryPerformance.ts` | Create | Runtime startup helper that runs the same `CREATE TABLE IF NOT EXISTS` so existing VM volumes get the new table without re-init |
+| `packages/dashboard/src/services/bootstrapShadowCategoryPerformance.test.ts` | Create | Unit test for the SQL string |
+| `packages/dashboard/src/server.ts` | Modify (alongside other startup hooks) | Wire the new bootstrap call inside the existing `if (dbHealth.connected)` block |
+| `packages/data-collector/src/services/MarketScorer.ts` | Modify | New `shadowExpectedValue` static method; `WEIGHTS` rescaled (×0.95 for the 7 existing, +0.05 for shadow); `ScoreDimensions` interface extended; `compositeScore` adds the new dimension; `loadCategoryMetrics` replaced by `loadAllCategoryMetrics` returning both maps; `scoreAllMarkets` passes shadow EV through both passes; `loadWeights` includes shadowExpectedValue in returned ScorerWeights |
+| `packages/data-collector/src/services/MarketScorer.test.ts` | Modify | New tests for `shadowExpectedValue`, `WEIGHTS` total = 1.0, two-source `compositeScore` |
+| `packages/data-collector/src/services/MarketPerformanceTracker.ts` | Modify | New exported function `updateShadowCategoryPerformance()`. `updateCategoryPriors()` is **untouched** |
+| `packages/data-collector/src/services/MarketPerformanceTracker.test.ts` | Modify | New tests for `updateShadowCategoryPerformance` (haircut applied, env override, MIN_N gate) |
+| `packages/data-collector/src/services/Scheduler.ts` | Modify | Inside `computeMarketPriors()`, add `await updateShadowCategoryPerformance()` after the existing `updateCategoryPriors()` call |
+| `scripts/daily-review-prompt.md` | Modify | Append a "Shadow haircut validation" section that explains the implied-haircut query and the alert thresholds |
+
+No DB migrations beyond the new table. No env vars in docker-compose changed by default. `SHADOW_HAIRCUT` and `CATEGORY_MIN_SHADOW_N` are env-tunable but use defaults.
+
+---
+
+### Task 1: Migration 029 + runtime bootstrap helper
+
+**Files:**
+- Create: `packages/data-collector/src/database/init/029_category_performance_shadow.sql`
+- Create: `packages/dashboard/src/services/bootstrapShadowCategoryPerformance.ts`
+- Create: `packages/dashboard/src/services/bootstrapShadowCategoryPerformance.test.ts`
+
+- [ ] **Step 1: Write the migration**
+
+Create `packages/data-collector/src/database/init/029_category_performance_shadow.sql` with this exact content:
+
+```sql
+-- Mirrors category_performance schema but stores shadow-derived metrics with
+-- an applied haircut. See docs/plans/2026-05-01-shadow-haircut-scorer-integration-design.md.
+
+CREATE TABLE IF NOT EXISTS category_performance_shadow (
+  market_type     VARCHAR(20)  PRIMARY KEY,
+  win_rate        DOUBLE PRECISION,
+  avg_pnl         DOUBLE PRECISION,
+  sharpe_ratio    DOUBLE PRECISION,
+  n_trades        INTEGER NOT NULL DEFAULT 0,
+  prior           DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+  haircut_applied DOUBLE PRECISION NOT NULL DEFAULT 0.33,
+  updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+- [ ] **Step 2: Write failing test for bootstrap helper**
+
+Create `packages/dashboard/src/services/bootstrapShadowCategoryPerformance.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../database/index.js', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '../database/index.js';
+import { bootstrapShadowCategoryPerformanceTable } from './bootstrapShadowCategoryPerformance.js';
+
+describe('bootstrapShadowCategoryPerformanceTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('issues a CREATE TABLE IF NOT EXISTS for category_performance_shadow', async () => {
+    (query as any).mockResolvedValueOnce({ rows: [] });
+    await bootstrapShadowCategoryPerformanceTable();
+    expect(query).toHaveBeenCalledTimes(1);
+    const sql = (query as any).mock.calls[0][0] as string;
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS category_performance_shadow/);
+    expect(sql).toMatch(/PRIMARY KEY/);
+    expect(sql).toMatch(/haircut_applied DOUBLE PRECISION NOT NULL DEFAULT 0\.33/);
+    expect(sql).toMatch(/sharpe_ratio DOUBLE PRECISION/);
+  });
+});
+```
+
+- [ ] **Step 3: Run test, verify it FAILS**
+
+```bash
+cd packages/dashboard
+pnpm test bootstrapShadowCategoryPerformance.test.ts
+```
+
+Expected: FAIL — module `./bootstrapShadowCategoryPerformance.js` not found.
+
+- [ ] **Step 4: Implement the helper**
+
+Create `packages/dashboard/src/services/bootstrapShadowCategoryPerformance.ts`:
+
+```typescript
+import { query } from '../database/index.js';
+
+/**
+ * Idempotent runtime creation of the category_performance_shadow table.
+ *
+ * init/029_category_performance_shadow.sql only fires on first volume
+ * creation. Production deployments need this helper at startup so the
+ * table appears without a database wipe. Mirrors the PR #163 pattern
+ * for bootstrapDirectionMultiplierRows.
+ */
+export async function bootstrapShadowCategoryPerformanceTable(): Promise<void> {
+  await query(
+    `CREATE TABLE IF NOT EXISTS category_performance_shadow (
+       market_type     VARCHAR(20)  PRIMARY KEY,
+       win_rate        DOUBLE PRECISION,
+       avg_pnl         DOUBLE PRECISION,
+       sharpe_ratio    DOUBLE PRECISION,
+       n_trades        INTEGER NOT NULL DEFAULT 0,
+       prior           DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+       haircut_applied DOUBLE PRECISION NOT NULL DEFAULT 0.33,
+       updated_at      TIMESTAMPTZ DEFAULT NOW()
+     )`,
+  );
+}
+```
+
+- [ ] **Step 5: Run test, verify it PASSES**
+
+```bash
+cd packages/dashboard
+pnpm test bootstrapShadowCategoryPerformance.test.ts
+```
+
+Expected: 1 test passes.
+
+- [ ] **Step 6: Type-check**
+
+```bash
+cd packages/dashboard
+pnpm tsc --noEmit
+```
+
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+rtk git add packages/data-collector/src/database/init/029_category_performance_shadow.sql \
+            packages/dashboard/src/services/bootstrapShadowCategoryPerformance.ts \
+            packages/dashboard/src/services/bootstrapShadowCategoryPerformance.test.ts
+rtk git commit -m "feat(db): category_performance_shadow table + idempotent runtime bootstrap (029)"
+```
+
+---
+
+### Task 2: Wire runtime bootstrap into server.ts startup
+
+**Files:**
+- Modify: `packages/dashboard/src/server.ts` (alongside `bootstrapDirectionMultiplierRows` call)
+
+- [ ] **Step 1: Locate the existing bootstrap pattern**
+
+```bash
+rtk grep -n "bootstrapDirectionMultiplierRows" packages/dashboard/src/server.ts
+```
+
+Expected: matches around line 34 (import) and line ~430 (call inside the `if (dbHealth.connected)` block).
+
+- [ ] **Step 2: Add import**
+
+In `packages/dashboard/src/server.ts`, add the import next to the existing `bootstrapDirectionMultiplierRows` import:
+
+```typescript
+import { bootstrapShadowCategoryPerformanceTable } from './services/bootstrapShadowCategoryPerformance.js';
+```
+
+- [ ] **Step 3: Add the bootstrap call**
+
+In the same file, locate the `try { await bootstrapDirectionMultiplierRows(); ...` block. Immediately after that block (still inside the `if (dbHealth.connected)` gate), add:
+
+```typescript
+try {
+  await bootstrapShadowCategoryPerformanceTable();
+  console.log('[server] category_performance_shadow table ensured');
+} catch (err) {
+  console.error('[server] Failed to bootstrap category_performance_shadow:', err);
+}
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd packages/dashboard
+pnpm tsc --noEmit
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Run all dashboard tests**
+
+```bash
+cd packages/dashboard
+pnpm test
+```
+
+Expected: all tests pass; baseline +1 from Task 1.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add packages/dashboard/src/server.ts
+rtk git commit -m "feat(server): wire bootstrapShadowCategoryPerformanceTable into startup"
+```
+
+---
+
+### Task 3: `MarketScorer.shadowExpectedValue` static method
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketScorer.ts` (add method, update `ScoreDimensions` interface)
+- Modify: `packages/data-collector/src/services/MarketScorer.test.ts` (add tests)
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `packages/data-collector/src/services/MarketScorer.test.ts`:
+
+```typescript
+describe('MarketScorer.shadowExpectedValue', () => {
+  it('returns 0.5 (neutral) when sharpe is null', () => {
+    expect(MarketScorer.shadowExpectedValue(null, 100)).toBe(0.5);
+  });
+
+  it('returns 0.5 (neutral) when nTrades < MIN_N (5)', () => {
+    expect(MarketScorer.shadowExpectedValue(0.7, 4)).toBe(0.5);
+    expect(MarketScorer.shadowExpectedValue(0.7, 5)).not.toBe(0.5);
+  });
+
+  it('mirrors typeExpectedValue formula for the same inputs', () => {
+    // Identical shrinkage and mapping: expect identical output.
+    const sharpe = 0.5;
+    const n = 100;
+    expect(MarketScorer.shadowExpectedValue(sharpe, n))
+      .toBeCloseTo(MarketScorer.typeExpectedValue(sharpe, n), 6);
+  });
+
+  it('clamps to [0, 1]', () => {
+    expect(MarketScorer.shadowExpectedValue(10, 100)).toBe(1);
+    expect(MarketScorer.shadowExpectedValue(-10, 100)).toBe(0);
+  });
+
+  it('honors K override', () => {
+    const sharpe = 0.5;
+    const n = 100;
+    const default_K = MarketScorer.shadowExpectedValue(sharpe, n);
+    const high_K = MarketScorer.shadowExpectedValue(sharpe, n, 1000);
+    // Higher K shrinks more aggressively → output closer to 0.5.
+    expect(Math.abs(high_K - 0.5)).toBeLessThan(Math.abs(default_K - 0.5));
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+```bash
+cd packages/data-collector
+pnpm test MarketScorer.test.ts -- -t "shadowExpectedValue"
+```
+
+Expected: 5 tests fail — `MarketScorer.shadowExpectedValue is not a function`.
+
+- [ ] **Step 3: Add method to MarketScorer.ts**
+
+In `packages/data-collector/src/services/MarketScorer.ts`, immediately after the existing `typeExpectedValue` static method (~line 210), add:
+
+```typescript
+/**
+ * Shadow Expected Value dimension.
+ *
+ * Reads the haircut-adjusted shadow Sharpe (effectiveSharpe = raw_shadow_Sharpe × SHADOW_HAIRCUT,
+ * applied by the writer in MarketPerformanceTracker.updateShadowCategoryPerformance).
+ * Returns 0.5 (neutral) when shadow data is insufficient (sharpe null or n_trades below MIN_N).
+ *
+ * Identical formula to typeExpectedValue — the only difference is the data source. Reusing the
+ * same shrinkage and clamp mapping keeps both dimensions on a comparable [0, 1] scale, so the
+ * weighted sum in compositeScore behaves predictably.
+ */
+static shadowExpectedValue(
+  effectiveSharpe: number | null,
+  nTrades: number,
+  K: number = SCORER_SHRINKAGE_K,
+  MIN_N: number = 5,
+): number {
+  if (!Number.isFinite(K)) K = SCORER_SHRINKAGE_K;
+  if (effectiveSharpe === null || nTrades < MIN_N) return 0.5;
+  const shrunk = (effectiveSharpe * nTrades) / (nTrades + K);
+  return clamp01((shrunk + 1) / 1.5);
+}
+```
+
+- [ ] **Step 4: Extend `ScoreDimensions` interface**
+
+In the same file (~line 27), update the interface:
+
+```typescript
+export interface ScoreDimensions {
+  tradeability: number;
+  liquidity: number;
+  volatility: number | null;
+  ttr: number;
+  dataQuality: number | null;
+  typeExpectedValue: number;
+  realizedVolatility: number | null;
+  shadowExpectedValue: number;       // NEW — always present (0.5 neutral default)
+}
+```
+
+- [ ] **Step 5: Run tests, verify PASS**
+
+```bash
+cd packages/data-collector
+pnpm test MarketScorer.test.ts -- -t "shadowExpectedValue"
+```
+
+Expected: 5 tests pass. tsc still clean (run `pnpm tsc --noEmit` to confirm).
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add packages/data-collector/src/services/MarketScorer.ts \
+            packages/data-collector/src/services/MarketScorer.test.ts
+rtk git commit -m "feat(scorer): add shadowExpectedValue static method + ScoreDimensions field"
+```
+
+---
+
+### Task 4: Rescale `WEIGHTS` and add `shadowExpectedValue: 0.05`
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketScorer.ts` (`WEIGHTS` constant, `ScorerWeights` interface)
+- Modify: `packages/data-collector/src/services/MarketScorer.test.ts` (weights invariant test, update existing tests that reference WEIGHTS values)
+
+- [ ] **Step 1: Write failing weights-invariant test**
+
+Append to `packages/data-collector/src/services/MarketScorer.test.ts`:
+
+```typescript
+describe('MarketScorer.WEIGHTS', () => {
+  it('all weight values sum to 1.0 (within float tolerance)', () => {
+    const total = Object.values(WEIGHTS).reduce((sum, w) => sum + w, 0);
+    expect(total).toBeCloseTo(1.0, 6);
+  });
+
+  it('shadowExpectedValue weight is 0.05', () => {
+    expect(WEIGHTS.shadowExpectedValue).toBe(0.05);
+  });
+
+  it('typeExpectedValue weight is 0.1615 (rescaled from 0.17 by 0.95)', () => {
+    expect(WEIGHTS.typeExpectedValue).toBeCloseTo(0.1615, 6);
+  });
+});
+```
+
+You will need to import `WEIGHTS` at the top of the test file if it's not already imported:
+
+```typescript
+import { MarketScorer, WEIGHTS } from './MarketScorer.js';
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+```bash
+cd packages/data-collector
+pnpm test MarketScorer.test.ts -- -t "WEIGHTS"
+```
+
+Expected: at least the "shadowExpectedValue weight is 0.05" test fails because `WEIGHTS.shadowExpectedValue` is undefined; the sum test currently passes because old WEIGHTS sum to 1.0 already.
+
+- [ ] **Step 3: Update `WEIGHTS` constant**
+
+In `packages/data-collector/src/services/MarketScorer.ts` (~line 7), replace the `WEIGHTS` object with:
+
+```typescript
+export const WEIGHTS = {
+  tradeability:        0.1995,  // 0.21 × 0.95
+  liquidity:           0.1615,  // 0.17 × 0.95
+  volatility:          0.1425,  // 0.15 × 0.95
+  ttr:                 0.0760,  // 0.08 × 0.95
+  dataQuality:         0.0950,  // 0.10 × 0.95
+  typeExpectedValue:   0.1615,  // 0.17 × 0.95
+  realizedVolatility:  0.1140,  // 0.12 × 0.95
+  shadowExpectedValue: 0.0500,  // NEW
+} as const;
+// Total: 1.0000
+```
+
+- [ ] **Step 4: Update `ScorerWeights` interface**
+
+In the same file (~line 37), add the field to the interface:
+
+```typescript
+export interface ScorerWeights {
+  tradeability: number;
+  liquidity: number;
+  volatility: number;
+  ttr: number;
+  dataQuality: number;
+  typeExpectedValue: number;
+  realizedVolatility: number;
+  shadowExpectedValue: number;     // NEW
+}
+```
+
+- [ ] **Step 5: Update `loadWeights` fallback**
+
+Still in the same file (~line 343, the `weights = row ? { ... } : { ...WEIGHTS }` block), the per-type DB rows do NOT have a `shadow_expected_value` column. Add the field with a fallback to the WEIGHTS default in BOTH branches of the ternary. The branch that constructs from `row` becomes:
+
+```typescript
+weights = row
+  ? {
+      tradeability:        Number(row.tradeability),
+      liquidity:           Number(row.liquidity),
+      volatility:          Number(row.volatility),
+      ttr:                 Number(row.ttr),
+      dataQuality:         Number(row.data_quality),
+      typeExpectedValue:   row.type_expected_value !== null
+        ? Number(row.type_expected_value)
+        : WEIGHTS.typeExpectedValue,
+      realizedVolatility:  row.realized_volatility !== null
+        ? Number(row.realized_volatility)
+        : WEIGHTS.realizedVolatility,
+      shadowExpectedValue: WEIGHTS.shadowExpectedValue,  // NEW — always WEIGHTS default; per-type DB override out of scope
+    }
+  : { ...WEIGHTS };
+```
+
+(The `else` branch `{ ...WEIGHTS }` already includes shadowExpectedValue once the `WEIGHTS` constant is updated.)
+
+- [ ] **Step 6: Run all MarketScorer tests**
+
+```bash
+cd packages/data-collector
+pnpm test MarketScorer.test.ts
+```
+
+Expected: all WEIGHTS tests pass; existing tests should also pass — they don't assert specific weight values directly, they verify behavioural outputs of `compositeScore` and the per-dimension methods. If any existing test asserts a specific WEIGHTS value (e.g. `WEIGHTS.tradeability === 0.21`), update it to the rescaled value (`0.1995`) or to be agnostic of the absolute value.
+
+- [ ] **Step 7: Type-check**
+
+```bash
+cd packages/data-collector
+pnpm tsc --noEmit
+```
+
+Expected: clean. Any tsc error here likely means a downstream consumer destructures `ScorerWeights` and is missing the new field — fix by adding it.
+
+- [ ] **Step 8: Commit**
+
+```bash
+rtk git add packages/data-collector/src/services/MarketScorer.ts \
+            packages/data-collector/src/services/MarketScorer.test.ts
+rtk git commit -m "feat(scorer): rescale WEIGHTS + add shadowExpectedValue=0.05; loadWeights fallback"
+```
+
+---
+
+### Task 5: `compositeScore` integrates `shadowExpectedValue` dimension
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketScorer.ts` (`compositeScore` method)
+- Modify: `packages/data-collector/src/services/MarketScorer.test.ts`
+
+- [ ] **Step 1: Write failing test for compositeScore with shadow dim**
+
+Append to `packages/data-collector/src/services/MarketScorer.test.ts`:
+
+```typescript
+describe('MarketScorer.compositeScore — shadowExpectedValue integration', () => {
+  // All other dims at neutral 0.5 to isolate the shadow contribution.
+  const neutralDims = {
+    tradeability: 0.5,
+    liquidity: 0.5,
+    volatility: 0.5,
+    ttr: 0.5,
+    dataQuality: 0.5,
+    typeExpectedValue: 0.5,
+    realizedVolatility: 0.5,
+  };
+
+  it('shadowEV neutral (0.5) → composite is 0.5 (all dims neutral)', () => {
+    const score = MarketScorer.compositeScore({
+      ...neutralDims,
+      shadowExpectedValue: 0.5,
+    });
+    expect(score).toBeCloseTo(0.5, 6);
+  });
+
+  it('shadowEV at 1.0 lifts composite by 0.025 (= 0.05 × 0.5)', () => {
+    const score = MarketScorer.compositeScore({
+      ...neutralDims,
+      shadowExpectedValue: 1.0,
+    });
+    expect(score).toBeCloseTo(0.525, 6);
+  });
+
+  it('shadowEV at 0.0 drags composite by 0.025', () => {
+    const score = MarketScorer.compositeScore({
+      ...neutralDims,
+      shadowExpectedValue: 0.0,
+    });
+    expect(score).toBeCloseTo(0.475, 6);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+```bash
+cd packages/data-collector
+pnpm test MarketScorer.test.ts -- -t "shadowExpectedValue integration"
+```
+
+Expected: 3 tests fail because `compositeScore` does not yet add `shadowExpectedValue` to the weighted sum.
+
+- [ ] **Step 3: Add the dimension to `compositeScore`**
+
+In `packages/data-collector/src/services/MarketScorer.ts`, in the `compositeScore` method (~line 238), find the `// Always-present dimensions` block and add `shadowExpectedValue` next to `typeExpectedValue`:
+
+```typescript
+// Always-present dimensions
+weightedSum += dims.tradeability * weights.tradeability;
+totalWeight += weights.tradeability;
+
+weightedSum += dims.liquidity * weights.liquidity;
+totalWeight += weights.liquidity;
+
+weightedSum += dims.ttr * weights.ttr;
+totalWeight += weights.ttr;
+
+weightedSum += dims.typeExpectedValue * weights.typeExpectedValue;
+totalWeight += weights.typeExpectedValue;
+
+// NEW — shadowExpectedValue is always present (returns 0.5 neutral when missing data)
+weightedSum += dims.shadowExpectedValue * weights.shadowExpectedValue;
+totalWeight += weights.shadowExpectedValue;
+```
+
+- [ ] **Step 4: Run tests, verify PASS**
+
+```bash
+cd packages/data-collector
+pnpm test MarketScorer.test.ts
+```
+
+Expected: 3 new tests pass + every existing test still passes. The full file (`pnpm test`) should also pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add packages/data-collector/src/services/MarketScorer.ts \
+            packages/data-collector/src/services/MarketScorer.test.ts
+rtk git commit -m "feat(scorer): include shadowExpectedValue in compositeScore weighted sum"
+```
+
+---
+
+### Task 6: `loadAllCategoryMetrics` replaces single-source loader
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketScorer.ts` (replace `loadCategoryMetrics`, update callers)
+- Modify: `packages/data-collector/src/services/MarketScorer.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `packages/data-collector/src/services/MarketScorer.test.ts` (after the other describes, before the closing of the file):
+
+```typescript
+import { query } from '../database/connection.js';
+vi.mock('../database/connection.js', () => ({
+  query: vi.fn(),
+}));
+
+describe('MarketScorer.loadAllCategoryMetrics', () => {
+  beforeEach(() => {
+    (query as any).mockReset();
+  });
+
+  it('returns parallel maps for live and shadow', async () => {
+    (query as any)
+      .mockResolvedValueOnce({  // live
+        rows: [
+          { market_type: 'event_short', sharpe_ratio: '0.13', n_trades: '419' },
+          { market_type: 'event_long', sharpe_ratio: '0.17', n_trades: '1317' },
+        ],
+      })
+      .mockResolvedValueOnce({  // shadow
+        rows: [
+          { market_type: 'event_short', sharpe_ratio: '0.67', n_trades: '444' },
+        ],
+      });
+
+    const { live, shadow } = await MarketScorer.loadAllCategoryMetrics();
+
+    expect(live.get('event_short')).toEqual({ sharpe: 0.13, n: 419 });
+    expect(live.get('event_long')).toEqual({ sharpe: 0.17, n: 1317 });
+    expect(shadow.get('event_short')).toEqual({ sharpe: 0.67, n: 444 });
+    expect(shadow.size).toBe(1);
+  });
+
+  it('returns empty maps on DB error (graceful degradation)', async () => {
+    (query as any).mockRejectedValueOnce(new Error('DB down'));
+    const { live, shadow } = await MarketScorer.loadAllCategoryMetrics();
+    expect(live.size).toBe(0);
+    expect(shadow.size).toBe(0);
+  });
+});
+```
+
+If `vi.mock('../database/connection.js', ...)` is already declared at the top of the test file because of other tests, **don't** redeclare. Otherwise add it once at the top.
+
+- [ ] **Step 2: Run, verify FAIL**
+
+```bash
+cd packages/data-collector
+pnpm test MarketScorer.test.ts -- -t "loadAllCategoryMetrics"
+```
+
+Expected: 2 tests fail — `MarketScorer.loadAllCategoryMetrics is not a function`.
+
+- [ ] **Step 3: Replace `loadCategoryMetrics` with `loadAllCategoryMetrics`**
+
+In `packages/data-collector/src/services/MarketScorer.ts`, replace the existing `loadCategoryMetrics` static method (~line 361) with:
+
+```typescript
+/**
+ * Load both live and shadow category metrics in parallel.
+ * Returned numerics are coerced from pg strings.
+ * Falls back to empty maps on any error (table missing, DB down, etc.).
+ *
+ * Live source: category_performance (existing).
+ * Shadow source: category_performance_shadow (new in this PR; sharpe_ratio is
+ * already haircut-adjusted by the writer).
+ */
+static async loadAllCategoryMetrics(): Promise<{
+  live: Map<string, { sharpe: number | null; n: number }>;
+  shadow: Map<string, { sharpe: number | null; n: number }>;
+}> {
+  const empty = {
+    live: new Map<string, { sharpe: number | null; n: number }>(),
+    shadow: new Map<string, { sharpe: number | null; n: number }>(),
+  };
+  try {
+    const [liveResult, shadowResult] = await Promise.all([
+      query<{ market_type: string; sharpe_ratio: number | string | null; n_trades: number | string }>(
+        `SELECT market_type, sharpe_ratio, n_trades FROM category_performance`,
+      ),
+      query<{ market_type: string; sharpe_ratio: number | string | null; n_trades: number | string }>(
+        `SELECT market_type, sharpe_ratio, n_trades FROM category_performance_shadow`,
+      ),
+    ]);
+    const live = new Map<string, { sharpe: number | null; n: number }>();
+    for (const r of liveResult.rows) {
+      live.set(r.market_type, {
+        sharpe: r.sharpe_ratio !== null ? Number(r.sharpe_ratio) : null,
+        n: Number(r.n_trades),
+      });
+    }
+    const shadow = new Map<string, { sharpe: number | null; n: number }>();
+    for (const r of shadowResult.rows) {
+      shadow.set(r.market_type, {
+        sharpe: r.sharpe_ratio !== null ? Number(r.sharpe_ratio) : null,
+        n: Number(r.n_trades),
+      });
+    }
+    return { live, shadow };
+  } catch {
+    return empty;
+  }
+}
+```
+
+The old single-source `loadCategoryMetrics` is removed. The only caller is `scoreAllMarkets`, updated in Task 7.
+
+- [ ] **Step 4: Run tests, verify PASS**
+
+```bash
+cd packages/data-collector
+pnpm test MarketScorer.test.ts -- -t "loadAllCategoryMetrics"
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add packages/data-collector/src/services/MarketScorer.ts \
+            packages/data-collector/src/services/MarketScorer.test.ts
+rtk git commit -m "feat(scorer): replace loadCategoryMetrics with loadAllCategoryMetrics (live + shadow)"
+```
+
+---
+
+### Task 7: `scoreAllMarkets` integration — pass shadowEV through both passes
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketScorer.ts` (`scoreAllMarkets`, both passes' dimension construction)
+
+- [ ] **Step 1: Update Pass 1 (cold candidates per-type loop)**
+
+In `packages/data-collector/src/services/MarketScorer.ts`, replace the `const categoryMetrics = await MarketScorer.loadCategoryMetrics();` line (~line 407) with:
+
+```typescript
+const { live: liveMetrics, shadow: shadowMetrics } = await MarketScorer.loadAllCategoryMetrics();
+```
+
+Then, inside the per-type loop where `metrics = categoryMetrics.get(marketType)` was used to compute `typeEV`, replace with:
+
+```typescript
+const liveRow = liveMetrics.get(marketType);
+const shadowRow = shadowMetrics.get(marketType);
+const typeEV = MarketScorer.typeExpectedValue(
+  liveRow?.sharpe ?? null,
+  liveRow?.n ?? 0,
+);
+const shadowEV = MarketScorer.shadowExpectedValue(
+  shadowRow?.sharpe ?? null,
+  shadowRow?.n ?? 0,
+);
+```
+
+In the inner `rows.map((row) => { ... })` block where the `compositeScore` is called and the `EnrichUpdate` is constructed, add `shadowExpectedValue: shadowEV` to BOTH the `compositeScore` argument and the returned `EnrichUpdate` object:
+
+```typescript
+const score = MarketScorer.compositeScore({
+  tradeability,
+  liquidity,
+  volatility: null,
+  ttr,
+  dataQuality: null,
+  typeExpectedValue: typeEV,
+  realizedVolatility,
+  shadowExpectedValue: shadowEV,  // NEW
+}, weights);
+
+return {
+  conditionId: row.condition_id,
+  trackingStatus: 'cold',
+  score,
+  tradeability,
+  liquidity,
+  ttr,
+  volatility: null,
+  dataQuality: null,
+  typeExpectedValue: typeEV,
+  realizedVolatility,
+  currentPriceYes: row.current_price_yes != null ? Number(row.current_price_yes) : null,
+  volume24h: row.volume_24h != null ? Number(row.volume_24h) : null,
+  marketType: row.market_type ?? null,
+} satisfies EnrichUpdate;
+```
+
+The `EnrichUpdate` interface should also be extended (see Step 3).
+
+- [ ] **Step 2: Update Pass 2 (enrich tracked markets)**
+
+Find the second invocation of `MarketScorer.typeExpectedValue` (~line 609) and apply the same pattern: read `shadowMetrics`, compute `shadowEV`, pass into `compositeScore` and `EnrichUpdate`. Same code shape as Step 1, just inside the Pass 2 block.
+
+In the same loop's null-marketType fallback (where `categoryMetrics.get(null)` would have returned undefined), use `shadowEV = MarketScorer.shadowExpectedValue(null, 0)` (returns 0.5 neutral).
+
+- [ ] **Step 3: Extend `EnrichUpdate` interface**
+
+In the same file (~line 47), update the interface:
+
+```typescript
+export interface EnrichUpdate {
+  conditionId: string;
+  trackingStatus: string;
+  score: number;
+  tradeability: number;
+  liquidity: number;
+  ttr: number;
+  volatility: number | null;
+  dataQuality: number | null;
+  typeExpectedValue: number;
+  realizedVolatility: number | null;
+  shadowExpectedValue: number;       // NEW
+  currentPriceYes: number | null;
+  volume24h: number | null;
+  marketType: string | null;
+}
+```
+
+- [ ] **Step 4: Update `batchUpdateScores` and `batchUpdateScoresForType` if they reference the dim**
+
+```bash
+rtk grep -n "shadowExpectedValue\|typeExpectedValue" packages/data-collector/src/services/MarketScorer.ts | tail -20
+```
+
+The `batchUpdateScores` SQL writes a `score_dimensions` JSON blob (probably) or persists individual dim columns. If it persists individual columns (`type_expected_value`, etc.) into `markets` or `score_history`, the spec acknowledges this is **not part of this plan** — `shadowExpectedValue` is an in-memory dim only, not persisted as a markets column. The composite `score` already incorporates it via Step 1/2.
+
+If you find that `batchUpdateScores*` references `dim.shadowExpectedValue` and tries to persist it to a column that doesn't exist, leave the persistence path unchanged (don't add a new markets column for shadowEV). Just ensure that the dim flows through `compositeScore` correctly, which is what we tested in Task 5.
+
+- [ ] **Step 5: Type-check**
+
+```bash
+cd packages/data-collector
+pnpm tsc --noEmit
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Run full MarketScorer tests**
+
+```bash
+cd packages/data-collector
+pnpm test MarketScorer.test.ts
+```
+
+Expected: all tests pass (tests added in Tasks 3-6 plus existing ones).
+
+- [ ] **Step 7: Commit**
+
+```bash
+rtk git add packages/data-collector/src/services/MarketScorer.ts
+rtk git commit -m "feat(scorer): wire shadowExpectedValue through scoreAllMarkets passes 1 and 2"
+```
+
+---
+
+### Task 8: `MarketPerformanceTracker.updateShadowCategoryPerformance` writer
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketPerformanceTracker.ts`
+- Modify: `packages/data-collector/src/services/MarketPerformanceTracker.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `packages/data-collector/src/services/MarketPerformanceTracker.test.ts`:
+
+```typescript
+import { vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../database/connection.js', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '../database/connection.js';
+import { updateShadowCategoryPerformance } from './MarketPerformanceTracker.js';
+
+describe('updateShadowCategoryPerformance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.SHADOW_HAIRCUT;
+    delete process.env.CATEGORY_MIN_SHADOW_N;
+  });
+  afterEach(() => {
+    delete process.env.SHADOW_HAIRCUT;
+    delete process.env.CATEGORY_MIN_SHADOW_N;
+  });
+
+  it('applies default haircut 0.33 to raw shadow Sharpe before upsert', async () => {
+    (query as any)
+      .mockResolvedValueOnce({  // SELECT
+        rows: [
+          { market_type: 'event_short', n_trades: '444', win_rate: '0.5',
+            avg_pnl: '383', raw_sharpe: '2.03' },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });  // INSERT … ON CONFLICT
+
+    await updateShadowCategoryPerformance();
+
+    // Two queries fired: SELECT + INSERT
+    expect(query).toHaveBeenCalledTimes(2);
+    const insertCall = (query as any).mock.calls[1];
+    const insertSql = insertCall[0] as string;
+    const insertParams = insertCall[1] as unknown[];
+    expect(insertSql).toMatch(/INSERT INTO category_performance_shadow/);
+    expect(insertSql).toMatch(/ON CONFLICT \(market_type\) DO UPDATE/);
+    // The 4th param is the haircut-adjusted Sharpe (raw 2.03 * 0.33 = 0.6699).
+    // Param order must be (market_type, win_rate, avg_pnl, sharpe_ratio, n_trades, prior, haircut_applied).
+    expect(insertParams[0]).toBe('event_short');
+    expect(insertParams[3]).toBeCloseTo(2.03 * 0.33, 4);
+    expect(insertParams[4]).toBe(444);
+    expect(insertParams[6]).toBeCloseTo(0.33, 4);  // haircut_applied
+  });
+
+  it('skips upsert when n_trades < CATEGORY_MIN_SHADOW_N (default 30)', async () => {
+    (query as any).mockResolvedValueOnce({
+      rows: [
+        { market_type: 'crypto_intraday', n_trades: '20', win_rate: '0.5',
+          avg_pnl: '5', raw_sharpe: '0.4' },
+      ],
+    });
+    await updateShadowCategoryPerformance();
+    // Only the SELECT fired; no INSERT.
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors SHADOW_HAIRCUT env var override', async () => {
+    process.env.SHADOW_HAIRCUT = '0.5';
+    (query as any)
+      .mockResolvedValueOnce({
+        rows: [
+          { market_type: 'event_short', n_trades: '444', win_rate: '0.5',
+            avg_pnl: '383', raw_sharpe: '2.0' },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await updateShadowCategoryPerformance();
+
+    const insertCall = (query as any).mock.calls[1];
+    const insertParams = insertCall[1] as unknown[];
+    expect(insertParams[3]).toBeCloseTo(2.0 * 0.5, 4);   // sharpe_ratio = 1.0
+    expect(insertParams[6]).toBeCloseTo(0.5, 4);          // haircut_applied
+  });
+
+  it('honors CATEGORY_MIN_SHADOW_N env var override', async () => {
+    process.env.CATEGORY_MIN_SHADOW_N = '10';
+    (query as any)
+      .mockResolvedValueOnce({
+        rows: [
+          { market_type: 'event_short', n_trades: '15', win_rate: '0.5',
+            avg_pnl: '50', raw_sharpe: '0.4' },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await updateShadowCategoryPerformance();
+
+    // With env override 10, n=15 passes — INSERT should fire.
+    expect(query).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+```bash
+cd packages/data-collector
+pnpm test MarketPerformanceTracker.test.ts -- -t "updateShadowCategoryPerformance"
+```
+
+Expected: 4 tests fail because the function does not exist yet.
+
+- [ ] **Step 3: Implement `updateShadowCategoryPerformance`**
+
+In `packages/data-collector/src/services/MarketPerformanceTracker.ts`, append after the existing `updateCategoryPriors` and `resolveShadowTrades` exports (right before the file ends at line 102, or wherever the file structure suggests):
+
+```typescript
+export async function updateShadowCategoryPerformance(): Promise<void> {
+  const haircut = parseFloat(process.env.SHADOW_HAIRCUT ?? '0.33');
+  const minN = parseInt(process.env.CATEGORY_MIN_SHADOW_N ?? '30', 10);
+
+  if (!Number.isFinite(haircut)) {
+    logger.warn({ haircut: process.env.SHADOW_HAIRCUT }, 'Invalid SHADOW_HAIRCUT, falling back to 0.33');
+  }
+  const effectiveHaircut = Number.isFinite(haircut) ? haircut : 0.33;
+
+  const result = await query<{
+    market_type: string;
+    n_trades: string;
+    win_rate: string;
+    avg_pnl: string;
+    raw_sharpe: string;
+  }>(`
+    SELECT market_type,
+           COUNT(*)::text AS n_trades,
+           AVG(CASE WHEN theoretical_pnl > 0 THEN 1.0 ELSE 0.0 END)::text AS win_rate,
+           AVG(theoretical_pnl)::text AS avg_pnl,
+           CASE WHEN STDDEV(theoretical_pnl) > 0
+                THEN (AVG(theoretical_pnl) / STDDEV(theoretical_pnl))::text
+                ELSE '0' END AS raw_sharpe
+    FROM shadow_trades
+    WHERE resolved_at IS NOT NULL
+      AND theoretical_pnl IS NOT NULL
+    GROUP BY market_type
+  `);
+
+  logger.info({ categories: result.rows.length, haircut: effectiveHaircut, minN },
+    'Computing shadow category performance');
+
+  for (const row of result.rows) {
+    const nTrades = parseInt(row.n_trades, 10);
+    if (nTrades < minN) {
+      logger.debug({ market_type: row.market_type, nTrades, minN }, 'Skipping shadow category (below MIN_N)');
+      continue;
+    }
+    const rawSharpe = parseFloat(row.raw_sharpe);
+    const effectiveSharpe = rawSharpe * effectiveHaircut;
+    const prior = computePrior(effectiveSharpe);
+
+    await query(
+      `INSERT INTO category_performance_shadow
+         (market_type, win_rate, avg_pnl, sharpe_ratio, n_trades, prior, haircut_applied, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+       ON CONFLICT (market_type) DO UPDATE SET
+         win_rate = $2, avg_pnl = $3, sharpe_ratio = $4, n_trades = $5,
+         prior = $6, haircut_applied = $7, updated_at = NOW()`,
+      [row.market_type, parseFloat(row.win_rate), parseFloat(row.avg_pnl),
+       effectiveSharpe, nTrades, prior, effectiveHaircut],
+    );
+
+    logger.info({ market_type: row.market_type, nTrades,
+                  raw_sharpe: rawSharpe.toFixed(3), effective_sharpe: effectiveSharpe.toFixed(3),
+                  haircut: effectiveHaircut, prior: prior.toFixed(3) },
+      'Updated shadow category performance');
+  }
+}
+```
+
+- [ ] **Step 4: Run tests, verify PASS**
+
+```bash
+cd packages/data-collector
+pnpm test MarketPerformanceTracker.test.ts -- -t "updateShadowCategoryPerformance"
+```
+
+Expected: 4 tests pass. The pre-existing `computePrior` tests still pass (no change to that pure function).
+
+- [ ] **Step 5: Type-check**
+
+```bash
+cd packages/data-collector
+pnpm tsc --noEmit
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+rtk git add packages/data-collector/src/services/MarketPerformanceTracker.ts \
+            packages/data-collector/src/services/MarketPerformanceTracker.test.ts
+rtk git commit -m "feat(market-perf): updateShadowCategoryPerformance with haircut + MIN_N gate"
+```
+
+---
+
+### Task 9: Wire `updateShadowCategoryPerformance` into Scheduler
+
+**Files:**
+- Modify: `packages/data-collector/src/services/Scheduler.ts`
+
+- [ ] **Step 1: Locate the existing call**
+
+```bash
+rtk grep -n "updateCategoryPriors\|resolveShadowTrades\|computeMarketPriors" packages/data-collector/src/services/Scheduler.ts | head -10
+```
+
+Expected: matches around lines 12 (import) and 504-506 (calls inside `computeMarketPriors`).
+
+- [ ] **Step 2: Update import**
+
+In `packages/data-collector/src/services/Scheduler.ts` line 12, extend the import to include the new function:
+
+```typescript
+import {
+  updateCategoryPriors,
+  resolveShadowTrades,
+  updateShadowCategoryPerformance,
+} from './MarketPerformanceTracker.js';
+```
+
+- [ ] **Step 3: Add the call**
+
+Around line 504 (inside `computeMarketPriors`), insert the new call between the existing two:
+
+```typescript
+private async computeMarketPriors(): Promise<void> {
+  await updateCategoryPriors();
+  await updateShadowCategoryPerformance();   // NEW
+  await resolveShadowTrades();
+}
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd packages/data-collector
+pnpm tsc --noEmit
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+rtk git add packages/data-collector/src/services/Scheduler.ts
+rtk git commit -m "feat(scheduler): wire updateShadowCategoryPerformance into daily computeMarketPriors"
+```
+
+---
+
+### Task 10: Daily review prompt — shadow validation section
+
+**Files:**
+- Modify: `scripts/daily-review-prompt.md`
+
+- [ ] **Step 1: Find a stable insertion point**
+
+```bash
+rtk grep -n "category_performance\|shadow" scripts/daily-review-prompt.md | head -10
+```
+
+Identify the most natural section to extend (likely near the existing scoring or shadow-related rules). If there is no obvious section, append a new one at the end of the prompt under a `## Shadow haircut validation` heading.
+
+- [ ] **Step 2: Add the validation section**
+
+Insert this section verbatim:
+
+```markdown
+## Shadow haircut validation (post-PR scoring change)
+
+A shadow-derived dimension `shadowExpectedValue` (weight 0.05) was added to the
+MarketScorer composite. The shadow Sharpe is haircut-adjusted at write time
+(`SHADOW_HAIRCUT`, default 0.33) by `updateShadowCategoryPerformance`. Verify the
+haircut is well-calibrated.
+
+```sql
+SELECT cp.market_type,
+       cp.sharpe_ratio AS live_sharpe,
+       cp.n_trades AS live_n,
+       cps.sharpe_ratio AS shadow_effective_sharpe,
+       cps.n_trades AS shadow_n,
+       cps.haircut_applied,
+       -- Implied haircut: if live is the realised target, what would the
+       -- haircut have to be for shadow_effective to match?
+       CASE
+         WHEN cp.n_trades >= 30 AND cps.n_trades >= 30 AND cps.sharpe_ratio != 0
+         THEN ROUND(
+           (cp.sharpe_ratio / NULLIF(cps.sharpe_ratio / cps.haircut_applied, 0))::numeric,
+           3
+         )
+         ELSE NULL
+       END AS implied_haircut
+FROM category_performance cp
+LEFT JOIN category_performance_shadow cps ON cps.market_type = cp.market_type
+ORDER BY cp.market_type;
+```
+
+Interpretation rules:
+- **Both sides have ≥ 30 trades**: `implied_haircut` should be in `[0.15, 0.55]` (≈ 0.33 ± 0.20). Outside that band → flag for per-type haircut consideration (out of scope; follow-up PR).
+- **Shadow only**: the only evidence is theoretical. Note in the review.
+- **Sign disagreement** (live positive vs shadow negative or vice versa): flag for human review — likely regime divergence.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+rtk git add scripts/daily-review-prompt.md
+rtk git commit -m "docs(daily-review): add shadow haircut validation section"
+```
+
+---
+
+### Task 11: Integration smoke + full type-check + test sweep
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Per-package tsc**
+
+```bash
+cd packages/data-collector && pnpm tsc --noEmit
+cd ../dashboard && pnpm tsc --noEmit
+```
+
+Expected: clean for both.
+
+- [ ] **Step 2: Full vitest sweep**
+
+```bash
+cd ../..
+npx vitest run packages
+```
+
+Expected: every test file passes; total tests should be `prior_baseline + N_new_tests`. If any unrelated test fails, investigate before proceeding.
+
+- [ ] **Step 3: Verify regression — original `loadCategoryMetrics` not referenced anywhere**
+
+```bash
+rtk grep -nE "loadCategoryMetrics\b" packages
+```
+
+Expected: zero matches. The single original caller (`scoreAllMarkets`) was updated in Task 7; no stale references.
+
+- [ ] **Step 4: Verify the WEIGHTS sum invariant holds**
+
+```bash
+cd packages/data-collector
+pnpm test MarketScorer.test.ts -- -t "WEIGHTS"
+```
+
+Expected: PASS — total = 1.0 within float tolerance.
+
+- [ ] **Step 5: No commit needed (verification only)**
+
+---
+
+### Task 12: Push branch + open PR + final reviewer subagent
+
+- [ ] **Step 1: Confirm git auth**
+
+```bash
+rtk gh auth status
+```
+
+If active account is not `JaviMaligno`, switch:
+
+```bash
+rtk gh auth switch --user JaviMaligno
+```
+
+- [ ] **Step 2: Push branch**
+
+```bash
+rtk git push -u origin feat/shadow-haircut-scorer-integration
+```
+
+- [ ] **Step 3: Create PR**
+
+```bash
+rtk gh pr create --title "feat(scorer): shadow as additive dimension via category_performance_shadow + haircut" \
+  --body-file - <<'EOF'
+## Summary
+
+Adds a `shadowExpectedValue` dimension to `MarketScorer` (weight 0.05) fed by a new `category_performance_shadow` table. Shadow Sharpe is haircut-adjusted at write time (`SHADOW_HAIRCUT`, default 0.33). Live `category_performance` and `typeExpectedValue` are **untouched**.
+
+Spec: `docs/plans/2026-05-01-shadow-haircut-scorer-integration-design.md`
+Plan: `docs/plans/2026-05-01-shadow-haircut-scorer-integration-plan.md`
+
+## Why
+
+`event_short` has shadow Sharpe +2.03 (n=444 resolved, 88.5% WR) but `category_performance.sharpe_ratio` of +0.13 (n=419 historic live, mostly pre-fix). The scorer reads only live data, so event_short's shadow validation never reaches the score. Result: 14 cold candidates, only 2 promoted to active.
+
+The shadow/live gap is structural (early exits, risk gates, sizing), not just fees. Fee subtraction moves Sharpe in the 4th decimal — measured. Adding shadow as a separate downweighted dim is more rigorous than a multiplicative haircut on the combined Sharpe.
+
+## Pre-computed impact
+
+| type | composite contribution before | after | Δ |
+|---|---|---|---|
+| event_short | 0.127 | 0.171 | +0.044 |
+| event_financial | 0.138 | 0.131 | -0.007 |
+
+Spread flip: event_short was 0.011 below event_financial in scoring contribution; now 0.040 above. Sufficient to enter rotator's top-50.
+
+## Architecture
+
+```
+computeMarketPriors() (daily 02:45 UTC)
+  ├── updateCategoryPriors()              ← UNCHANGED
+  ├── updateShadowCategoryPerformance()   ← NEW
+  └── resolveShadowTrades()               ← unchanged
+
+MarketScorer.scoreAllMarkets()
+  ├── loadAllCategoryMetrics() → { live, shadow }
+  └── compositeScore({ ..., shadowExpectedValue: shadowEV }) ← +0.05 weight
+```
+
+## Constants & env vars
+
+- `SHADOW_HAIRCUT` (default 0.33, env-tunable) — applied at write time, persisted as `haircut_applied` per row.
+- `CATEGORY_MIN_SHADOW_N` (default 30, env-tunable) — gate below which shadow rows are not upserted.
+- `WEIGHTS.shadowExpectedValue = 0.05` — fixed in code; changing is a deliberate scoring decision.
+
+## Validation
+
+- Daily review query (`scripts/daily-review-prompt.md`) computes `implied_haircut` per type. Alert if outside `[0.15, 0.55]`.
+- Post-deploy: confirm event_short active count rises from 2 toward 5+ within 48h.
+- After 1 week: review implied_haircut trends; consider per-type override PR if needed.
+
+## Test plan
+
+- [x] `pnpm tsc --noEmit` clean per package
+- [x] Full vitest sweep passes (existing baseline + new tests)
+- [x] `WEIGHTS` sum to 1.0 invariant
+- [x] `shadowExpectedValue` mirrors `typeExpectedValue` formula
+- [x] `compositeScore` integrates shadow weight correctly
+- [x] `loadAllCategoryMetrics` returns parallel maps; graceful degradation on DB error
+- [x] `updateShadowCategoryPerformance` applies haircut, honors env overrides, gates by MIN_N
+- [ ] Post-deploy: `category_performance_shadow` rows appear after first 02:45 UTC run
+- [ ] Post-deploy: event_short composite contribution rises as predicted
+
+## Files touched
+
+```
+packages/data-collector/src/database/init/029_category_performance_shadow.sql       [new]
+packages/dashboard/src/services/bootstrapShadowCategoryPerformance.ts                [new]
+packages/dashboard/src/services/bootstrapShadowCategoryPerformance.test.ts           [new]
+packages/dashboard/src/server.ts                                                     [+bootstrap call]
+packages/data-collector/src/services/MarketScorer.ts                                 [+shadowExpectedValue, rescaled WEIGHTS, loadAllCategoryMetrics, scoreAllMarkets passes]
+packages/data-collector/src/services/MarketScorer.test.ts                            [+tests]
+packages/data-collector/src/services/MarketPerformanceTracker.ts                     [+updateShadowCategoryPerformance]
+packages/data-collector/src/services/MarketPerformanceTracker.test.ts                [+tests]
+packages/data-collector/src/services/Scheduler.ts                                    [+wire call]
+scripts/daily-review-prompt.md                                                       [+validation section]
+```
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+```
+
+- [ ] **Step 4: Wait for CI**
+
+```bash
+until rtk gh pr checks $(rtk gh pr view --json number --jq '.number') 2>&1 | grep -qE "Passed|FAIL"; do sleep 15; done
+rtk gh pr checks $(rtk gh pr view --json number --jq '.number')
+```
+
+Expected: all checks pass.
+
+- [ ] **Step 5: (If subagent-driven plan) dispatch final code reviewer**
+
+If executing this plan via `superpowers:subagent-driven-development`, dispatch the final code reviewer agent with `BASE_SHA = git merge-base origin/main HEAD` and `HEAD_SHA = HEAD`. Address any blocking findings before merge.
+
+- [ ] **Step 6: Merge**
+
+```bash
+rtk gh pr merge $(rtk gh pr view --json number --jq '.number') --squash --delete-branch
+```
+
+- [ ] **Step 7: Confirm Deploy to GCP fired automatically**
+
+```bash
+rtk gh run list --workflow="Deploy to GCP" --limit 1 --json conclusion,status,headSha
+```
+
+Expected: a new run on the squash commit, status `queued` or `in_progress`. Wait for it; if it hangs on health check or e2-micro saturation, see `memory/project_billing_incident_2026-05-01.md` for recovery steps (cancel + manual `docker compose pull && up`).
+
+---
+
+## Self-review checklist (post-merge)
+
+- [ ] On VM: `git log --oneline -1` shows the merge commit at HEAD.
+- [ ] `docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c "\\d category_performance_shadow"` returns the new schema.
+- [ ] After first daily 02:45 UTC run: `SELECT * FROM category_performance_shadow ORDER BY market_type;` returns ≥ 1 row (event_short and/or event_long).
+- [ ] After ~30 min following the daily run: `SELECT m.market_type, COUNT(*) FROM markets m WHERE m.tracking_status='active' GROUP BY m.market_type ORDER BY m.market_type;` shows event_short count rising vs pre-deploy snapshot.
+- [ ] Run the daily review query (Task 10 §SQL); `implied_haircut` for event_short, when both sides ≥ 30 trades, lands in `[0.15, 0.55]`.

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -33,6 +33,7 @@ import { WalletMonitor, setWalletMonitor } from './services/WalletMonitor.js';
 import { getNotificationService } from './services/NotificationService.js';
 import { getSignalSigmaCache } from './services/SignalSigmaCache.js';
 import { bootstrapDirectionMultiplierRows } from './services/bootstrapDirectionMultiplier.js';
+import { bootstrapShadowCategoryPerformanceTable } from './services/bootstrapShadowCategoryPerformance.js';
 
 const logger = pino({ name: 'server' });
 
@@ -440,6 +441,13 @@ async function main(): Promise<void> {
         console.log('[server] direction_multiplier per-type bootstrap rows ensured');
       } catch (err) {
         console.error('[server] Failed to bootstrap direction_multiplier rows:', err);
+      }
+
+      try {
+        await bootstrapShadowCategoryPerformanceTable();
+        console.log('[server] category_performance_shadow table ensured');
+      } catch (err) {
+        console.error('[server] Failed to bootstrap category_performance_shadow:', err);
       }
 
       // #143 cleanup: drop per-type rows for generators not wired in BacktestService.createSignals.

--- a/packages/dashboard/src/services/bootstrapShadowCategoryPerformance.test.ts
+++ b/packages/dashboard/src/services/bootstrapShadowCategoryPerformance.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../database/index.js', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '../database/index.js';
+import { bootstrapShadowCategoryPerformanceTable } from './bootstrapShadowCategoryPerformance.js';
+
+describe('bootstrapShadowCategoryPerformanceTable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('issues a CREATE TABLE IF NOT EXISTS for category_performance_shadow', async () => {
+    (query as any).mockResolvedValueOnce({ rows: [] });
+    await bootstrapShadowCategoryPerformanceTable();
+    expect(query).toHaveBeenCalledTimes(1);
+    const sql = (query as any).mock.calls[0][0] as string;
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS category_performance_shadow/);
+    expect(sql).toMatch(/PRIMARY KEY/);
+    expect(sql).toMatch(/haircut_applied DOUBLE PRECISION NOT NULL DEFAULT 0\.33/);
+    expect(sql).toMatch(/sharpe_ratio DOUBLE PRECISION/);
+  });
+});

--- a/packages/dashboard/src/services/bootstrapShadowCategoryPerformance.ts
+++ b/packages/dashboard/src/services/bootstrapShadowCategoryPerformance.ts
@@ -1,0 +1,24 @@
+import { query } from '../database/index.js';
+
+/**
+ * Idempotent runtime creation of the category_performance_shadow table.
+ *
+ * init/029_category_performance_shadow.sql only fires on first volume
+ * creation. Production deployments need this helper at startup so the
+ * table appears without a database wipe. Mirrors the PR #163 pattern
+ * for bootstrapDirectionMultiplierRows.
+ */
+export async function bootstrapShadowCategoryPerformanceTable(): Promise<void> {
+  await query(
+    `CREATE TABLE IF NOT EXISTS category_performance_shadow (
+       market_type VARCHAR(20) PRIMARY KEY,
+       win_rate DOUBLE PRECISION,
+       avg_pnl DOUBLE PRECISION,
+       sharpe_ratio DOUBLE PRECISION,
+       n_trades INTEGER NOT NULL DEFAULT 0,
+       prior DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+       haircut_applied DOUBLE PRECISION NOT NULL DEFAULT 0.33,
+       updated_at TIMESTAMPTZ DEFAULT NOW()
+     )`,
+  );
+}

--- a/packages/data-collector/src/database/init/029_category_performance_shadow.sql
+++ b/packages/data-collector/src/database/init/029_category_performance_shadow.sql
@@ -1,0 +1,13 @@
+-- Mirrors category_performance schema but stores shadow-derived metrics with
+-- an applied haircut. See docs/plans/2026-05-01-shadow-haircut-scorer-integration-design.md.
+
+CREATE TABLE IF NOT EXISTS category_performance_shadow (
+  market_type     VARCHAR(20)  PRIMARY KEY,
+  win_rate        DOUBLE PRECISION,
+  avg_pnl         DOUBLE PRECISION,
+  sharpe_ratio    DOUBLE PRECISION,
+  n_trades        INTEGER NOT NULL DEFAULT 0,
+  prior           DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+  haircut_applied DOUBLE PRECISION NOT NULL DEFAULT 0.33,
+  updated_at      TIMESTAMPTZ DEFAULT NOW()
+);

--- a/packages/data-collector/src/services/MarketPerformanceTracker.test.ts
+++ b/packages/data-collector/src/services/MarketPerformanceTracker.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { computePrior, MIN_CATEGORY_TRADES } from './MarketPerformanceTracker.js';
+
+vi.mock('../database/connection.js', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '../database/connection.js';
+import { updateShadowCategoryPerformance } from './MarketPerformanceTracker.js';
 
 describe('computePrior', () => {
   it('returns 1.0 for sharpe = 0 (neutral)', () => {
@@ -28,5 +35,88 @@ describe('computePrior', () => {
 describe('MIN_CATEGORY_TRADES', () => {
   it('is 5', () => {
     expect(MIN_CATEGORY_TRADES).toBe(5);
+  });
+});
+
+describe('updateShadowCategoryPerformance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.SHADOW_HAIRCUT;
+    delete process.env.CATEGORY_MIN_SHADOW_N;
+  });
+  afterEach(() => {
+    delete process.env.SHADOW_HAIRCUT;
+    delete process.env.CATEGORY_MIN_SHADOW_N;
+  });
+
+  it('applies default haircut 0.33 to raw shadow Sharpe before upsert', async () => {
+    (query as any)
+      .mockResolvedValueOnce({  // SELECT
+        rows: [
+          { market_type: 'event_short', n_trades: '444', win_rate: '0.5',
+            avg_pnl: '383', raw_sharpe: '2.03' },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });  // INSERT
+
+    await updateShadowCategoryPerformance();
+
+    expect(query).toHaveBeenCalledTimes(2);
+    const insertCall = (query as any).mock.calls[1];
+    const insertSql = insertCall[0] as string;
+    const insertParams = insertCall[1] as unknown[];
+    expect(insertSql).toMatch(/INSERT INTO category_performance_shadow/);
+    expect(insertSql).toMatch(/ON CONFLICT \(market_type\) DO UPDATE/);
+    // Param order: (market_type, win_rate, avg_pnl, sharpe_ratio, n_trades, prior, haircut_applied)
+    expect(insertParams[0]).toBe('event_short');
+    expect(insertParams[3]).toBeCloseTo(2.03 * 0.33, 4);
+    expect(insertParams[4]).toBe(444);
+    expect(insertParams[6]).toBeCloseTo(0.33, 4);
+  });
+
+  it('skips upsert when n_trades < CATEGORY_MIN_SHADOW_N (default 30)', async () => {
+    (query as any).mockResolvedValueOnce({
+      rows: [
+        { market_type: 'crypto_intraday', n_trades: '20', win_rate: '0.5',
+          avg_pnl: '5', raw_sharpe: '0.4' },
+      ],
+    });
+    await updateShadowCategoryPerformance();
+    expect(query).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors SHADOW_HAIRCUT env var override', async () => {
+    process.env.SHADOW_HAIRCUT = '0.5';
+    (query as any)
+      .mockResolvedValueOnce({
+        rows: [
+          { market_type: 'event_short', n_trades: '444', win_rate: '0.5',
+            avg_pnl: '383', raw_sharpe: '2.0' },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await updateShadowCategoryPerformance();
+
+    const insertCall = (query as any).mock.calls[1];
+    const insertParams = insertCall[1] as unknown[];
+    expect(insertParams[3]).toBeCloseTo(2.0 * 0.5, 4);
+    expect(insertParams[6]).toBeCloseTo(0.5, 4);
+  });
+
+  it('honors CATEGORY_MIN_SHADOW_N env var override', async () => {
+    process.env.CATEGORY_MIN_SHADOW_N = '10';
+    (query as any)
+      .mockResolvedValueOnce({
+        rows: [
+          { market_type: 'event_short', n_trades: '15', win_rate: '0.5',
+            avg_pnl: '50', raw_sharpe: '0.4' },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await updateShadowCategoryPerformance();
+
+    expect(query).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/data-collector/src/services/MarketPerformanceTracker.ts
+++ b/packages/data-collector/src/services/MarketPerformanceTracker.ts
@@ -100,3 +100,63 @@ export async function resolveShadowTrades(): Promise<void> {
 
   logger.info({ resolved: result.rows.length }, 'Shadow trades resolved');
 }
+
+export async function updateShadowCategoryPerformance(): Promise<void> {
+  const haircutRaw = parseFloat(process.env.SHADOW_HAIRCUT ?? '0.33');
+  const minN = parseInt(process.env.CATEGORY_MIN_SHADOW_N ?? '30', 10);
+
+  if (!Number.isFinite(haircutRaw)) {
+    logger.warn({ haircut: process.env.SHADOW_HAIRCUT }, 'Invalid SHADOW_HAIRCUT, falling back to 0.33');
+  }
+  const effectiveHaircut = Number.isFinite(haircutRaw) ? haircutRaw : 0.33;
+
+  const result = await query<{
+    market_type: string;
+    n_trades: string;
+    win_rate: string;
+    avg_pnl: string;
+    raw_sharpe: string;
+  }>(`
+    SELECT market_type,
+           COUNT(*)::text AS n_trades,
+           AVG(CASE WHEN theoretical_pnl > 0 THEN 1.0 ELSE 0.0 END)::text AS win_rate,
+           AVG(theoretical_pnl)::text AS avg_pnl,
+           CASE WHEN STDDEV(theoretical_pnl) > 0
+                THEN (AVG(theoretical_pnl) / STDDEV(theoretical_pnl))::text
+                ELSE '0' END AS raw_sharpe
+    FROM shadow_trades
+    WHERE resolved_at IS NOT NULL
+      AND theoretical_pnl IS NOT NULL
+    GROUP BY market_type
+  `);
+
+  logger.info({ categories: result.rows.length, haircut: effectiveHaircut, minN },
+    'Computing shadow category performance');
+
+  for (const row of result.rows) {
+    const nTrades = parseInt(row.n_trades, 10);
+    if (nTrades < minN) {
+      logger.debug({ market_type: row.market_type, nTrades, minN }, 'Skipping shadow category (below MIN_N)');
+      continue;
+    }
+    const rawSharpe = parseFloat(row.raw_sharpe);
+    const effectiveSharpe = rawSharpe * effectiveHaircut;
+    const prior = computePrior(effectiveSharpe);
+
+    await query(
+      `INSERT INTO category_performance_shadow
+         (market_type, win_rate, avg_pnl, sharpe_ratio, n_trades, prior, haircut_applied, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+       ON CONFLICT (market_type) DO UPDATE SET
+         win_rate = $2, avg_pnl = $3, sharpe_ratio = $4, n_trades = $5,
+         prior = $6, haircut_applied = $7, updated_at = NOW()`,
+      [row.market_type, parseFloat(row.win_rate), parseFloat(row.avg_pnl),
+       effectiveSharpe, nTrades, prior, effectiveHaircut],
+    );
+
+    logger.info({ market_type: row.market_type, nTrades,
+                  raw_sharpe: rawSharpe.toFixed(3), effective_sharpe: effectiveSharpe.toFixed(3),
+                  haircut: effectiveHaircut, prior: prior.toFixed(3) },
+      'Updated shadow category performance');
+  }
+}

--- a/packages/data-collector/src/services/MarketScorer.test.ts
+++ b/packages/data-collector/src/services/MarketScorer.test.ts
@@ -505,6 +505,7 @@ describe('MarketScorer', () => {
         dataQuality: 0.0,
         typeExpectedValue: 0.0,
         realizedVolatility: 0.0,
+        shadowExpectedValue: 0.0,
       };
       // Expected: (1.0*0.5 + 0.0*0.0 + 0.0*0.0 + 1.0*0.5 + 0.0*0.0 + 0.0*0.0 + 0.0*0.0) / (0.5+0.0+0.0+0.5+0.0+0.0+0.0) = 1.0 / 1.0 = 1.0
       expect(MarketScorer.compositeScore(dims, customWeights)).toBeCloseTo(1.0);
@@ -529,6 +530,7 @@ describe('MarketScorer', () => {
         dataQuality: 0.5,
         typeExpectedValue: 0.5,
         realizedVolatility: 0.5,
+        shadowExpectedValue: 0.0,
       };
       // volatility, dataQuality, and realizedVolatility are null → excluded. sumW = 2.0+1.0+1.0+0.5 = 4.5
       // score = (1.0*2.0 + 1.0*1.0 + 1.0*1.0 + 0.0*0.5) / 4.5 = 4.0 / 4.5 = 0.888...
@@ -547,7 +549,7 @@ describe('MarketScorer', () => {
       const weights: ScorerWeights = {
         tradeability: 0.25, liquidity: 0.20, volatility: 0.15,
         ttr: 0.10, dataQuality: 0.10, typeExpectedValue: 0.20,
-        realizedVolatility: 0.12,
+        realizedVolatility: 0.12, shadowExpectedValue: 0.0,
       };
       // All non-null dims at 1: tradeability + liquidity + ttr + typeExpectedValue
       // weighted sum = 0.25+0.20+0.10+0.20 = 0.75, normalized by same = 1.0
@@ -564,7 +566,7 @@ describe('MarketScorer', () => {
       const weights: ScorerWeights = {
         tradeability: 0.25, liquidity: 0.20, volatility: 0.15,
         ttr: 0.10, dataQuality: 0.10, typeExpectedValue: 0.20,
-        realizedVolatility: 0.12,
+        realizedVolatility: 0.12, shadowExpectedValue: 0.0,
       };
       // Non-null weighted sum = 0.25+0.20+0.10+0 = 0.55
       // Normalized by non-null weight-sum (0.25+0.20+0.10+0.20) = 0.75
@@ -859,7 +861,7 @@ describe('MarketScorer', () => {
     it('all weights sum to 1.0', () => {
       const sum = WEIGHTS.tradeability + WEIGHTS.liquidity + WEIGHTS.volatility +
                   WEIGHTS.ttr + WEIGHTS.dataQuality + WEIGHTS.typeExpectedValue +
-                  WEIGHTS.realizedVolatility;
+                  WEIGHTS.realizedVolatility + WEIGHTS.shadowExpectedValue;
       expect(sum).toBeCloseTo(1.0, 5);
     });
   });
@@ -889,7 +891,7 @@ describe('MarketScorer', () => {
     it('all weights still sum to 1.0', () => {
       const sum = WEIGHTS.tradeability + WEIGHTS.liquidity + WEIGHTS.volatility +
                   WEIGHTS.ttr + WEIGHTS.dataQuality + WEIGHTS.typeExpectedValue +
-                  WEIGHTS.realizedVolatility;
+                  WEIGHTS.realizedVolatility + WEIGHTS.shadowExpectedValue;
       expect(sum).toBeCloseTo(1.0, 5);
     });
   });
@@ -1306,6 +1308,21 @@ describe('MarketScorer', () => {
       const high_K = MarketScorer.shadowExpectedValue(sharpe, n, 1000);
       // Higher K shrinks more aggressively → output closer to 0.5.
       expect(Math.abs(high_K - 0.5)).toBeLessThan(Math.abs(default_K - 0.5));
+    });
+  });
+
+  describe('MarketScorer.WEIGHTS', () => {
+    it('all weight values sum to 1.0 (within float tolerance)', () => {
+      const total = Object.values(WEIGHTS).reduce((sum, w) => sum + w, 0);
+      expect(total).toBeCloseTo(1.0, 6);
+    });
+
+    it('shadowExpectedValue weight is 0.05', () => {
+      expect(WEIGHTS.shadowExpectedValue).toBe(0.05);
+    });
+
+    it('typeExpectedValue weight is 0.1615 (rescaled from 0.17 by 0.95)', () => {
+      expect(WEIGHTS.typeExpectedValue).toBeCloseTo(0.1615, 6);
     });
   });
 });

--- a/packages/data-collector/src/services/MarketScorer.test.ts
+++ b/packages/data-collector/src/services/MarketScorer.test.ts
@@ -913,55 +913,6 @@ describe('MarketScorer', () => {
     });
   });
 
-  // ─── loadCategoryMetrics ────────────────────────────────────────────────
-  describe('MarketScorer.loadCategoryMetrics', () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
-    });
-
-    it('loads a Map keyed by market_type', async () => {
-      (query as unknown as Mock).mockResolvedValue({
-        rows: [
-          { market_type: 'event_financial', sharpe_ratio: 0.27, n_trades: 159 },
-          { market_type: 'event_long',      sharpe_ratio: 0.17, n_trades: 1317 },
-        ],
-      });
-      const map = await MarketScorer.loadCategoryMetrics();
-      expect(map.get('event_financial')).toEqual({ sharpe: 0.27, n: 159 });
-      expect(map.get('event_long')).toEqual({ sharpe: 0.17, n: 1317 });
-    });
-
-    it('returns empty Map when table is empty', async () => {
-      (query as unknown as Mock).mockResolvedValue({ rows: [] });
-      const map = await MarketScorer.loadCategoryMetrics();
-      expect(map.size).toBe(0);
-    });
-
-    it('coerces string numerics from pg to numbers', async () => {
-      (query as unknown as Mock).mockResolvedValue({
-        rows: [{ market_type: 'event_short', sharpe_ratio: '0.13' as unknown as number, n_trades: '419' as unknown as number }],
-      });
-      const map = await MarketScorer.loadCategoryMetrics();
-      const entry = map.get('event_short');
-      expect(entry?.sharpe).toBe(0.13);
-      expect(entry?.n).toBe(419);
-    });
-
-    it('preserves null sharpe_ratio (insufficient data in category_performance)', async () => {
-      (query as unknown as Mock).mockResolvedValue({
-        rows: [{ market_type: 'crypto_daily', sharpe_ratio: null, n_trades: 4 }],
-      });
-      const map = await MarketScorer.loadCategoryMetrics();
-      expect(map.get('crypto_daily')).toEqual({ sharpe: null, n: 4 });
-    });
-
-    it('returns empty Map on DB error (graceful degrade)', async () => {
-      (query as unknown as Mock).mockRejectedValue(new Error('db down'));
-      const map = await MarketScorer.loadCategoryMetrics();
-      expect(map.size).toBe(0);
-    });
-  });
-
   // ─── MarketScorer.loadWeights per-type ──────────────────────────────
   describe('MarketScorer.loadWeights per-type', () => {
     beforeEach(() => {
@@ -1378,5 +1329,40 @@ describe('MarketScorer', () => {
       });
       expect(score).toBeCloseTo(0.475, 6);
     });
+  });
+});
+
+describe('MarketScorer.loadAllCategoryMetrics', () => {
+  beforeEach(() => {
+    (query as any).mockReset();
+  });
+
+  it('returns parallel maps for live and shadow', async () => {
+    (query as any)
+      .mockResolvedValueOnce({  // live
+        rows: [
+          { market_type: 'event_short', sharpe_ratio: '0.13', n_trades: '419' },
+          { market_type: 'event_long', sharpe_ratio: '0.17', n_trades: '1317' },
+        ],
+      })
+      .mockResolvedValueOnce({  // shadow
+        rows: [
+          { market_type: 'event_short', sharpe_ratio: '0.67', n_trades: '444' },
+        ],
+      });
+
+    const { live, shadow } = await MarketScorer.loadAllCategoryMetrics();
+
+    expect(live.get('event_short')).toEqual({ sharpe: 0.13, n: 419 });
+    expect(live.get('event_long')).toEqual({ sharpe: 0.17, n: 1317 });
+    expect(shadow.get('event_short')).toEqual({ sharpe: 0.67, n: 444 });
+    expect(shadow.size).toBe(1);
+  });
+
+  it('returns empty maps on DB error (graceful degradation)', async () => {
+    (query as any).mockRejectedValueOnce(new Error('DB down'));
+    const { live, shadow } = await MarketScorer.loadAllCategoryMetrics();
+    expect(live.size).toBe(0);
+    expect(shadow.size).toBe(0);
   });
 });

--- a/packages/data-collector/src/services/MarketScorer.test.ts
+++ b/packages/data-collector/src/services/MarketScorer.test.ts
@@ -263,6 +263,7 @@ describe('MarketScorer', () => {
         dataQuality: 1.0,
         typeExpectedValue: 1.0,
         realizedVolatility: 1.0,
+        shadowExpectedValue: 1.0,
       };
       expect(MarketScorer.compositeScore(dims)).toBeCloseTo(1.0, 5);
     });
@@ -276,11 +277,15 @@ describe('MarketScorer', () => {
         dataQuality: 0,
         typeExpectedValue: 0,
         realizedVolatility: 0,
+        shadowExpectedValue: 0,
       };
       expect(MarketScorer.compositeScore(dims)).toBe(0);
     });
 
     it('applies correct weights', () => {
+      // Each test sets one dim to 1.0 and others to 0; expected score equals that dim's
+      // post-Task-4 rescaled weight (the original WEIGHTS values × 0.95 to make room for
+      // shadowExpectedValue=0.05).
       // Only tradeability=1.0, rest=0
       const trade: ScoreDimensions = {
         tradeability: 1.0,
@@ -290,8 +295,9 @@ describe('MarketScorer', () => {
         dataQuality: 0,
         typeExpectedValue: 0,
         realizedVolatility: 0,
+        shadowExpectedValue: 0,
       };
-      expect(MarketScorer.compositeScore(trade)).toBeCloseTo(0.21, 5);
+      expect(MarketScorer.compositeScore(trade)).toBeCloseTo(0.1995, 5);
 
       // Only liquidity=1.0
       const liq: ScoreDimensions = {
@@ -302,8 +308,9 @@ describe('MarketScorer', () => {
         dataQuality: 0,
         typeExpectedValue: 0,
         realizedVolatility: 0,
+        shadowExpectedValue: 0,
       };
-      expect(MarketScorer.compositeScore(liq)).toBeCloseTo(0.17, 5);
+      expect(MarketScorer.compositeScore(liq)).toBeCloseTo(0.1615, 5);
 
       // Only volatility=1.0
       const vol: ScoreDimensions = {
@@ -314,8 +321,9 @@ describe('MarketScorer', () => {
         dataQuality: 0,
         typeExpectedValue: 0,
         realizedVolatility: 0,
+        shadowExpectedValue: 0,
       };
-      expect(MarketScorer.compositeScore(vol)).toBeCloseTo(0.15, 5);
+      expect(MarketScorer.compositeScore(vol)).toBeCloseTo(0.1425, 5);
 
       // Only ttr=1.0
       const ttr: ScoreDimensions = {
@@ -326,8 +334,9 @@ describe('MarketScorer', () => {
         dataQuality: 0,
         typeExpectedValue: 0,
         realizedVolatility: 0,
+        shadowExpectedValue: 0,
       };
-      expect(MarketScorer.compositeScore(ttr)).toBeCloseTo(0.08, 5);
+      expect(MarketScorer.compositeScore(ttr)).toBeCloseTo(0.0760, 5);
 
       // Only dataQuality=1.0
       const dq: ScoreDimensions = {
@@ -338,8 +347,9 @@ describe('MarketScorer', () => {
         dataQuality: 1.0,
         typeExpectedValue: 0,
         realizedVolatility: 0,
+        shadowExpectedValue: 0,
       };
-      expect(MarketScorer.compositeScore(dq)).toBeCloseTo(0.10, 5);
+      expect(MarketScorer.compositeScore(dq)).toBeCloseTo(0.0950, 5);
 
       // Only typeExpectedValue=1.0
       const tev: ScoreDimensions = {
@@ -350,8 +360,9 @@ describe('MarketScorer', () => {
         dataQuality: 0,
         typeExpectedValue: 1.0,
         realizedVolatility: 0,
+        shadowExpectedValue: 0,
       };
-      expect(MarketScorer.compositeScore(tev)).toBeCloseTo(0.17, 5);
+      expect(MarketScorer.compositeScore(tev)).toBeCloseTo(0.1615, 5);
     });
 
     it('normalizes by available weights when volatility is null', () => {
@@ -363,10 +374,9 @@ describe('MarketScorer', () => {
         dataQuality: 1.0,
         typeExpectedValue: 1.0,
         realizedVolatility: 1.0,
+        shadowExpectedValue: 1.0,
       };
-      // Available weights: 0.21 + 0.17 + 0.08 + 0.10 + 0.17 + 0.12 = 0.85
-      // (volatility=0.15 is null, excluded)
-      // Score = (0.21 + 0.17 + 0.08 + 0.10 + 0.17 + 0.12) / 0.85 = 1.0
+      // All non-null dims at 1.0 → score = 1.0 regardless of which weights are excluded.
       expect(MarketScorer.compositeScore(dims)).toBeCloseTo(1.0, 5);
     });
 
@@ -379,10 +389,9 @@ describe('MarketScorer', () => {
         dataQuality: null,
         typeExpectedValue: 1.0,
         realizedVolatility: 1.0,
+        shadowExpectedValue: 1.0,
       };
-      // Available weights: 0.21 + 0.17 + 0.15 + 0.08 + 0.17 + 0.12 = 0.90
-      // (dataQuality=0.10 is null, excluded)
-      // Score = 0.90 / 0.90 = 1.0
+      // All non-null dims at 1.0 → score = 1.0.
       expect(MarketScorer.compositeScore(dims)).toBeCloseTo(1.0, 5);
     });
 
@@ -395,10 +404,9 @@ describe('MarketScorer', () => {
         dataQuality: null,
         typeExpectedValue: 1.0,
         realizedVolatility: 1.0,
+        shadowExpectedValue: 1.0,
       };
-      // Available weights: 0.21 + 0.17 + 0.08 + 0.17 + 0.12 = 0.75
-      // (volatility=0.15 and dataQuality=0.10 are null, excluded)
-      // Score = 0.75 / 0.75 = 1.0
+      // All non-null dims at 1.0 → score = 1.0.
       expect(MarketScorer.compositeScore(dims)).toBeCloseTo(1.0, 5);
     });
 
@@ -411,12 +419,14 @@ describe('MarketScorer', () => {
         dataQuality: null,
         typeExpectedValue: 0,
         realizedVolatility: null,
+        shadowExpectedValue: 0,
       };
-      // Available weights: 0.21 + 0.17 + 0.08 + 0.17 = 0.63
-      // (volatility=0.15 and dataQuality=0.10 and realizedVolatility=0.12 are null, excluded)
-      // Weighted sum = 0.5*0.21 + 0.8*0.17 + 0.6*0.08 + 0*0.17 = 0.105 + 0.136 + 0.048 + 0 = 0.289
-      // Normalized = 0.289 / 0.63 ≈ 0.4587
-      expect(MarketScorer.compositeScore(dims)).toBeCloseTo(0.289 / 0.63, 4);
+      // Post-Task-4 rescaled WEIGHTS (×0.95): trade=0.1995, liq=0.1615, ttr=0.0760,
+      //                                        tev=0.1615, shadowEV=0.05.
+      // Available (non-null) weights = 0.1995 + 0.1615 + 0.0760 + 0.1615 + 0.05 = 0.6485
+      const weightedSum = 0.5 * 0.1995 + 0.8 * 0.1615 + 0.6 * 0.0760;
+      const totalWeight = 0.1995 + 0.1615 + 0.0760 + 0.1615 + 0.05;
+      expect(MarketScorer.compositeScore(dims)).toBeCloseTo(weightedSum / totalWeight, 4);
     });
 
     it('handles mixed scores correctly', () => {
@@ -428,12 +438,16 @@ describe('MarketScorer', () => {
         dataQuality: 0.7,
         typeExpectedValue: 0,
         realizedVolatility: null,
+        shadowExpectedValue: 0,
       };
-      // All dimensions present except realizedVolatility (null).
-      // Available weights: 0.21 + 0.17 + 0.15 + 0.08 + 0.10 + 0.17 = 0.88
+      // All dims present except realizedVolatility (null).
+      // Post-Task-4 rescaled WEIGHTS (×0.95): trade=0.1995, liq=0.1615, vol=0.1425,
+      //                                        ttr=0.0760, dq=0.0950, tev=0.1615, shadowEV=0.05.
       const weightedSum =
-        0.8 * 0.21 + 0.6 * 0.17 + 0.5 * 0.15 + 0.9 * 0.08 + 0.7 * 0.10 + 0 * 0.17;
-      const expected = weightedSum / 0.88;
+        0.8 * 0.1995 + 0.6 * 0.1615 + 0.5 * 0.1425 + 0.9 * 0.0760 + 0.7 * 0.0950 +
+        0 * 0.1615 + 0 * 0.05;
+      const totalWeight = 0.1995 + 0.1615 + 0.1425 + 0.0760 + 0.0950 + 0.1615 + 0.05;
+      const expected = weightedSum / totalWeight;
       expect(MarketScorer.compositeScore(dims)).toBeCloseTo(expected, 5);
     });
   });
@@ -495,6 +509,7 @@ describe('MarketScorer', () => {
         dataQuality: 0.0,
         typeExpectedValue: 0.0,
         realizedVolatility: 0.0,
+        shadowExpectedValue: 0.0,
       };
       // Equal weights for tradeability and ttr, zero for others
       const customWeights: ScorerWeights = {
@@ -520,6 +535,7 @@ describe('MarketScorer', () => {
         dataQuality: null,
         typeExpectedValue: 0.0,
         realizedVolatility: null,
+        shadowExpectedValue: 0.0,
       };
       // Unequal weights (don't sum to 1)
       const customWeights: ScorerWeights = {
@@ -544,7 +560,7 @@ describe('MarketScorer', () => {
       const dims: ScoreDimensions = {
         tradeability: 1, liquidity: 1, volatility: null,
         ttr: 1, dataQuality: null, typeExpectedValue: 1,
-        realizedVolatility: null,
+        realizedVolatility: null, shadowExpectedValue: 0,
       };
       const weights: ScorerWeights = {
         tradeability: 0.25, liquidity: 0.20, volatility: 0.15,
@@ -561,7 +577,7 @@ describe('MarketScorer', () => {
       const dims: ScoreDimensions = {
         tradeability: 1, liquidity: 1, volatility: null,
         ttr: 1, dataQuality: null, typeExpectedValue: 0,
-        realizedVolatility: null,
+        realizedVolatility: null, shadowExpectedValue: 0,
       };
       const weights: ScorerWeights = {
         tradeability: 0.25, liquidity: 0.20, volatility: 0.15,
@@ -848,6 +864,7 @@ describe('MarketScorer', () => {
         dataQuality: null,
         typeExpectedValue: 0.75,
         realizedVolatility: null,
+        shadowExpectedValue: 0.5,
       };
       expect(dims.typeExpectedValue).toBe(0.75);
     });
@@ -871,14 +888,14 @@ describe('MarketScorer', () => {
       const dims: ScoreDimensions = {
         tradeability: 1, liquidity: 0.5, volatility: null,
         ttr: 0.5, dataQuality: null, typeExpectedValue: 0.75,
-        realizedVolatility: 0.6,
+        realizedVolatility: 0.6, shadowExpectedValue: 0.5,
       };
       expect(dims.realizedVolatility).toBe(0.6);
 
       const dimsNull: ScoreDimensions = {
         tradeability: 1, liquidity: 0.5, volatility: null,
         ttr: 0.5, dataQuality: null, typeExpectedValue: 0.75,
-        realizedVolatility: null,
+        realizedVolatility: null, shadowExpectedValue: 0.5,
       };
       expect(dimsNull.realizedVolatility).toBeNull();
     });
@@ -1323,6 +1340,43 @@ describe('MarketScorer', () => {
 
     it('typeExpectedValue weight is 0.1615 (rescaled from 0.17 by 0.95)', () => {
       expect(WEIGHTS.typeExpectedValue).toBeCloseTo(0.1615, 6);
+    });
+  });
+
+  describe('MarketScorer.compositeScore — shadowExpectedValue integration', () => {
+    // All other dims at neutral 0.5 to isolate the shadow contribution.
+    const neutralDims = {
+      tradeability: 0.5,
+      liquidity: 0.5,
+      volatility: 0.5,
+      ttr: 0.5,
+      dataQuality: 0.5,
+      typeExpectedValue: 0.5,
+      realizedVolatility: 0.5,
+    };
+
+    it('shadowEV neutral (0.5) → composite is 0.5 (all dims neutral)', () => {
+      const score = MarketScorer.compositeScore({
+        ...neutralDims,
+        shadowExpectedValue: 0.5,
+      });
+      expect(score).toBeCloseTo(0.5, 6);
+    });
+
+    it('shadowEV at 1.0 lifts composite by 0.025 (= 0.05 × 0.5)', () => {
+      const score = MarketScorer.compositeScore({
+        ...neutralDims,
+        shadowExpectedValue: 1.0,
+      });
+      expect(score).toBeCloseTo(0.525, 6);
+    });
+
+    it('shadowEV at 0.0 drags composite by 0.025', () => {
+      const score = MarketScorer.compositeScore({
+        ...neutralDims,
+        shadowExpectedValue: 0.0,
+      });
+      expect(score).toBeCloseTo(0.475, 6);
     });
   });
 });

--- a/packages/data-collector/src/services/MarketScorer.test.ts
+++ b/packages/data-collector/src/services/MarketScorer.test.ts
@@ -1275,4 +1275,37 @@ describe('MarketScorer', () => {
       expect(insertCalls[0]).toContain('score_type_expected_value');
     });
   });
+
+  describe('MarketScorer.shadowExpectedValue', () => {
+    it('returns 0.5 (neutral) when sharpe is null', () => {
+      expect(MarketScorer.shadowExpectedValue(null, 100)).toBe(0.5);
+    });
+
+    it('returns 0.5 (neutral) when nTrades < MIN_N (5)', () => {
+      expect(MarketScorer.shadowExpectedValue(0.7, 4)).toBe(0.5);
+      expect(MarketScorer.shadowExpectedValue(0.7, 5)).not.toBe(0.5);
+    });
+
+    it('mirrors typeExpectedValue formula for the same inputs', () => {
+      // Identical shrinkage and mapping: expect identical output.
+      const sharpe = 0.5;
+      const n = 100;
+      expect(MarketScorer.shadowExpectedValue(sharpe, n))
+        .toBeCloseTo(MarketScorer.typeExpectedValue(sharpe, n), 6);
+    });
+
+    it('clamps to [0, 1]', () => {
+      expect(MarketScorer.shadowExpectedValue(10, 100)).toBe(1);
+      expect(MarketScorer.shadowExpectedValue(-10, 100)).toBe(0);
+    });
+
+    it('honors K override', () => {
+      const sharpe = 0.5;
+      const n = 100;
+      const default_K = MarketScorer.shadowExpectedValue(sharpe, n);
+      const high_K = MarketScorer.shadowExpectedValue(sharpe, n, 1000);
+      // Higher K shrinks more aggressively → output closer to 0.5.
+      expect(Math.abs(high_K - 0.5)).toBeLessThan(Math.abs(default_K - 0.5));
+    });
+  });
 });

--- a/packages/data-collector/src/services/MarketScorer.test.ts
+++ b/packages/data-collector/src/services/MarketScorer.test.ts
@@ -724,11 +724,12 @@ describe('MarketScorer', () => {
       //   liquidity    = log(30M) / log(30M) = 1.0, spread ≤ 0.03 → no penalty → 1.0
       //   ttr          = 1.0  (30 days → 7-60 day optimal window)
       //   volatility   = null, dataQuality = null → excluded
-      //   typeEV = 0.5 (neutral — no category_performance data for event_short, neutral for NULL)
-      // non-null weights: 0.25 + 0.20 + 0.10 + 0.20 = 0.75
-      // weightedSum = 1.0*0.25 + 1.0*0.20 + 1.0*0.10 + 0.5*0.20 = 0.65
-      // composite = 0.65 / 0.75 = 0.8667
-      // No prior multiplier — typeEV is now a composite dimension.
+      //   typeEV       = 0.5 (neutral — no category_performance data for event_short, neutral for NULL)
+      //   shadowEV     = 0.5 (neutral — no category_performance_shadow data either)
+      // non-null weights: 0.25 + 0.20 + 0.10 + 0.20 + 0.05 = 0.80
+      // weightedSum = 1.0*0.25 + 1.0*0.20 + 1.0*0.10 + 0.5*0.20 + 0.5*0.05 = 0.675
+      // composite = 0.675 / 0.80 = 0.84375
+      // No prior multiplier — typeEV/shadowEV are composite dimensions.
 
       // Find the event_short UPDATE: params[0]=marketType, params[1]=conditionId, params[2]=score
       const eventShortCall = querySpy.mock.calls.find(
@@ -740,7 +741,7 @@ describe('MarketScorer', () => {
       const eventShortParams = eventShortCall?.[1] as Array<string | number>;
       expect(eventShortParams?.[0]).toBe('event_short');
       expect(eventShortParams?.[1]).toBe('cold-1');
-      expect(eventShortParams?.[2] as number).toBeCloseTo(0.8667, 3);
+      expect(eventShortParams?.[2] as number).toBeCloseTo(0.84375, 4);
 
       // Find the NULL-type UPDATE: params[0] = null (the parameterized market_type)
       const nullTypeCall = querySpy.mock.calls.find(
@@ -752,7 +753,7 @@ describe('MarketScorer', () => {
       const nullTypeParams = nullTypeCall?.[1] as Array<string | number | null>;
       expect(nullTypeParams?.[0]).toBeNull();
       expect(nullTypeParams?.[1]).toBe('cold-2');
-      expect(nullTypeParams?.[2] as number).toBeCloseTo(0.8667, 3);
+      expect(nullTypeParams?.[2] as number).toBeCloseTo(0.84375, 4);
 
       vi.restoreAllMocks();
     });
@@ -845,11 +846,13 @@ describe('MarketScorer', () => {
       const firstCall = captured[0] as Array<unknown>;
       expect(firstCall[0]).toBe('event_financial');  // market_type param ($1)
       expect(firstCall[1]).toBe('ef-1');              // condition_id param ($2)
-      // typeEV = (0.27*159/179 + 1) / 1.5 ≈ 0.8264
+      // typeEV   = (0.27*159/179 + 1) / 1.5 ≈ 0.8264
+      // shadowEV = same as typeEV (mock matches both category_performance and category_performance_shadow queries)
       // tradeability=1.0 (price=0.5), liquidity=1.0 (vol=30M=MAX_VOLUME_REF), ttr=1.0 (30d optimal)
-      // weights (non-null): trade=0.25, liq=0.20, ttr=0.10, tev=0.20 → totalW=0.75
-      // score = (1.0*0.25 + 1.0*0.20 + 1.0*0.10 + 0.8264*0.20) / 0.75 ≈ 0.7153/0.75 ≈ 0.9537
-      expect(firstCall[2] as number).toBeCloseTo(0.9537, 2);
+      // weights (non-null): trade=0.25, liq=0.20, ttr=0.10, tev=0.20, shadowEV=0.05 → totalW=0.80
+      // weightedSum = 1.0*0.25 + 1.0*0.20 + 1.0*0.10 + 0.8264*0.20 + 0.8264*0.05 = 0.75660
+      // score = 0.75660 / 0.80 ≈ 0.9458
+      expect(firstCall[2] as number).toBeCloseTo(0.9458, 2);
     });
   });
 
@@ -1097,11 +1100,11 @@ describe('MarketScorer', () => {
       // The score param is index 2 (after marketType, conditionId).
       const score = updateCall!.params![2] as number;
       // All non-null dims at 1 (tradeability=1, liquidity=1 with 30M vol = MAX_VOLUME_REF, ttr=1,
-      // typeEV=0.5 since categoryMetrics has no event_long row, realizedVol=1).
-      // Non-null weighted sum = 1.0*0.21 + 1.0*0.17 + 1.0*0.08 + 0.5*0.17 + 1.0*0.12 = 0.665
-      // Normalized by (0.21+0.17+0.08+0.17+0.12) = 0.75
-      // Score = 0.665 / 0.75 ≈ 0.8867
-      expect(score).toBeCloseTo(0.8867, 2);
+      // typeEV=0.5 since categoryMetrics has no event_long row, realizedVol=1, shadowEV=0.5 neutral).
+      // Non-null weighted sum = 1.0*0.21 + 1.0*0.17 + 1.0*0.08 + 0.5*0.17 + 1.0*0.12 + 0.5*0.05 = 0.69
+      // Normalized by (0.21+0.17+0.08+0.17+0.12+0.05) = 0.80
+      // Score = 0.69 / 0.80 = 0.8625
+      expect(score).toBeCloseTo(0.8625, 2);
     });
   });
 

--- a/packages/data-collector/src/services/MarketScorer.ts
+++ b/packages/data-collector/src/services/MarketScorer.ts
@@ -32,6 +32,7 @@ export interface ScoreDimensions {
   dataQuality: number | null;
   typeExpectedValue: number;
   realizedVolatility: number | null;
+  shadowExpectedValue: number;       // NEW — always present (0.5 neutral default)
 }
 
 export interface ScorerWeights {
@@ -206,6 +207,29 @@ export class MarketScorer {
     if (!Number.isFinite(K)) K = SCORER_SHRINKAGE_K;
     if (sharpe === null || nTrades < MIN_N) return 0.5;
     const shrunk = (sharpe * nTrades) / (nTrades + K);
+    return clamp01((shrunk + 1) / 1.5);
+  }
+
+  /**
+   * Shadow Expected Value dimension.
+   *
+   * Reads the haircut-adjusted shadow Sharpe (effectiveSharpe = raw_shadow_Sharpe × SHADOW_HAIRCUT,
+   * applied by the writer in MarketPerformanceTracker.updateShadowCategoryPerformance).
+   * Returns 0.5 (neutral) when shadow data is insufficient (sharpe null or n_trades below MIN_N).
+   *
+   * Identical formula to typeExpectedValue — the only difference is the data source. Reusing the
+   * same shrinkage and clamp mapping keeps both dimensions on a comparable [0, 1] scale, so the
+   * weighted sum in compositeScore behaves predictably.
+   */
+  static shadowExpectedValue(
+    effectiveSharpe: number | null,
+    nTrades: number,
+    K: number = SCORER_SHRINKAGE_K,
+    MIN_N: number = 5,
+  ): number {
+    if (!Number.isFinite(K)) K = SCORER_SHRINKAGE_K;
+    if (effectiveSharpe === null || nTrades < MIN_N) return 0.5;
+    const shrunk = (effectiveSharpe * nTrades) / (nTrades + K);
     return clamp01((shrunk + 1) / 1.5);
   }
 

--- a/packages/data-collector/src/services/MarketScorer.ts
+++ b/packages/data-collector/src/services/MarketScorer.ts
@@ -5,14 +5,16 @@ const logger = pino({ name: 'MarketScorer' });
 
 // ─── Constants ─────────────────────────────────────────────────────────
 export const WEIGHTS = {
-  tradeability:       0.21,
-  liquidity:          0.17,
-  volatility:         0.15,
-  ttr:                0.08,
-  dataQuality:        0.10,
-  typeExpectedValue:  0.17,
-  realizedVolatility: 0.12,
+  tradeability:        0.1995,  // 0.21 × 0.95
+  liquidity:           0.1615,  // 0.17 × 0.95
+  volatility:          0.1425,  // 0.15 × 0.95
+  ttr:                 0.0760,  // 0.08 × 0.95
+  dataQuality:         0.0950,  // 0.10 × 0.95
+  typeExpectedValue:   0.1615,  // 0.17 × 0.95
+  realizedVolatility:  0.1140,  // 0.12 × 0.95
+  shadowExpectedValue: 0.0500,  // NEW
 } as const;
+// Total: 1.0000
 
 export const MAX_VOLUME_REF = 30_000_000;
 
@@ -43,6 +45,7 @@ export interface ScorerWeights {
   dataQuality: number;
   typeExpectedValue: number;
   realizedVolatility: number;
+  shadowExpectedValue: number;     // NEW
 }
 
 export interface EnrichUpdate {
@@ -352,17 +355,18 @@ export class MarketScorer {
 
       weights = row
         ? {
-            tradeability:       Number(row.tradeability),
-            liquidity:          Number(row.liquidity),
-            volatility:         Number(row.volatility),
-            ttr:                Number(row.ttr),
-            dataQuality:        Number(row.data_quality),
-            typeExpectedValue:  row.type_expected_value !== null
+            tradeability:        Number(row.tradeability),
+            liquidity:           Number(row.liquidity),
+            volatility:          Number(row.volatility),
+            ttr:                 Number(row.ttr),
+            dataQuality:         Number(row.data_quality),
+            typeExpectedValue:   row.type_expected_value !== null
               ? Number(row.type_expected_value)
               : WEIGHTS.typeExpectedValue,
-            realizedVolatility: row.realized_volatility !== null
+            realizedVolatility:  row.realized_volatility !== null
               ? Number(row.realized_volatility)
               : WEIGHTS.realizedVolatility,
+            shadowExpectedValue: WEIGHTS.shadowExpectedValue,  // NEW — always WEIGHTS default; per-type DB override out of scope
           }
         : { ...WEIGHTS };
 

--- a/packages/data-collector/src/services/MarketScorer.ts
+++ b/packages/data-collector/src/services/MarketScorer.ts
@@ -385,31 +385,48 @@ export class MarketScorer {
 
   // ─── Static method: load category metrics from DB ─────────────────
   /**
-   * Load current category_performance keyed by market_type.
-   * Used once per scoring run to compute typeExpectedValue per market.
+   * Load both live and shadow category metrics in parallel.
    * Returned numerics are coerced from pg strings.
-   * Falls back to empty Map on any error (table missing, DB down, etc.).
+   * Falls back to empty maps on any error (table missing, DB down, etc.).
+   *
+   * Live source: category_performance (existing).
+   * Shadow source: category_performance_shadow (new in this PR; sharpe_ratio is
+   * already haircut-adjusted by the writer).
    */
-  static async loadCategoryMetrics(): Promise<Map<string, { sharpe: number | null; n: number }>> {
+  static async loadAllCategoryMetrics(): Promise<{
+    live: Map<string, { sharpe: number | null; n: number }>;
+    shadow: Map<string, { sharpe: number | null; n: number }>;
+  }> {
+    const empty = {
+      live: new Map<string, { sharpe: number | null; n: number }>(),
+      shadow: new Map<string, { sharpe: number | null; n: number }>(),
+    };
     try {
-      const result = await query<{
-        market_type: string;
-        sharpe_ratio: number | string | null;
-        n_trades: number | string;
-      }>(
-        `SELECT market_type, sharpe_ratio, n_trades FROM category_performance`,
-      );
-      const map = new Map<string, { sharpe: number | null; n: number }>();
-      for (const r of result.rows) {
-        map.set(r.market_type, {
+      const [liveResult, shadowResult] = await Promise.all([
+        query<{ market_type: string; sharpe_ratio: number | string | null; n_trades: number | string }>(
+          `SELECT market_type, sharpe_ratio, n_trades FROM category_performance`,
+        ),
+        query<{ market_type: string; sharpe_ratio: number | string | null; n_trades: number | string }>(
+          `SELECT market_type, sharpe_ratio, n_trades FROM category_performance_shadow`,
+        ),
+      ]);
+      const live = new Map<string, { sharpe: number | null; n: number }>();
+      for (const r of liveResult.rows) {
+        live.set(r.market_type, {
           sharpe: r.sharpe_ratio !== null ? Number(r.sharpe_ratio) : null,
           n: Number(r.n_trades),
         });
       }
-      return map;
+      const shadow = new Map<string, { sharpe: number | null; n: number }>();
+      for (const r of shadowResult.rows) {
+        shadow.set(r.market_type, {
+          sharpe: r.sharpe_ratio !== null ? Number(r.sharpe_ratio) : null,
+          n: Number(r.n_trades),
+        });
+      }
+      return { live, shadow };
     } catch {
-      // Missing table or DB error → neutral typeEV (0.5) for all types.
-      return new Map();
+      return empty;
     }
   }
 

--- a/packages/data-collector/src/services/MarketScorer.ts
+++ b/packages/data-collector/src/services/MarketScorer.ts
@@ -59,6 +59,7 @@ export interface EnrichUpdate {
   dataQuality: number | null;
   typeExpectedValue: number;
   realizedVolatility: number | null;
+  shadowExpectedValue: number;       // NEW
   currentPriceYes: number | null;
   volume24h: number | null;
   marketType: string | null;
@@ -452,8 +453,10 @@ export class MarketScorer {
    * @returns { scored, enriched } counts
    */
   async scoreAllMarkets(): Promise<{ scored: number; enriched: number }> {
-    // Load category metrics (sharpe + n_trades per type) for typeExpectedValue computation.
-    const categoryMetrics = await MarketScorer.loadCategoryMetrics();
+    // Load both live and shadow category metrics in parallel.
+    // Live → typeExpectedValue. Shadow → shadowExpectedValue (haircut already applied by writer).
+    const { live: liveMetrics, shadow: shadowMetrics } =
+      await MarketScorer.loadAllCategoryMetrics();
 
     // Fetch all cold candidates.
     const pass1Candidates = await query<Pass1CandidateRow>(`
@@ -490,10 +493,15 @@ export class MarketScorer {
       if (rows.length === 0) continue;
 
       const weights = await MarketScorer.loadWeights(marketType);
-      const metrics = categoryMetrics.get(marketType);
+      const liveRow = liveMetrics.get(marketType);
+      const shadowRow = shadowMetrics.get(marketType);
       const typeEV = MarketScorer.typeExpectedValue(
-        metrics?.sharpe ?? null,
-        metrics?.n ?? 0,
+        liveRow?.sharpe ?? null,
+        liveRow?.n ?? 0,
+      );
+      const shadowEV = MarketScorer.shadowExpectedValue(
+        shadowRow?.sharpe ?? null,
+        shadowRow?.n ?? 0,
       );
 
       const updates = rows.map((row) => {
@@ -519,6 +527,7 @@ export class MarketScorer {
           dataQuality: null,
           typeExpectedValue: typeEV,
           realizedVolatility,
+          shadowExpectedValue: shadowEV,
         }, weights);
 
         return {
@@ -532,6 +541,7 @@ export class MarketScorer {
           dataQuality: null,
           typeExpectedValue: typeEV,
           realizedVolatility,
+          shadowExpectedValue: shadowEV,
           currentPriceYes: row.current_price_yes != null ? Number(row.current_price_yes) : null,
           volume24h: row.volume_24h != null ? Number(row.volume_24h) : null,
           marketType: row.market_type ?? null,
@@ -547,6 +557,7 @@ export class MarketScorer {
     if (nullRows.length > 0) {
       const weights = await MarketScorer.loadWeights(null);
       const typeEV = 0.5; // neutral for unknown type
+      const shadowEV = MarketScorer.shadowExpectedValue(null, 0); // neutral 0.5
 
       const updates = nullRows.map((row) => {
         const tradeability = MarketScorer.tradeabilityScore(
@@ -571,6 +582,7 @@ export class MarketScorer {
           dataQuality: null,
           typeExpectedValue: typeEV,
           realizedVolatility,
+          shadowExpectedValue: shadowEV,
         }, weights);
 
         return {
@@ -584,6 +596,7 @@ export class MarketScorer {
           dataQuality: null,
           typeExpectedValue: typeEV,
           realizedVolatility,
+          shadowExpectedValue: shadowEV,
           currentPriceYes: row.current_price_yes != null ? Number(row.current_price_yes) : null,
           volume24h: row.volume_24h != null ? Number(row.volume_24h) : null,
           marketType: null,
@@ -654,10 +667,15 @@ export class MarketScorer {
 
     for (const row of trackedRows) {
       const weights = await MarketScorer.loadWeights(row.market_type ?? null);
-      const metrics = categoryMetrics.get(row.market_type ?? '');
+      const liveRow = row.market_type != null ? liveMetrics.get(row.market_type) : undefined;
+      const shadowRow = row.market_type != null ? shadowMetrics.get(row.market_type) : undefined;
       const typeEV = MarketScorer.typeExpectedValue(
-        metrics?.sharpe ?? null,
-        metrics?.n ?? 0,
+        liveRow?.sharpe ?? null,
+        liveRow?.n ?? 0,
+      );
+      const shadowEV = MarketScorer.shadowExpectedValue(
+        shadowRow?.sharpe ?? null,
+        shadowRow?.n ?? 0,
       );
 
       const tradeability = MarketScorer.tradeabilityScore(
@@ -691,6 +709,7 @@ export class MarketScorer {
         dataQuality,
         typeExpectedValue: typeEV,
         realizedVolatility,
+        shadowExpectedValue: shadowEV,
       }, weights);
 
       enrichUpdates.push({
@@ -704,6 +723,7 @@ export class MarketScorer {
         dataQuality,
         typeExpectedValue: typeEV,
         realizedVolatility,
+        shadowExpectedValue: shadowEV,
         currentPriceYes: row.current_price_yes != null ? Number(row.current_price_yes) : null,
         volume24h: row.volume_24h != null ? Number(row.volume_24h) : null,
         marketType: row.market_type ?? null,

--- a/packages/data-collector/src/services/MarketScorer.ts
+++ b/packages/data-collector/src/services/MarketScorer.ts
@@ -279,6 +279,10 @@ export class MarketScorer {
     weightedSum += dims.typeExpectedValue * weights.typeExpectedValue;
     totalWeight += weights.typeExpectedValue;
 
+    // shadowExpectedValue is always present (returns 0.5 neutral when shadow data missing)
+    weightedSum += dims.shadowExpectedValue * weights.shadowExpectedValue;
+    totalWeight += weights.shadowExpectedValue;
+
     // Optional dimensions
     if (dims.volatility !== null) {
       weightedSum += dims.volatility * weights.volatility;

--- a/packages/data-collector/src/services/Scheduler.ts
+++ b/packages/data-collector/src/services/Scheduler.ts
@@ -9,7 +9,11 @@ import { ExternalDataCollector } from '../collectors/ExternalDataCollector.js';
 import { MarketScorer } from './MarketScorer.js';
 import { MarketRotator } from './MarketRotator.js';
 import { optimizeScorerWeights } from './ScorerWeightOptimizer.js';
-import { updateCategoryPriors, resolveShadowTrades } from './MarketPerformanceTracker.js';
+import {
+  updateCategoryPriors,
+  updateShadowCategoryPerformance,
+  resolveShadowTrades,
+} from './MarketPerformanceTracker.js';
 import { NewsCollector } from '../collectors/NewsCollector.js';
 
 const logger = pino({ name: 'scheduler' });
@@ -503,6 +507,7 @@ export class Scheduler {
    */
   private async computeMarketPriors(): Promise<void> {
     await updateCategoryPriors();
+    await updateShadowCategoryPerformance();
     await resolveShadowTrades();
   }
 

--- a/packages/data-collector/src/services/ScorerWeightOptimizer.test.ts
+++ b/packages/data-collector/src/services/ScorerWeightOptimizer.test.ts
@@ -29,14 +29,14 @@ describe('pearsonCorrelation', () => {
 describe('computeObjective', () => {
   const weights: ScorerWeights = {
     tradeability: 0.30, liquidity: 0.25, volatility: 0.20, ttr: 0.15, dataQuality: 0.10,
-    typeExpectedValue: 0.20, realizedVolatility: 0.05,
+    typeExpectedValue: 0.20, realizedVolatility: 0.05, shadowExpectedValue: 0.05,
   };
 
   it('returns positive correlation when high-score trades have positive pnl', () => {
     const trades = [
-      { dims: { tradeability: 1.0, liquidity: 0.8, ttr: 0.9, volatility: null, dataQuality: null, typeExpectedValue: 0.5, realizedVolatility: null }, pnl: 10 },
-      { dims: { tradeability: 0.1, liquidity: 0.1, ttr: 0.2, volatility: null, dataQuality: null, typeExpectedValue: 0.5, realizedVolatility: null }, pnl: -5 },
-      { dims: { tradeability: 0.8, liquidity: 0.7, ttr: 0.8, volatility: null, dataQuality: null, typeExpectedValue: 0.5, realizedVolatility: null }, pnl: 7 },
+      { dims: { tradeability: 1.0, liquidity: 0.8, ttr: 0.9, volatility: null, dataQuality: null, typeExpectedValue: 0.5, realizedVolatility: null, shadowExpectedValue: 0.5 }, pnl: 10 },
+      { dims: { tradeability: 0.1, liquidity: 0.1, ttr: 0.2, volatility: null, dataQuality: null, typeExpectedValue: 0.5, realizedVolatility: null, shadowExpectedValue: 0.5 }, pnl: -5 },
+      { dims: { tradeability: 0.8, liquidity: 0.7, ttr: 0.8, volatility: null, dataQuality: null, typeExpectedValue: 0.5, realizedVolatility: null, shadowExpectedValue: 0.5 }, pnl: 7 },
     ];
     const result = computeObjective(weights, trades);
     expect(result).toBeGreaterThan(0);
@@ -45,8 +45,8 @@ describe('computeObjective', () => {
 
   it('returns 0 when all pnl are identical (no variance)', () => {
     const trades = [
-      { dims: { tradeability: 0.5, liquidity: 0.5, ttr: 0.5, volatility: null, dataQuality: null, typeExpectedValue: 0.5, realizedVolatility: null }, pnl: 5 },
-      { dims: { tradeability: 0.8, liquidity: 0.8, ttr: 0.8, volatility: null, dataQuality: null, typeExpectedValue: 0.5, realizedVolatility: null }, pnl: 5 },
+      { dims: { tradeability: 0.5, liquidity: 0.5, ttr: 0.5, volatility: null, dataQuality: null, typeExpectedValue: 0.5, realizedVolatility: null, shadowExpectedValue: 0.5 }, pnl: 5 },
+      { dims: { tradeability: 0.8, liquidity: 0.8, ttr: 0.8, volatility: null, dataQuality: null, typeExpectedValue: 0.5, realizedVolatility: null, shadowExpectedValue: 0.5 }, pnl: 5 },
     ];
     expect(computeObjective(weights, trades)).toBe(0);
   });

--- a/packages/data-collector/src/services/ScorerWeightOptimizer.ts
+++ b/packages/data-collector/src/services/ScorerWeightOptimizer.ts
@@ -40,13 +40,14 @@ export function computeObjective(weights: ScorerWeights, trades: ClosedTrade[]):
 function randomWeights(): ScorerWeights {
   const r = () => Math.random() * 0.6 + 0.05; // uniform [0.05, 0.65]
   return {
-    tradeability:       r(),
-    liquidity:          r(),
-    volatility:         WEIGHTS.volatility,
-    ttr:                r(),
-    dataQuality:        WEIGHTS.dataQuality,
-    typeExpectedValue:  r(),
-    realizedVolatility: r(), // 5th optimizable dim
+    tradeability:        r(),
+    liquidity:           r(),
+    volatility:          WEIGHTS.volatility,
+    ttr:                 r(),
+    dataQuality:         WEIGHTS.dataQuality,
+    typeExpectedValue:   r(),
+    realizedVolatility:  r(), // 5th optimizable dim
+    shadowExpectedValue: WEIGHTS.shadowExpectedValue, // fixed; not optimized in this pass
   };
 }
 
@@ -73,13 +74,14 @@ async function loadClosedTrades(marketType: string | null): Promise<ClosedTrade[
     const d = r.score_dimensions_at_entry;
     return {
       dims: {
-        tradeability:       d.tradeability       ?? 0,
-        liquidity:          d.liquidity          ?? 0,
-        volatility:         d.volatility         ?? null,
-        ttr:                d.ttr                ?? 0,
-        dataQuality:        d.dataQuality        ?? null,
-        typeExpectedValue:  d.typeExpectedValue   ?? 0.5,
-        realizedVolatility: d.realizedVolatility  ?? null,
+        tradeability:        d.tradeability        ?? 0,
+        liquidity:           d.liquidity           ?? 0,
+        volatility:          d.volatility          ?? null,
+        ttr:                 d.ttr                 ?? 0,
+        dataQuality:         d.dataQuality         ?? null,
+        typeExpectedValue:   d.typeExpectedValue   ?? 0.5,
+        realizedVolatility:  d.realizedVolatility  ?? null,
+        shadowExpectedValue: d.shadowExpectedValue ?? 0.5, // neutral when historical entry pre-dates dim
       },
       pnl: parseFloat(r.realized_pnl),
     };

--- a/scripts/daily-review-prompt.md
+++ b/scripts/daily-review-prompt.md
@@ -663,3 +663,37 @@ Integration tests run against isolated test tables (`test_paper_*`) and are safe
 - **No `Fixes #N` / `Closes #N`** in commits or PR bodies — GitHub auto-closes issues on merge. Use `Related to #N`.
 - **Always rollback VM to main** after each PR verification
 - **Maximum 3 PRs per run** — document remaining fixes in the issue for manual follow-up
+
+## Shadow haircut validation (post-PR scoring change)
+
+A shadow-derived dimension `shadowExpectedValue` (weight 0.05) was added to the
+MarketScorer composite. The shadow Sharpe is haircut-adjusted at write time
+(`SHADOW_HAIRCUT`, default 0.33) by `updateShadowCategoryPerformance`. Verify the
+haircut is well-calibrated.
+
+```sql
+SELECT cp.market_type,
+       cp.sharpe_ratio AS live_sharpe,
+       cp.n_trades AS live_n,
+       cps.sharpe_ratio AS shadow_effective_sharpe,
+       cps.n_trades AS shadow_n,
+       cps.haircut_applied,
+       -- Implied haircut: if live is the realised target, what would the
+       -- haircut have to be for shadow_effective to match?
+       CASE
+         WHEN cp.n_trades >= 30 AND cps.n_trades >= 30 AND cps.sharpe_ratio != 0
+         THEN ROUND(
+           (cp.sharpe_ratio / NULLIF(cps.sharpe_ratio / cps.haircut_applied, 0))::numeric,
+           3
+         )
+         ELSE NULL
+       END AS implied_haircut
+FROM category_performance cp
+LEFT JOIN category_performance_shadow cps ON cps.market_type = cp.market_type
+ORDER BY cp.market_type;
+```
+
+Interpretation rules:
+- **Both sides have ≥ 30 trades**: `implied_haircut` should be in `[0.15, 0.55]` (≈ 0.33 ± 0.20). Outside that band → flag for per-type haircut consideration (out of scope; follow-up PR).
+- **Shadow only**: the only evidence is theoretical. Note in the review.
+- **Sign disagreement** (live positive vs shadow negative or vice versa): flag for human review — likely regime divergence.


### PR DESCRIPTION
## Summary

Adds `shadowExpectedValue` dimension (weight 0.05) to `MarketScorer` fed by a new `category_performance_shadow` table. Shadow Sharpe is haircut-adjusted at write time (`SHADOW_HAIRCUT`, default 0.33). Live `category_performance` and `typeExpectedValue` are **untouched**.

Spec: `docs/plans/2026-05-01-shadow-haircut-scorer-integration-design.md`
Plan: `docs/plans/2026-05-01-shadow-haircut-scorer-integration-plan.md`

## Why

`event_short` has shadow Sharpe +2.03 (n=444, 88.5% WR) but `category_performance.sharpe_ratio` of +0.13 (n=419 historic live). Scorer reads only live → event_short never gets the shadow boost. Result: 14 cold candidates, only 2 active.

Empirical analysis (this PR): fee subtraction moves shadow Sharpe in the 4th decimal. The gap is structural (early exits, risk gates, sizing), not modelable with a multiplicative haircut on combined Sharpe. Adding shadow as a separate downweighted dim is more rigorous.

## Pre-computed impact

| type | composite contribution before | after | Δ |
|---|---|---|---|
| event_short | 0.127 | 0.171 | +0.044 |
| event_financial | 0.138 | 0.131 | -0.007 |

Spread flip: event_short was 0.011 below event_financial; now 0.040 above. Sufficient to enter top-50.

## Architecture

```
computeMarketPriors() (daily 02:45 UTC)
  ├── updateCategoryPriors()              ← UNCHANGED
  ├── updateShadowCategoryPerformance()   ← NEW (haircut 0.33, MIN_N 30)
  └── resolveShadowTrades()               ← unchanged

MarketScorer.scoreAllMarkets()
  ├── loadAllCategoryMetrics() → { live, shadow }
  └── compositeScore({ ..., shadowExpectedValue: shadowEV }) ← +0.05 weight
```

## Constants & env vars

- `SHADOW_HAIRCUT` (default 0.33, env-tunable). Empirical from time-matched event_long Sharpe ratio (n_live=16, ratio≈0.33). Sample small; documented honestly in `memory/project_shadow_execution_realism.md`.
- `CATEGORY_MIN_SHADOW_N` (default 30, env-tunable).
- `WEIGHTS.shadowExpectedValue = 0.05` — fixed in code.

## Test plan

- [x] tsc clean per package (data-collector + dashboard)
- [x] Full vitest sweep: 853 passed / 14 skipped / 0 failed (+17 new tests)
- [x] WEIGHTS sum to 1.0 invariant
- [x] shadowExpectedValue mirrors typeExpectedValue formula
- [x] compositeScore integrates shadow weight correctly
- [x] loadAllCategoryMetrics returns parallel maps; graceful degradation on DB error
- [x] updateShadowCategoryPerformance applies haircut, honors env, gates by MIN_N
- [x] Daily review prompt has shadow validation section
- [ ] Post-deploy: \`category_performance_shadow\` rows after first 02:45 UTC run
- [ ] Post-deploy: event_short composite contribution rises as predicted; active count rises from 2

## Files touched (12 commits)

```
packages/data-collector/src/database/init/029_category_performance_shadow.sql       [new]
packages/dashboard/src/services/bootstrapShadowCategoryPerformance.ts               [new]
packages/dashboard/src/services/bootstrapShadowCategoryPerformance.test.ts          [new]
packages/dashboard/src/server.ts                                                    [+bootstrap call]
packages/data-collector/src/services/MarketScorer.ts                                [+shadowEV method, rescaled WEIGHTS, loadAllCategoryMetrics, scoreAllMarkets passes]
packages/data-collector/src/services/MarketScorer.test.ts                           [+tests, fixture updates]
packages/data-collector/src/services/MarketPerformanceTracker.ts                    [+updateShadowCategoryPerformance]
packages/data-collector/src/services/MarketPerformanceTracker.test.ts               [+tests]
packages/data-collector/src/services/Scheduler.ts                                   [+wire call]
packages/data-collector/src/services/ScorerWeightOptimizer.ts                       [+field default]
packages/data-collector/src/services/ScorerWeightOptimizer.test.ts                  [+test fixtures]
scripts/daily-review-prompt.md                                                      [+validation section]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated shadow-based performance metrics into market scoring with weight redistribution (new dimension at 5% weight).
  * Added haircut-adjusted Sharpe calculations for shadow market analysis.

* **Documentation**
  * Added design specification and integration plan for shadow scoring framework.
  * Added shadow calibration validation guidance to daily review checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->