### PR TITLE
fix(direction-multiplier): flip global +1 (was -1) and parse policy JSON correctly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,18 +81,20 @@ Analyzes recent trades to identify patterns in losing trades.
 ### Current Configuration
 
 - **Combiner thresholds**: minCombinedConfidence=0.43, minCombinedStrength=0.27
-- **Direction multiplier**: -1.0 (contrarian flip — see design rationale below)
+- **Direction multiplier**: +1.0 (no flip — see history below)
 - **Market filter**: Excludes markets with Yes price <5% or >95%. NO 50/50 filter (removed intentionally).
 - **Max positions**: 50 concurrent open positions
 - **Signal interval**: 60 seconds
 
-### Signal Directions (post-flip)
+### Signal Directions (history of the flip)
 
-The combined signal direction is INVERTED by `directionMultiplier = -1`. This is intentional:
-- Prediction market signals detect information-driven moves as "overextension" and bet against them
-- But information is permanent — the price doesn't revert
-- Flipping converts the signals into trend-followers: "when a significant move is detected, follow it"
-- Empirical validation: 91.5% accuracy when flipped vs 3.7% unflipped (188 trades, Apr 2026)
+The system has gone through two regimes:
+
+1. **dm = -1 (flipped)** — original validated configuration. Empirical: 91.5% accuracy flipped vs 3.7% unflipped (188 trades, Apr 2026). Rationale: prediction-market signals were detecting information-driven moves as "overextension" and betting against them; flipping turned them into trend-followers.
+
+2. **dm = +1 (no flip), since 2026-05-04** — empirical re-analysis on n=386 post-2026-04-07-reset trades showed dm=-1 produced 13.5% WR while the counter direction would have hit 84.7%. Signal-generator changes since the original validation made raw outputs already correctly directional, so the -1 had become a double-flip producing the inverse of the intended behaviour. New baseline: +1.
+
+If a future regression takes WR back below ~30% for several days, the right diagnostic is the counter-WR-vs-actual-WR-by-side query (see the `daily-autoreview-analysis` skill): a counter-WR materially above the actual-WR is the signature of a directional inversion.
 
 ### Market Selection (intentional design)
 

--- a/packages/dashboard/src/services/DirectionMultiplierPolicy.ts
+++ b/packages/dashboard/src/services/DirectionMultiplierPolicy.ts
@@ -35,8 +35,8 @@ export interface ResolvedDirectionMultiplier {
   segmentId: string | null;
 }
 
