### PR TITLE
refactor(drawdown): extract computeEquityDrawdown helper (DRY)

### DIFF
--- a/packages/dashboard/src/services/AutoSignalExecutor.ts
+++ b/packages/dashboard/src/services/AutoSignalExecutor.ts
@@ -27,6 +27,7 @@ import { getExecutionRouter } from './ExecutionRouter.js';
 import { OrderBookExecutionSimulator, type SimulationResult } from './OrderBookExecutionSimulator.js';
 import { getSignalSigmaCache } from './SignalSigmaCache.js';
 import { shouldBlockReopen, getKSigma, type PrevCloseSignal } from './concentrationGate.js';
+import { computeEquityDrawdown } from './drawdown.js';
 
 // ---------------------------------------------------------------------------
 // Inline score helpers (mirror MarketScorer statics — no cross-package import)
@@ -846,28 +847,13 @@ export class AutoSignalExecutor extends EventEmitter {
 
     // Check account has enough capital + drawdown proximity to CB threshold
     try {
-      const accountResult = await query<{ available_capital: string; current_capital: string; peak_equity: string }>(
-        'SELECT available_capital, current_capital, peak_equity FROM paper_account LIMIT 1'
-      );
-      const availableCapital = parseFloat(accountResult.rows[0]?.available_capital ?? '0');
-      const currentCapital = parseFloat(accountResult.rows[0]?.current_capital ?? '0');
       const initialCapital = parseFloat(process.env.INITIAL_CAPITAL || '10000');
-      // peak_equity tracks the highest equity reached since last reset.
-      // Fall back to initialCapital only if DB value is absent or zero (e.g. fresh account).
-      const peakEquity = parseFloat(accountResult.rows[0]?.peak_equity ?? '0') || initialCapital;
+      const dd = await computeEquityDrawdown(initialCapital);
+      if (!dd) return { executed: false, reason: 'paper_account row missing' };
+      const { availableCapital, drawdownPct } = dd;
 
       // Don't open if near CB threshold — prevents open->CB->close->reopen cycle.
-      // Drawdown must be measured from peak_equity (same basis as RiskManager) so that
-      // normal cumulative losses do not lock the guard below the real circuit-breaker
-      // threshold. Using initial_capital as denominator caused a permanent deadlock
-      // whenever cumulative losses exceeded (CB - 2%) of initial capital.
-      const exposureResult = await query<{ total_exposure: string }>(
-        `SELECT COALESCE(SUM(size * current_price), 0) as total_exposure
-         FROM paper_positions WHERE closed_at IS NULL`
-      );
-      const totalExposure = parseFloat(exposureResult.rows[0]?.total_exposure || '0');
-      const currentEquity = currentCapital + totalExposure;
-      const drawdownPct = ((peakEquity - currentEquity) / peakEquity) * 100;
+      // Peak-based denominator (see drawdown.ts header for the deadlock history).
       const CB_THRESHOLD = parseFloat(process.env.MAX_DRAWDOWN || '0.15') * 100; // env is decimal (0.15 = 15%)
       if (drawdownPct > CB_THRESHOLD - 2) {
         console.log(`[AutoSignalExecutor] Skipping open — drawdown ${drawdownPct.toFixed(1)}% too close to CB threshold ${CB_THRESHOLD}%`);

--- a/packages/dashboard/src/services/CircuitBreakerService.test.ts
+++ b/packages/dashboard/src/services/CircuitBreakerService.test.ts
@@ -198,10 +198,10 @@ describe('CircuitBreakerService', () => {
         // The start() CREATE TABLE call — succeed
         return { rows: [], rowCount: 0 } as any;
       }
-      if (sqlStr.includes('SELECT current_capital')) {
+      if (sqlStr.includes('FROM paper_account')) {
         // Return low capital to trigger the circuit breaker. peak_equity matches
         // initial here so post-fix denominator behaviour is identical to legacy.
-        return { rows: [{ current_capital: '5000', initial_capital: '10000', peak_equity: '10000' }], rowCount: 1 } as any;
+        return { rows: [{ available_capital: '5000', current_capital: '5000', initial_capital: '10000', peak_equity: '10000' }], rowCount: 1 } as any;
       }
       if (sqlStr.includes('paper_positions')) {
         // No open positions to close

--- a/packages/dashboard/src/services/CircuitBreakerService.ts
+++ b/packages/dashboard/src/services/CircuitBreakerService.ts
@@ -18,6 +18,7 @@ import { isDatabaseConfigured, query } from '../database/index.js';
 import { getTradingAutomation } from './TradingAutomation.js';
 import { getStopLossService } from './StopLossService.js';
 import { getPositionClosingService } from './PositionClosingService.js';
+import { computeEquityDrawdown } from './drawdown.js';
 
 export interface CircuitBreakerConfig {
   enabled: boolean;
@@ -217,37 +218,9 @@ export class CircuitBreakerService extends EventEmitter {
     }
 
     try {
-      // Get current account state
-      const accountResult = await query<{
-        current_capital: string;
-        initial_capital: string;
-        peak_equity: string;
-      }>('SELECT current_capital, initial_capital, peak_equity FROM paper_account WHERE id = 1');
-
-      if (accountResult.rows.length === 0) {
-        return;
-      }
-
-      const currentCapital = parseFloat(accountResult.rows[0].current_capital);
-      const initialCapital = this.config.initialCapital;
-      // peak_equity tracks the highest equity reached since last reset.
-      // Fall back to initialCapital only if DB value is absent or zero (e.g. fresh account).
-      const peakEquity = parseFloat(accountResult.rows[0].peak_equity ?? '0') || initialCapital;
-
-      // Get total exposure from open positions
-      const exposureResult = await query<{ total_exposure: string }>(
-        `SELECT COALESCE(SUM(size * current_price), 0) as total_exposure
-         FROM paper_positions WHERE closed_at IS NULL`
-      );
-      const totalExposure = parseFloat(exposureResult.rows[0]?.total_exposure || '0');
-      const currentEquity = currentCapital + totalExposure;
-
-      // Drawdown must be measured from peak_equity (same basis as RiskManager and
-      // AutoSignalExecutor.openPosition's proximity guard, fixed in 44f16d1). Using
-      // initialCapital as denominator silently inflated drawdown whenever cumulative
-      // realised losses exceeded the CB threshold relative to initial — the same
-      // class of bug that produced the 2026-04-30 → 2026-05-03 trade deadlock.
-      const drawdownPct = ((peakEquity - currentEquity) / peakEquity) * 100;
+      const dd = await computeEquityDrawdown(this.config.initialCapital);
+      if (!dd) return;
+      const { currentCapital, drawdownPct } = dd;
 
       // Check if we need to trigger circuit breaker
       if (drawdownPct >= this.config.maxDrawdownPct) {
@@ -275,7 +248,7 @@ export class CircuitBreakerService extends EventEmitter {
           timestamp: new Date(),
           drawdownPct,
           capitalBefore: currentCapital,
-          capitalAfter: this.config.autoReset ? initialCapital : capitalAfterClose,
+          capitalAfter: this.config.autoReset ? this.config.initialCapital : capitalAfterClose,
           positionsClosed,
         };
 

--- a/packages/dashboard/src/services/drawdown.test.ts
+++ b/packages/dashboard/src/services/drawdown.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../database/index.js', () => ({
+  query: vi.fn(),
+}));
+
+import { query } from '../database/index.js';
+import { computeEquityDrawdown } from './drawdown.js';
+
+describe('computeEquityDrawdown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when paper_account is empty', async () => {
+    vi.mocked(query)
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+    expect(await computeEquityDrawdown(10000)).toBeNull();
+  });
+
+  it('uses peak_equity as denominator (the deadlock scenario from issue #173)', async () => {
+    // current=8695, peak=8898, no open positions → drawdown 2.28% (not 13.05%)
+    vi.mocked(query)
+      .mockResolvedValueOnce({
+        rows: [{ available_capital: '8695', current_capital: '8695.16', peak_equity: '8897.79' }],
+        rowCount: 1,
+      } as any)
+      .mockResolvedValueOnce({ rows: [{ total_exposure: '0' }], rowCount: 1 } as any);
+
+    const dd = await computeEquityDrawdown(10000);
+    expect(dd).not.toBeNull();
+    expect(dd!.drawdownPct).toBeCloseTo(2.28, 1);
+    expect(dd!.peakEquity).toBeCloseTo(8897.79, 2);
+    expect(dd!.totalExposure).toBe(0);
+  });
+
+  it('falls back to initialCapital when peak_equity is null (fresh account)', async () => {
+    vi.mocked(query)
+      .mockResolvedValueOnce({
+        rows: [{ available_capital: '5000', current_capital: '5000', peak_equity: null }],
+        rowCount: 1,
+      } as any)
+      .mockResolvedValueOnce({ rows: [{ total_exposure: '0' }], rowCount: 1 } as any);
+
+    const dd = await computeEquityDrawdown(10000);
+    expect(dd!.peakEquity).toBe(10000);
+    expect(dd!.drawdownPct).toBe(50);  // (10000 - 5000) / 10000
+  });
+
+  it('falls back to initialCapital when peak_equity is "0" string', async () => {
+    vi.mocked(query)
+      .mockResolvedValueOnce({
+        rows: [{ available_capital: '8000', current_capital: '8000', peak_equity: '0' }],
+        rowCount: 1,
+      } as any)
+      .mockResolvedValueOnce({ rows: [{ total_exposure: '0' }], rowCount: 1 } as any);
+
+    const dd = await computeEquityDrawdown(10000);
+    expect(dd!.peakEquity).toBe(10000);
+    expect(dd!.drawdownPct).toBe(20);
+  });
+
+  it('includes open-position exposure in currentEquity', async () => {
+    // capital=5000, peak=10000, exposure=4000 → currentEquity=9000 → drawdown 10%
+    vi.mocked(query)
+      .mockResolvedValueOnce({
+        rows: [{ available_capital: '5000', current_capital: '5000', peak_equity: '10000' }],
+        rowCount: 1,
+      } as any)
+      .mockResolvedValueOnce({ rows: [{ total_exposure: '4000' }], rowCount: 1 } as any);
+
+    const dd = await computeEquityDrawdown(10000);
+    expect(dd!.currentEquity).toBe(9000);
+    expect(dd!.drawdownPct).toBe(10);
+  });
+
+  it('returns 0% drawdown when peakEquity is 0 and initialCapital is 0', async () => {
+    // Pathological — neither peak nor initial → guard returns 0 instead of NaN/Infinity.
+    vi.mocked(query)
+      .mockResolvedValueOnce({
+        rows: [{ available_capital: '0', current_capital: '0', peak_equity: '0' }],
+        rowCount: 1,
+      } as any)
+      .mockResolvedValueOnce({ rows: [{ total_exposure: '0' }], rowCount: 1 } as any);
+
+    const dd = await computeEquityDrawdown(0);
+    expect(dd!.drawdownPct).toBe(0);
+  });
+});

--- a/packages/dashboard/src/services/drawdown.ts
+++ b/packages/dashboard/src/services/drawdown.ts
@@ -1,0 +1,49 @@
+import { query } from '../database/index.js';
+
+export interface EquityDrawdown {
+  availableCapital: number;
+  currentCapital: number;
+  peakEquity: number;
+  totalExposure: number;
+  currentEquity: number;
+  /** Drawdown as a percentage 0–100 (peak-based). */
+  drawdownPct: number;
+}
+
+/**
+ * Read paper_account + open paper_positions and compute the canonical
+ * peak-based drawdown percentage.
+ *
+ * Same denominator as RiskManager — using initialCapital instead inflated
+ * drawdown whenever realised losses pushed equity below initial, the bug
+ * class that produced the 2026-04-30 → 2026-05-03 trade deadlock (44f16d1)
+ * and lurked in CircuitBreakerService until #174. peakEquity falls back to
+ * initialCapital only on fresh accounts where the DB column is null/zero.
+ *
+ * Returns null when paper_account is empty (e.g. before bootstrap).
+ */
+export async function computeEquityDrawdown(initialCapital: number): Promise<EquityDrawdown | null> {
+  const accountResult = await query<{
+    available_capital: string;
+    current_capital: string;
+    peak_equity: string | null;
+  }>('SELECT available_capital, current_capital, peak_equity FROM paper_account LIMIT 1');
+
+  if (!accountResult.rows[0]) return null;
+
+  const availableCapital = parseFloat(accountResult.rows[0].available_capital ?? '0');
+  const currentCapital = parseFloat(accountResult.rows[0].current_capital);
+  const peakEquity = parseFloat(accountResult.rows[0].peak_equity ?? '0') || initialCapital;
+
+  const exposureResult = await query<{ total_exposure: string }>(
+    `SELECT COALESCE(SUM(size * current_price), 0) as total_exposure
+     FROM paper_positions WHERE closed_at IS NULL`
+  );
+  const totalExposure = parseFloat(exposureResult.rows[0]?.total_exposure ?? '0');
+  const currentEquity = currentCapital + totalExposure;
+  const drawdownPct = peakEquity > 0
+    ? ((peakEquity - currentEquity) / peakEquity) * 100
+    : 0;
+
+  return { availableCapital, currentCapital, peakEquity, totalExposure, currentEquity, drawdownPct };
+}


### PR DESCRIPTION
Follow-up to #174. The peak-based drawdown formula was duplicated across the two consumers fixed during the 2026-04-30 → 2026-05-03 deadlock investigation:

- `AutoSignalExecutor.openPosition` — commit \`44f16d1\`
- \`CircuitBreakerService.checkDrawdown\` — commit \`2d54716\` (#174)

Both ran the same SELECT, summed open-position exposure, and computed \`(peak - equity) / peak\`. Different fixes were applied to the same logic in two PRs over three days. \`RiskManager.updateRiskState\` is the third site, but it does more (maintains in-memory peak + writes \`peak_equity\` back to DB) — it stays as-is.

## Helper

New \`packages/dashboard/src/services/drawdown.ts\` exposes \`computeEquityDrawdown(initialCapital)\`. Returns \`availableCapital\`, \`currentCapital\`, \`peakEquity\`, \`totalExposure\`, \`currentEquity\`, \`drawdownPct\`. Header comment documents the deadlock history so the next consumer cannot accidentally reintroduce \`initialCapital\` as denominator.

\`AutoSignalExecutor\` and \`CircuitBreakerService\` now call the helper. Net change: -53 / +150 (most of the +150 is the new test file).

## Tests

- 6 new cases for the helper: null on empty paper_account, the exact \`8695/8898\` deadlock scenario, fresh-account fallback (peak null AND peak \"0\"), exposure inclusion in equity, divide-by-zero guard.
- \`CircuitBreakerService.test.ts\` matcher updated from \`'SELECT current_capital'\` to \`'FROM paper_account'\` (the helper SELECTs \`available_capital\` first now). Existing CB scenarios still pass.
- Suite: 864 pass, 14 skipped, dashboard tsc clean.