### PR TITLE
fix(review-email): trading-inactive banner + Performance Breakdown reorg

### DIFF
--- a/packages/dashboard/src/services/OptimizationScheduler.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.ts
@@ -912,15 +912,23 @@ export class OptimizationScheduler {
       }
     }
 
-    // Enforce direction multiplier = -1.0 after every optimization run.
-    // It is excluded from the parameter space (not optimized), but we reset it here
-    // so any manual or legacy DB changes are corrected automatically.
-    // Validated value: -1.0 gives 91.5% accuracy vs 3.7% unflipped (188 trades, Apr 2026).
+    // Reset the __global__ direction_multiplier row to -1.0 every cycle.
+    //
+    // Note: this is NOT a pin — direction_multiplier IS optimized per-type
+    // (categorical {-1, +1}) via REFINEMENT_PARAM_SPACE / WEIGHT_PARAM_MAP
+    // below, and per-type rows take precedence in DirectionResolver. The
+    // __global__ row is only the fallback when no per-type entry exists,
+    // and -1.0 is the empirically validated default (91.5% accuracy vs 3.7%
+    // unflipped, 188 trades, Apr 2026 — still the best baseline for any
+    // unclassified market_type).
+    //
+    // Per-type drift (e.g. event_long → +1 on 2026-05-01) is mitigated by
+    // the OPTIMIZER_DM_FLIP_MIN_LIFT env-gate (#174), not by this reset.
     try {
       await signalWeightsRepo.update('direction_multiplier', -1.0, `optimization-${new Date().toISOString().slice(0, 10)}`);
-      console.log('[OptimizationScheduler] direction_multiplier enforced to -1.0 (pinned design spec)');
+      console.log('[OptimizationScheduler] direction_multiplier __global__ reset to -1.0 (per-type values preserved)');
     } catch (err) {
-      console.error('[OptimizationScheduler] Failed to enforce direction_multiplier to -1.0:', err);
+      console.error('[OptimizationScheduler] Failed to reset __global__ direction_multiplier to -1.0:', err);
     }
 
     // Apply optimized signal weights to database

--- a/scripts/format-review.js
+++ b/scripts/format-review.js
@@ -177,6 +177,18 @@ const tradesByType = Array.isArray(data.trades_by_type) ? data.trades_by_type : 
 const shadowSummary = Array.isArray(data.shadow_summary) ? data.shadow_summary : [];
 const generatedAt = data.generated_at || new Date().toISOString();
 
+// ── Trading-state derived signals ───────────────────────────────────────────
+// "Inactive" = the executor is not opening or closing positions right now.
+// Detect with the data we already collect: zero trades in the last 24h AND no
+// open positions. Useful so the email can label "consecutive losses" (which is
+// a cumulative DB counter, not a recent metric) with honest context, and to
+// surface the inactive state explicitly instead of leaving the reader to
+// derive it from a wall of zeroed-out 24h counters.
+const tradesIn24h = tradesSummary && Number.isFinite(Number(tradesSummary.total_trades))
+  ? Number(tradesSummary.total_trades)
+  : 0;
+const tradingInactive = tradesIn24h === 0 && openPositions.length === 0 && recentlyClosed.length === 0;
+
 // ── Detect alerts ───────────────────────────────────────────────────────────
 
 const alerts = []; // { level: 'critical'|'warning', message: string }
@@ -186,9 +198,13 @@ if (account && account.max_drawdown != null && account.max_drawdown > 10) {
   alerts.push({ level: 'critical', message: `Drawdown at ${fmtPctRaw(account.max_drawdown)} (threshold: 10%)` });
 }
 
-// 5+ consecutive losses
+// 5+ consecutive losses. The metric is a cumulative DB counter, so when the
+// executor has been idle (tradingInactive) the "5 in a row" is historical and
+// not actionable — surface that context instead of paging on stale data.
 if (consecutiveLosses && consecutiveLosses.max_consecutive_losses >= 5) {
-  alerts.push({ level: 'critical', message: `${consecutiveLosses.max_consecutive_losses} consecutive losing trades (threshold: 5)` });
+  const suffix = tradingInactive ? ' (historical — no trades in last 24h)' : '';
+  const level = tradingInactive ? 'warning' : 'critical';
+  alerts.push({ level, message: `${consecutiveLosses.max_consecutive_losses} consecutive losing trades (threshold: 5)${suffix}` });
 }
 
 // No prices in last hour