-const DEFAULT_MIN_MULTIPLIER = -1.5;
-const DEFAULT_MAX_MULTIPLIER = 0.25;
+const DEFAULT_MIN_MULTIPLIER = -1.0;
+const DEFAULT_MAX_MULTIPLIER = 1.0;
 export const DIRECTION_PRICE_BUCKETS = [
   { label: 'lt20', min: 0, max: 0.2 },
   { label: '20to40', min: 0.2, max: 0.4 },
@@ -45,8 +45,15 @@ export const DIRECTION_PRICE_BUCKETS = [
   { label: 'gte80', min: 0.8, max: 1.01 },
 ] as const;
 
+// 2026-05-04: flipped from -1.0 → +1.0 after empirical analysis showed the
+// system was operating with inverted direction. n=386 trades (post-2026-04-07
+// reset) produced 13.5% WR with dm=-1; the counter-direction would have hit
+// 84.7% WR. The "91.5% accuracy when flipped" cited in CLAUDE.md was true at
+// the time of measurement, but signal-generator changes since then made the
+// raw outputs already correctly directional, so the -1 flip became a
+// double-flip. New baseline: +1 (no flip).
 export const DEFAULT_DIRECTION_MULTIPLIER_POLICY: DirectionMultiplierPolicy = {
-  global: -1.0,
+  global: 1.0,
   minMultiplier: DEFAULT_MIN_MULTIPLIER,
   maxMultiplier: DEFAULT_MAX_MULTIPLIER,
   segments: [],

--- a/packages/dashboard/src/services/OptimizationScheduler.test.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.test.ts
@@ -74,7 +74,7 @@ describe('OptimizationScheduler', () => {
     expect(names).not.toContain('combiner.directionMultiplier');
   });
 
-  it('always enforces direction_multiplier to -1.0 after a successful optimization', async () => {
+  it('always enforces direction_multiplier to +1.0 after a successful optimization', async () => {
     const scheduler = new OptimizationScheduler();
     (scheduler as any)._lastOOSResult = {
       passed: true,
@@ -101,7 +101,7 @@ describe('OptimizationScheduler', () => {
 
     expect(signalWeightsRepo.update).toHaveBeenCalledWith(
       'direction_multiplier',
-      -1.0,
+      1.0,
       expect.stringMatching(/^optimization-\d{4}-\d{2}-\d{2}$/),
     );
   });

--- a/packages/dashboard/src/services/OptimizationScheduler.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.ts
@@ -912,23 +912,26 @@ export class OptimizationScheduler {
       }
     }
 
-    // Reset the __global__ direction_multiplier row to -1.0 every cycle.
+    // Reset the __global__ direction_multiplier row to +1.0 every cycle.
     //
     // Note: this is NOT a pin — direction_multiplier IS optimized per-type
     // (categorical {-1, +1}) via REFINEMENT_PARAM_SPACE / WEIGHT_PARAM_MAP
     // below, and per-type rows take precedence in DirectionResolver. The
-    // __global__ row is only the fallback when no per-type entry exists,
-    // and -1.0 is the empirically validated default (91.5% accuracy vs 3.7%
-    // unflipped, 188 trades, Apr 2026 — still the best baseline for any
-    // unclassified market_type).
+    // __global__ row is only the fallback when no per-type entry exists.
     //
-    // Per-type drift (e.g. event_long → +1 on 2026-05-01) is mitigated by
-    // the OPTIMIZER_DM_FLIP_MIN_LIFT env-gate (#174), not by this reset.
+    // 2026-05-04: flipped baseline -1 → +1. Empirical analysis on n=386
+    // post-2026-04-07-reset trades showed dm=-1 produced 13.5% WR while the
+    // counter direction would have hit 84.7%. The "91.5% when flipped"
+    // result cited here previously held at the time of measurement, but
+    // signal-generator changes since then made raw outputs correctly
+    // directional, so the -1 became a double-flip in production.
+    //
+    // Per-type drift is gated by OPTIMIZER_DM_FLIP_MIN_LIFT (#174).
     try {
-      await signalWeightsRepo.update('direction_multiplier', -1.0, `optimization-${new Date().toISOString().slice(0, 10)}`);
-      console.log('[OptimizationScheduler] direction_multiplier __global__ reset to -1.0 (per-type values preserved)');
+      await signalWeightsRepo.update('direction_multiplier', 1.0, `optimization-${new Date().toISOString().slice(0, 10)}`);
+      console.log('[OptimizationScheduler] direction_multiplier __global__ reset to +1.0 (per-type values preserved)');
     } catch (err) {
-      console.error('[OptimizationScheduler] Failed to reset __global__ direction_multiplier to -1.0:', err);
+      console.error('[OptimizationScheduler] Failed to reset __global__ direction_multiplier to +1.0:', err);
     }
 
     // Apply optimized signal weights to database

--- a/packages/dashboard/src/services/bootstrapDirectionMultiplier.test.ts
+++ b/packages/dashboard/src/services/bootstrapDirectionMultiplier.test.ts
@@ -19,8 +19,10 @@ describe('bootstrapDirectionMultiplierRows', () => {
     const sql = (query as any).mock.calls[0][0] as string;
     expect(sql).toMatch(/INSERT INTO signal_weights/);
     expect(sql).toMatch(/'direction_multiplier'/);
-    expect(sql).toMatch(/'event_financial'.*1\.0/s);
-    expect(sql).toMatch(/'crypto_intraday'.*-1\.0/s);
+    // 2026-05-04: all five seeds flipped to +1.0 (see DirectionMultiplierPolicy.ts header).
+    expect(sql).toMatch(/'event_financial',\s*1\.0/);
+    expect(sql).toMatch(/'crypto_intraday',\s*1\.0/);
+    expect(sql).toMatch(/'event_short',\s*1\.0/);
     expect(sql).toMatch(/ON CONFLICT \(signal_type, market_type\) DO NOTHING/);
   });
 });

--- a/packages/dashboard/src/services/bootstrapDirectionMultiplier.ts
+++ b/packages/dashboard/src/services/bootstrapDirectionMultiplier.ts
@@ -4,11 +4,13 @@ export async function bootstrapDirectionMultiplierRows(): Promise<void> {
   await query(
     `INSERT INTO signal_weights (signal_type, market_type, weight, updated_at, is_enabled)
      VALUES
-       ('direction_multiplier', 'crypto_intraday', -1.0, NOW(), true),
-       ('direction_multiplier', 'crypto_daily',    -1.0, NOW(), true),
-       ('direction_multiplier', 'event_short',     -1.0, NOW(), true),
-       ('direction_multiplier', 'event_long',      -1.0, NOW(), true),
-       ('direction_multiplier', 'event_financial', 1.0,  NOW(), true)
+       -- 2026-05-04: flipped seeds -1 → +1 after empirical reverse-direction
+       -- analysis (n=386, 84.7% counter-WR). See DirectionMultiplierPolicy.ts header.
+       ('direction_multiplier', 'crypto_intraday', 1.0, NOW(), true),
+       ('direction_multiplier', 'crypto_daily',    1.0, NOW(), true),
+       ('direction_multiplier', 'event_short',     1.0, NOW(), true),
+       ('direction_multiplier', 'event_long',      1.0, NOW(), true),
+       ('direction_multiplier', 'event_financial', 1.0, NOW(), true)
      ON CONFLICT (signal_type, market_type) DO NOTHING`
   );
 }

--- a/packages/dashboard/src/services/wipeDirectionMultiplierSegments.test.ts
+++ b/packages/dashboard/src/services/wipeDirectionMultiplierSegments.test.ts
@@ -58,7 +58,26 @@ describe('wipeDirectionMultiplierSegments', () => {
     expect(tradingConfigRepo.set).toHaveBeenCalledTimes(1);
     const [, value] = (tradingConfigRepo.set as any).mock.calls[0];
     expect(value.segments).toEqual([]);
-    expect(value.global).toBe(-1.0);
+    // 2026-05-04: default global flipped -1 → +1 (see DirectionMultiplierPolicy.ts header).
+    expect(value.global).toBe(1.0);
+  });
+
+  it('parses the JSON string returned by tradingConfigRepo.get (TEXT column)', async () => {
+    // tradingConfigRepo.get returns a string because trading_config.value is TEXT.
+    // Pre-fix this caused the whole policy to be silently overwritten with defaults
+    // on every server restart. Regression test for the 2026-05-04 reset of the +1 flip.
+    (tradingConfigRepo.get as any).mockResolvedValueOnce(
+      '{"global":1,"minMultiplier":-1,"maxMultiplier":1,"segments":[{"id":"x","multiplier":0.5}]}'
+    );
+
+    await wipeDirectionMultiplierSegments();
+
+    expect(tradingConfigRepo.set).toHaveBeenCalledTimes(1);
+    const [, value] = (tradingConfigRepo.set as any).mock.calls[0];
+    expect(value.global).toBe(1);            // preserved from parsed string, not from default
+    expect(value.minMultiplier).toBe(-1);    // preserved
+    expect(value.maxMultiplier).toBe(1);     // preserved
+    expect(value.segments).toEqual([]);      // wiped
   });
 
   it('skips the write when segments is already empty (idempotent no-op)', async () => {

--- a/packages/dashboard/src/services/wipeDirectionMultiplierSegments.ts
+++ b/packages/dashboard/src/services/wipeDirectionMultiplierSegments.ts
@@ -17,9 +17,27 @@ import {
  * if present. Only `segments` is wiped.
  */
 export async function wipeDirectionMultiplierSegments(): Promise<void> {
-  const existing = await tradingConfigRepo.get<DirectionMultiplierPolicy>(
+  // trading_config.value is TEXT (JSON.stringify'd by tradingConfigRepo.set), so
+  // tradingConfigRepo.get returns the raw string, not a parsed object. Without
+  // explicit parse, every field access here returns undefined and the function
+  // silently overwrites the persisted policy with DEFAULT_DIRECTION_MULTIPLIER_POLICY
+  // on every server restart — exactly what reset the +1 flip back to -1 on
+  // 2026-05-04 until this fix.
+  const raw = await tradingConfigRepo.get<DirectionMultiplierPolicy | string>(
     'direction_multiplier_policy'
   );
+  let existing: DirectionMultiplierPolicy | null = null;
+  if (typeof raw === 'string') {
+    try { existing = JSON.parse(raw) as DirectionMultiplierPolicy; }
+    catch { existing = null; }
+  } else if (raw && typeof raw === 'object') {
+    existing = raw as DirectionMultiplierPolicy;
+  }
+
+  // Skip the write when the policy is already in the wiped state.
+  if (existing && Array.isArray(existing.segments) && existing.segments.length === 0) {
+    return;
+  }
 
   const next: DirectionMultiplierPolicy = {
     global: existing?.global ?? DEFAULT_DIRECTION_MULTIPLIER_POLICY.global,
@@ -28,11 +46,6 @@ export async function wipeDirectionMultiplierSegments(): Promise<void> {
     segments: [],
     ...(existing?.perMarketType ? { perMarketType: existing.perMarketType } : {}),
   };
-
-  // Skip the write when the policy is already in the wiped state.
-  if (existing && Array.isArray(existing.segments) && existing.segments.length === 0) {
-    return;
-  }
 
   await tradingConfigRepo.set(
     'direction_multiplier_policy',


### PR DESCRIPTION
## Why

Empirical analysis of every closed trade since the 2026-04-07 reset (n=386):

| side | n | actual wins | actual WR | counter WR (if flipped) |
|------|---|-------------|-----------|-------------------------|
| long  | 222 |  42 | 18.9% | **77.9%** |
| short | 164 |  10 |  6.1% | **93.9%** |
| **TOTAL** | **386** | **52** | **13.5%** | **84.7%** |

The "91.5% accuracy when flipped" result documented in CLAUDE.md held when measured (188 trades, Apr 2026), but signal-generator changes since then made the raw outputs already correctly directional. The persisting `dm = -1` thus became a double-flip producing the inverse of the intended behaviour — exactly the symptom the user has been pointing out for weeks ("WR ~5% means the system is working in the opposite direction").

**Live SQL flip applied on 2026-05-04 09:37 UTC**; this PR codifies the new defaults so deploys / bootstraps / optimizer cycles do not revert.

## Two fixes

### 1. Flip the directional baseline -1 → +1

- \`DirectionMultiplierPolicy.ts\`:
  - \`DEFAULT_MIN_MULTIPLIER\` -1.5 → -1.0
  - \`DEFAULT_MAX_MULTIPLIER\` 0.25 → +1.0 (the 0.25 cap was residue from the old segment-multiplier domain and silently truncated +1 bootstraps; cf. PR #166 for the same regression)
  - \`DEFAULT_DIRECTION_MULTIPLIER_POLICY.global\` -1.0 → +1.0
- \`bootstrapDirectionMultiplier.ts\`: all five seed rows flipped to +1.0
- \`OptimizationScheduler.ts:920\`: per-cycle reset of \`__global__\` row flipped to +1.0 (fallback only — per-type rows still handled by the optimizer + \`OPTIMIZER_DM_FLIP_MIN_LIFT\` gate from #174)
- \`CLAUDE.md\` "Signal Directions" rewritten to document both regimes and the diagnostic query

### 2. Parse the JSON string in \`wipeDirectionMultiplierSegments\`

\`tradingConfigRepo.get()\` returns the raw TEXT value from \`trading_config\` — a JSON string, not a parsed object. Pre-fix the wipe accessed \`existing?.global\`, \`existing?.segments\` on a string → always undefined → the "skip when segments empty" guard never fired and every server restart silently rewrote the policy back to \`DEFAULT_DIRECTION_MULTIPLIER_POLICY\`.

That is what reset the manually-applied +1 flip back to -1 minutes after the SQL UPDATE on 2026-05-04 — caught only because it happened during this session's debugging. Fix parses the string defensively (also accepts already-parsed objects) before reading fields. Regression test added.

## Tests

865 pass. Three updated: bootstrap-test for the new +1 seeds, wipe-test for the new default global and the new JSON-parse path, OptimizationScheduler-test for the new +1 reset.

## Live status

Already applied via SQL on the VM at 09:37 UTC. Logs since then confirm \`multiplier:1\` is being used by \`weighted-average-combiner\`. This PR is the durability layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated trading signal direction configuration documentation.

* **Chores**
  * Updated default direction multiplier baseline from -1.0 to +1.0 across system configuration and initialization.
  * Enhanced robustness of direction multiplier configuration parsing and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->