### PR TITLE
fix: CB peak_equity formula + dm-flip min-lift gate enabled

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -127,6 +127,12 @@ services:
       MAX_SIGNAL_MARKETS: "35"
       ENABLE_OPTIMIZATION: "true"
       OPTIMIZER_URL: "https://polymarket-optimizer-server.onrender.com"
+      # Min Sharpe lift required to flip direction_multiplier per market_type.
+      # Default 0 (disabled) lets the optimizer flip on any improvement, which
+      # produced the event_long → +1 drift on 2026-05-01. 0.5 means a flip is
+      # only persisted when it improves Sharpe by at least 0.5 vs the previous
+      # best for that market_type — kills marginal flips, lets real ones through.
+      OPTIMIZER_DM_FLIP_MIN_LIFT: "0.5"
       POLYMARKET_API_URL: https://clob.polymarket.com
       INITIAL_CAPITAL: "10000"
       FEE_RATE: "0.001"

--- a/packages/dashboard/src/services/CircuitBreakerService.test.ts
+++ b/packages/dashboard/src/services/CircuitBreakerService.test.ts
@@ -107,7 +107,7 @@ describe('CircuitBreakerService', () => {
       .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any) // CREATE TABLE
       .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any) // SELECT paper_account (start()'s initial check — exits early)
       .mockResolvedValueOnce({  // SELECT paper_account (timer-triggered check)
-        rows: [{ current_capital: '5000', initial_capital: '10000' }],
+        rows: [{ current_capital: '5000', initial_capital: '10000', peak_equity: '10000' }],
         rowCount: 1,
       } as any)
       .mockResolvedValueOnce({  // SELECT total exposure from positions (timer-triggered check)
@@ -127,6 +127,66 @@ describe('CircuitBreakerService', () => {
     expect(service.isTradingHalted()).toBe(false);
   });
 
+  it('drawdown is computed from peak_equity, not initial_capital (avoids deadlock when peak < initial)', async () => {
+    // Account state matching the 2026-04-30 deadlock that produced the trade
+    // drought before commit 44f16d1: equity below initial but well above peak.
+    //   current_capital=8695, peak_equity=8898, total_exposure=0
+    // Pre-fix denominator (initial): (10000-8695)/10000 = 13.05% → would HALT at 13% threshold
+    // Post-fix denominator (peak):   (8898-8695)/8898 = 2.28%  → safely below threshold
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any) // CREATE TABLE
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any) // start()'s initial check (empty rows, exits early)
+      .mockResolvedValueOnce({  // timer-triggered check — note peak_equity < initial
+        rows: [{ current_capital: '8695', initial_capital: '10000', peak_equity: '8897.79' }],
+        rowCount: 1,
+      } as any)
+      .mockResolvedValueOnce({  // exposure
+        rows: [{ total_exposure: '0' }],
+        rowCount: 1,
+      } as any);
+
+    const service = new CircuitBreakerService({
+      checkIntervalMs: 60_000,
+      maxDrawdownPct: 13,  // tight enough that pre-fix would trip
+      initialCapital: 10000,
+    });
+    await service.start();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // peak-based drawdown is 2.28%, well below 13% — no halt.
+    expect(service.isTradingHalted()).toBe(false);
+  });
+
+  it('falls back to initialCapital when peak_equity is null/zero (fresh account)', async () => {
+    // Fresh account with no peak yet recorded — denominator falls back to initial.
+    // current_capital=5000, initial=10000, peak_equity=null → drawdown = 50%
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any) // CREATE TABLE
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any) // start()'s initial check (empty)
+      .mockResolvedValueOnce({  // timer-triggered check, peak_equity null
+        rows: [{ current_capital: '5000', initial_capital: '10000', peak_equity: null }],
+        rowCount: 1,
+      } as any)
+      .mockResolvedValueOnce({  // exposure
+        rows: [{ total_exposure: '0' }],
+        rowCount: 1,
+      } as any)
+      // closeAllPositions / haltTrading / etc. — let them succeed but we only
+      // care about the halt decision.
+      .mockResolvedValue({ rows: [], rowCount: 0 } as any);
+
+    const service = new CircuitBreakerService({
+      checkIntervalMs: 60_000,
+      maxDrawdownPct: 30,
+      initialCapital: 10000,
+    });
+    await service.start();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // 50% drawdown > 30% threshold → halt.
+    expect(service.isTradingHalted()).toBe(true);
+  });
+
   it('after checkDrawdown triggers halt, isTradingHalted() returns true even if DB writes fail', async () => {
     // Setup: query mock returns capital=5000 for account check (50% drawdown > 30% threshold)
     // Then all subsequent queries fail (simulating DB failure for halt/close operations)
@@ -139,8 +199,9 @@ describe('CircuitBreakerService', () => {
         return { rows: [], rowCount: 0 } as any;
       }
       if (sqlStr.includes('SELECT current_capital')) {
-        // Return low capital to trigger the circuit breaker
-        return { rows: [{ current_capital: '5000', initial_capital: '10000' }], rowCount: 1 } as any;
+        // Return low capital to trigger the circuit breaker. peak_equity matches
+        // initial here so post-fix denominator behaviour is identical to legacy.
+        return { rows: [{ current_capital: '5000', initial_capital: '10000', peak_equity: '10000' }], rowCount: 1 } as any;
       }
       if (sqlStr.includes('paper_positions')) {
         // No open positions to close

--- a/packages/dashboard/src/services/CircuitBreakerService.ts
+++ b/packages/dashboard/src/services/CircuitBreakerService.ts
@@ -221,7 +221,8 @@ export class CircuitBreakerService extends EventEmitter {
       const accountResult = await query<{
         current_capital: string;
         initial_capital: string;
-      }>('SELECT current_capital, initial_capital FROM paper_account WHERE id = 1');
+        peak_equity: string;
+      }>('SELECT current_capital, initial_capital, peak_equity FROM paper_account WHERE id = 1');
 
       if (accountResult.rows.length === 0) {
         return;
@@ -229,6 +230,9 @@ export class CircuitBreakerService extends EventEmitter {
 
       const currentCapital = parseFloat(accountResult.rows[0].current_capital);
       const initialCapital = this.config.initialCapital;
+      // peak_equity tracks the highest equity reached since last reset.
+      // Fall back to initialCapital only if DB value is absent or zero (e.g. fresh account).
+      const peakEquity = parseFloat(accountResult.rows[0].peak_equity ?? '0') || initialCapital;
 
       // Get total exposure from open positions
       const exposureResult = await query<{ total_exposure: string }>(
@@ -238,8 +242,12 @@ export class CircuitBreakerService extends EventEmitter {
       const totalExposure = parseFloat(exposureResult.rows[0]?.total_exposure || '0');
       const currentEquity = currentCapital + totalExposure;
 
-      // Calculate drawdown using equity (capital + positions), not capital alone
-      const drawdownPct = ((initialCapital - currentEquity) / initialCapital) * 100;
+      // Drawdown must be measured from peak_equity (same basis as RiskManager and
+      // AutoSignalExecutor.openPosition's proximity guard, fixed in 44f16d1). Using
+      // initialCapital as denominator silently inflated drawdown whenever cumulative
+      // realised losses exceeded the CB threshold relative to initial — the same
+      // class of bug that produced the 2026-04-30 → 2026-05-03 trade deadlock.
+      const drawdownPct = ((peakEquity - currentEquity) / peakEquity) * 100;
 
       // Check if we need to trigger circuit breaker
       if (drawdownPct >= this.config.maxDrawdownPct) {


### PR DESCRIPTION
Two follow-ups to issue #173 / commit 44f16d1.

## 1. CircuitBreakerService — peak_equity denominator

PR #168 (44f16d1) fixed `(initial - equity) / initial` → `(peak - equity) / peak` in AutoSignalExecutor's proximity guard. The same wrong denominator survived in CircuitBreakerService.ts:242. The hard CB threshold (15%) is loose enough that it didn't trip in the 2026-04-30 deadlock, but if cumulative losses ever crossed 15% of initial it would false-trigger the same way the proximity guard did at 13%.

This PR mirrors the 44f16d1 fix: read `peak_equity` from `paper_account`, fall back to `initialCapital` only when null/zero (fresh-account path).

**New tests:**
- `8695/8898` scenario (the exact deadlock state from issue #173) → drawdown 2.28%, no halt
- `peak_equity = null` → falls back to initial → 50% drawdown halts as expected

## 2. OPTIMIZER_DM_FLIP_MIN_LIFT = 0.5

The min-lift gate in `OptimizationScheduler.ts:954` exists but defaults to 0 (disabled). The optimizer was flipping `direction_multiplier` for `event_long` to `+1` on any marginal Sharpe improvement — issue #171 and #173 both flagged it as persistent.

Setting `OPTIMIZER_DM_FLIP_MIN_LIFT=0.5` in `docker-compose.gcp.yml` means flips only persist when Sharpe improves by ≥ 0.5 vs the prior best for that market_type. Marginal flips are skipped; meaningful ones still go through.

`event_long` already corrected to `-1` via direct SQL UPDATE on the VM (issue #173 action item). The gate prevents drift back next cycle.

## Out of scope (follow-up)

`OptimizationScheduler.ts:915-924` has a legacy comment claiming `direction_multiplier` is "excluded from the parameter space" but the code at 938+977 actively writes it per-type. The `update('direction_multiplier', -1.0, ...)` call resets `__global__` every cycle — benign because per-type rows take precedence in the resolver, but the comment lies. Worth a follow-up cleanup PR (remove the reset or convert to startup-only seed); not in scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Circuit breaker drawdown calculation now uses peak equity baseline instead of initial capital for more accurate halt triggers.

* **Chores**
  * Added optimizer configuration parameter for strategy adjustment persistence threshold based on Sharpe lift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->