@@ -276,6 +292,13 @@ function buildMarkdown() {
   ln(`> Generated: ${fmtDate(generatedAt)}`);
   ln();
 
+  // Banner: trading-state context (avoids the "0 trades + 14 consecutive losses"
+  // confusion where a stale cumulative counter looks like a fresh alert).
+  if (tradingInactive) {
+    ln(`> **⚠️ TRADING INACTIVE** — 0 trades in the last 24h, 0 open positions, 0 closed in 24h. All "24h" tables below will be empty by definition; cumulative metrics (consecutive losses, drawdown) are historical, not current.`);
+    ln();
+  }
+
   // Alerts
   if (alerts.length > 0) {
     ln(`## Alerts`);
@@ -356,24 +379,30 @@ function buildMarkdown() {
     ln();
   }
 
-  // By Market Type
+  // Performance breakdown — three independent sources, separated so live and
+  // shadow numbers are not visually adjacent (shadow is theoretical-no-fees
+  // and was being mistaken for promotion candidates).
   if (tradesByType.length > 0 || categoryPerformance.length > 0 || shadowSummary.length > 0) {
-    ln(`## By Market Type`);
+    ln(`## Performance Breakdown`);
     ln();
 
+    // Live, last 24h
+    ln(`### Live — last 24h`);
+    ln();
     if (tradesByType.length > 0) {
-      ln(`### Trades 24h`);
-      ln();
       ln(`| Type | Trades | Win % | PnL |`);
       ln(`|------|--------|-------|-----|`);
       for (const t of tradesByType) {
         ln(`| ${t.market_type || 'N/A'} | ${fmt(t.trades_24h, 0)} | ${fmtPctRaw(t.win_pct)} | ${fmtUsd(t.pnl_24h)} |`);
       }
-      ln();
+    } else {
+      ln(`*No trades in the last 24h.*`);
     }
+    ln();
 
+    // Live, since reset (cumulative)
     if (categoryPerformance.length > 0) {
-      ln(`### Cumulative Performance`);
+      ln(`### Live — cumulative since last reset`);
       ln();
       ln(`| Type | Trades | Win Rate | Avg PnL | Sharpe | Prior |`);
       ln(`|------|--------|----------|---------|--------|-------|`);
@@ -383,8 +412,11 @@ function buildMarkdown() {
       ln();
     }
 
+    // Shadow — theoretical, NOT directly comparable to live
     if (shadowSummary.length > 0) {
-      ln(`### Shadow Trades (blocked by gate)`);
+      ln(`### Shadow — last 30d (theoretical, no fees, no slippage)`);
+      ln();
+      ln(`> Computed at the resolution price. Prediction markets resolve mostly to NO, so SHORT direction systematically over-states win rate (sampling artifact, not strategy edge). **Do not promote based on shadow PnL alone — apply the empirical haircut (≈0.33) and validate with live data.**`);
       ln();
       ln(`| Type | Total | Resolved | Avg PnL |`);
       ln(`|------|-------|----------|---------|`);
@@ -603,6 +635,13 @@ function buildEmailHtml() {
   p(`<h1>Polymarket Daily Review</h1>`);
   p(`<p style="font-size:12px;color:#6a737d;">${fmtDate(generatedAt)}</p>`);
 
+  // Banner: trading-state context (avoids stale-counter confusion)
+  if (tradingInactive) {
+    p(`<div style="background:#fff5b1;border:1px solid #d9b400;border-radius:4px;padding:10px 12px;margin:8px 0 16px;font-size:13px;">`);
+    p(`<strong>⚠️ TRADING INACTIVE</strong><br>0 trades in the last 24h, 0 open positions, 0 closed in 24h. All "24h" tables below will be empty by definition; cumulative metrics (consecutive losses, drawdown) are historical, not current.`);
+    p(`</div>`);
+  }
+
   // Alerts
   if (alerts.length > 0) {
     p('<h2>Alerts</h2><ul>');
@@ -654,12 +693,15 @@ function buildEmailHtml() {
     p('<p><em>No trade data.</em></p>');
   }
 
-  // By market type
-  if (tradesByType.length > 0 || shadowSummary.length > 0) {
-    p('<h2>By Market Type</h2>');
+  // Performance breakdown — three independent sources kept visually separate.
+  // Shadow is theoretical (no fees, no slippage) and was previously rendered
+  // adjacent to live with no disclaimer; readers mistook the inflated SHORT
+  // win rates for promotion candidates.
+  if (tradesByType.length > 0 || shadowSummary.length > 0 || categoryPerformance.length > 0) {
+    p('<h2>Performance Breakdown</h2>');
 
+    p('<h3 style="font-size:14px;margin-top:16px;">Live — last 24h</h3>');
     if (tradesByType.length > 0) {
-      p('<p style="margin:4px 0;font-size:13px;color:#586069;">Trades 24h</p>');
       p('<table>');
       p('<tr><th>Type</th><th>Trades</th><th>Win %</th><th>PnL</th></tr>');
       for (const t of tradesByType) {
@@ -668,10 +710,23 @@ function buildEmailHtml() {
         p(`<tr><td>${escapeHtml(t.market_type || 'N/A')}</td><td>${escapeHtml(fmt(t.trades_24h, 0))}</td><td>${escapeHtml(fmtPctRaw(t.win_pct))}</td><td class="${cls}">${escapeHtml(fmtUsd(t.pnl_24h))}</td></tr>`);
       }
       p('</table>');
+    } else {
+      p('<p><em>No trades in the last 24h.</em></p>');
+    }
+
+    if (categoryPerformance.length > 0) {
+      p('<h3 style="font-size:14px;margin-top:16px;">Live — cumulative since last reset</h3>');
+      p('<table>');
+      p('<tr><th>Type</th><th>Trades</th><th>Win Rate</th><th>Avg PnL</th><th>Sharpe</th></tr>');
+      for (const c of categoryPerformance) {
+        p(`<tr><td>${escapeHtml(c.market_type || 'N/A')}</td><td>${escapeHtml(fmt(c.n_trades, 0))}</td><td>${escapeHtml(fmtPct(c.win_rate))}</td><td>${escapeHtml(fmtUsd(c.avg_pnl))}</td><td>${escapeHtml(fmt(c.sharpe_ratio, 3))}</td></tr>`);
+      }
+      p('</table>');
     }
 
     if (shadowSummary.length > 0) {
-      p('<p style="margin:8px 0 4px;font-size:13px;color:#586069;">Shadow trades (blocked by gate)</p>');
+      p('<h3 style="font-size:14px;margin-top:16px;">Shadow — last 30d <span style="font-weight:normal;color:#6a737d;font-size:12px;">(theoretical: no fees, no slippage)</span></h3>');
+      p('<p style="font-size:12px;color:#6a737d;margin:4px 0 8px;">Resolution-price PnL. Prediction markets mostly resolve to NO, so SHORT win rate is structurally inflated — sampling artifact, not strategy edge. Apply the ≈0.33 empirical haircut before any promotion comparison.</p>');
       p('<table>');
       p('<tr><th>Type</th><th>Total</th><th>Resolved</th><th>Avg PnL</th></tr>');
       for (const s of shadowSummary) {


### PR DESCRIPTION
Two UX fixes triggered by reviewing today's email during the 4-day deadlock window.

## 1. \"TRADING INACTIVE\" banner

When the executor is idle (\`trades_24h=0\` AND \`open_positions=0\` AND \`recently_closed_24h=0\`), the email previously rendered as a normal day with everything zeroed out — while the cumulative \`consecutive_losses\` counter still appeared as a 🔴 CRITICAL alert. Reading "14 consecutive losing trades" alongside "0 trades today" forced the operator to derive the explanation.

This PR adds a yellow banner at the top of the email (and a corresponding callout in the markdown report) labelling the inactive state explicitly, and downgrades the consecutive-loss alert from \`critical\` → \`warning\` with a "(historical — no trades in last 24h)" suffix when applicable.

## 2. Performance Breakdown reorg

The old "By Market Type" section stacked **Trades 24h** (showing zeros for the deadlock days) directly above **Shadow trades** (showing thousands of trades with positive SHORT PnL). With no visual separation or disclaimer, today's reader asked "did something get promoted to live?" — exactly the confusion this layout invites.

Replaced with three clearly separated subsections:

- **Live — last 24h** (explicit "No trades in the last 24h" fallback)
- **Live — cumulative since last reset** (typeEV / category_performance with Sharpe column)
- **Shadow — last 30d** *(theoretical: no fees, no slippage)* with a disclaimer about the structural SHORT-resolves-NO sampling bias and the empirical ≈0.33 haircut from \`project_shadow_execution_realism.md\`.

The markdown report carries the same restructure.

## 3. \`OptimizationScheduler\` comment cleanup

Line 915 claimed \`direction_multiplier\` was "excluded from the parameter space (not optimized)" — false since #163 (per-type categorical {-1, +1}). Replaced with an honest description: the reset only touches the \`__global__\` fallback row; per-type values are managed by the optimizer and gated by \`OPTIMIZER_DM_FLIP_MIN_LIFT\` (#174). Zero behaviour change.

## Tests

858/858 pass. Manual render check on a deadlock-shaped JSON shows the banner, downgraded alert, and three-section breakdown all rendering correctly. Normal-trading payload renders unchanged (banner suppressed, alert stays critical, breakdown shows live first then shadow).