### PR TITLE
fix(format-review): emit failure email + slack on gather_failed payload

### DIFF
--- a/scripts/format-review.js
+++ b/scripts/format-review.js
@@ -29,6 +29,73 @@ try {
   process.exit(1);
 }
 
+// ── gather_failed early-exit path ───────────────────────────────────────────
+// daily-review.sh emits {"gather_failed":true,...} via its EXIT trap when the
+// VM/DB is unreachable. In that case the JSON has none of the expected fields,
+// so build a minimal failure report (email + slack + stdout) and exit 0 so the
+// workflow's notification step still runs and the operator gets paged.
+if (data && data.gather_failed === true) {
+  const fs2 = require('fs');
+  const path2 = require('path');
+  const exitCode = data.exit_code ?? 'unknown';
+  const ts = data.generated_at || new Date().toISOString();
+  const subject = `Polymarket Daily Review FAILED — gather exit ${exitCode} (${ts})`;
+  const summary = `Daily review data collection failed (daily-review.sh exited ${exitCode} at ${ts}). The VM, DB, or SSH connection was unreachable. Check VM status and rerun the workflow.`;
+
+  const reportMd = [
+    `# Daily Trading Review — FAILED`,
+    `> Generated: ${ts}`,
+    ``,
+    `## \u{1F534} Data collection failed`,
+    ``,
+    `\`daily-review.sh\` exited with code **${exitCode}**. No metrics were gathered.`,
+    ``,
+    `Common causes:`,
+    `- VM stopped or unreachable (check \`gcloud compute instances describe polymarket-vm\`)`,
+    `- TimescaleDB container down (\`docker compose ps\`)`,
+    `- SSH auth/network failure on the GitHub runner`,
+    ``,
+    `Once the infrastructure is restored, rerun the workflow manually.`,
+    ``,
+  ].join('\n');
+
+  const emailHtml = [
+    `<!DOCTYPE html><html><body style="font-family:-apple-system,BlinkMacSystemFont,sans-serif;max-width:600px;margin:0 auto;padding:20px;">`,
+    `<h1 style="color:#d73a49;">\u{1F534} Polymarket Daily Review FAILED</h1>`,
+    `<p><strong>${escapeHtmlMinimal(summary)}</strong></p>`,
+    `<p>Generated: ${escapeHtmlMinimal(ts)}<br>Exit code: ${escapeHtmlMinimal(String(exitCode))}</p>`,
+    `<p>The workflow's <code>daily-review.sh</code> script failed before any metrics could be collected. Common causes: VM stopped, TimescaleDB down, SSH/auth failure on the runner.</p>`,
+    `<p>Restore the infrastructure and rerun the workflow manually from the GitHub Actions UI.</p>`,
+    `</body></html>`,
+  ].join('\n');
+
+  const slackPayload = {
+    text: `Polymarket Alert: ${summary}`,
+    blocks: [
+      { type: 'header', text: { type: 'plain_text', text: '\u{1F534} Polymarket Daily Review FAILED', emoji: true } },
+      { type: 'section', text: { type: 'mrkdwn', text: `*Data collection failed:* daily-review.sh exited ${exitCode} at ${ts}` } },
+      { type: 'section', text: { type: 'mrkdwn', text: 'Likely cause: VM, TimescaleDB, or SSH unreachable. Restore infra and rerun the workflow.' } },
+    ],
+  };
+
+  const outDir2 = process.cwd();
+  fs2.writeFileSync(path2.join(outDir2, 'report.md'), reportMd, 'utf8');
+  fs2.writeFileSync(path2.join(outDir2, 'email.html'), emailHtml, 'utf8');
+  fs2.writeFileSync(path2.join(outDir2, 'slack.json'), JSON.stringify(slackPayload, null, 2), 'utf8');
+
+  console.log(JSON.stringify({
+    has_critical_alerts: true,
+    alert_count: 1,
+    alerts: [`[CRITICAL] Data collection failed (gather_failed, exit ${exitCode})`],
+    gather_failed: true,
+  }));
+  process.exit(0);
+}
+
+function escapeHtmlMinimal(s) {
+  return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function fmt(n, decimals = 2) {


### PR DESCRIPTION
## Context

Pair-fix to #161. When `daily-review.sh`'s `EXIT` trap fires (VM down, DB unreachable, SSH transient), it writes `{\"gather_failed\":true,\"exit_code\":N,\"generated_at\":...}` to stdout — exactly so the workflow's `jq` validation passes and Claude runs.

But `format-review.js` then tries to walk the rest of the file expecting `account`, `alerts`, `containers`, `recently_closed` etc. — none of which exist on a failure payload. Result on today's run (2026-05-01):

```
Error parsing JSON: Unexpected end of JSON input
##[error]Process completed with exit code 1.
```

(The pre-#161 case crashed on `JSON.parse('')` because the file was 0 bytes; with #161 it would parse fine and then proceed to silently emit a half-empty email or crash later on `data.account.current_capital`.) Either way: **no email, no Slack — the operator has no idea the review even attempted to run**.

## Fix

Right after `JSON.parse`, branch on `data.gather_failed === true`:
- Write minimal `report.md` documenting the failure (exit code + timestamp + likely causes)
- Write minimal `email.html` (red header, the same text)
- Write `slack.json` with a critical-alert payload
- Print stdout summary `{has_critical_alerts:true, alert_count:1, alerts:['[CRITICAL] Data collection failed (gather_failed, exit N)']}`
- Exit 0 so the workflow's *Send notifications* step still runs

The workflow's notification step already conditionally sends Slack only when `slack.json` exists — so the new failure path triggers email + Slack, which is exactly what we want when infra is down.

## Manual verification

- `gather_failed:true` input → 3 files written, critical-alert summary printed, exit 0
- Normal payload (account + drawdown) → unchanged behavior, alerts detected as before

## Why this matters

Without this fix, every infra failure (VM stopped, billing pause, TimescaleDB OOM, SSH transient) silently drops the daily review on the floor. With #161 + this PR, the same failure path now reaches you via email + Slack with enough context to act.