### PR TITLE
fix(news-llm): use synthetic h1/m1 ids in prompt to unfreeze sentiment pipeline

### DIFF
--- a/packages/data-collector/src/collectors/sources/LLMProvider.test.ts
+++ b/packages/data-collector/src/collectors/sources/LLMProvider.test.ts
@@ -68,4 +68,93 @@ describe('AnthropicProvider', () => {
     );
     expect(result.evaluations).toHaveLength(0);
   });
+
+  it('renders headlines and markets with synthetic h<i>/m<i> ids in the prompt (not the raw caller ids)', async () => {
+    // Regression test for the 2026-04-13 → 2026-05-04 outage: the previous
+    // prompt embedded full URLs and UUIDs as headline/market identifiers and
+    // the LLM consistently returned its own short tokens (A, B, 1, 2),
+    // missing every map lookup downstream. Now the prompt itself uses short
+    // synthetic ids so there is nothing for the LLM to "shorten".
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: 'tool_use', name: 'evaluate_headlines', input: { matches: [] } }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+
+    const headlines: Headline[] = [
+      { id: 'https://very-long-url.example.com/article/12345', title: 'Title A' },
+      { id: 'https://another.example.com/x/y/z', title: 'Title B' },
+    ];
+    const markets: Market[] = [
+      { id: '0x9f8f7d6c5b4a3928172616502f4e3d2c1b0a', question: 'Q1?', currentPrice: 0.42 },
+    ];
+
+    await provider.evaluateHeadlines(headlines, markets);
+
+    const sentMessages = mockCreate.mock.calls[0][0].messages;
+    const promptText = sentMessages[0].content as string;
+    expect(promptText).toContain('[h1] "Title A"');
+    expect(promptText).toContain('[h2] "Title B"');
+    expect(promptText).toContain('[m1] "Q1?" (price: 0.42)');
+    // The raw URL/UUID identifiers must NOT leak into the prompt — that was the source of the LLM confusion.
+    expect(promptText).not.toContain('https://very-long-url');
+    expect(promptText).not.toContain('0x9f8f7d6c5b4a');
+  });
+
+  it('translates synthetic ids returned by the LLM back to the original caller-supplied ids', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{
+        type: 'tool_use',
+        name: 'evaluate_headlines',
+        input: {
+          matches: [
+            { headline_id: 'h2', market_id: 'm1', direction: 'LONG', impact: 0.7 },
+          ],
+        },
+      }],
+      usage: { input_tokens: 100, output_tokens: 30 },
+    });
+
+    const headlines: Headline[] = [
+      { id: 'https://news.example.com/a', title: 'A' },
+      { id: 'https://news.example.com/b', title: 'B' },
+    ];
+    const markets: Market[] = [
+      { id: '0xMARKET-UUID-1234', question: 'Q?', currentPrice: 0.5 },
+    ];
+
+    const result = await provider.evaluateHeadlines(headlines, markets);
+
+    expect(result.evaluations).toHaveLength(1);
+    expect(result.evaluations[0].headlineId).toBe('https://news.example.com/b');
+    expect(result.evaluations[0].marketId).toBe('0xMARKET-UUID-1234');
+    expect(result.evaluations[0].direction).toBe('LONG');
+  });
+
+  it('passes through unresolved synthetic ids so the caller can drop them', async () => {
+    // If the LLM hallucinates an id that isn't in the prompt (e.g. "h99"
+    // when only h1 and h2 exist), the provider returns it verbatim. The
+    // caller's headlineMap.get(...) lookup will miss and the stray match
+    // is silently dropped — preserves the existing safety net.
+    mockCreate.mockResolvedValueOnce({
+      content: [{
+        type: 'tool_use',
+        name: 'evaluate_headlines',
+        input: {
+          matches: [
+            { headline_id: 'h99', market_id: 'mZ', direction: 'SHORT', impact: 0.3 },
+          ],
+        },
+      }],
+      usage: { input_tokens: 50, output_tokens: 10 },
+    });
+
+    const result = await provider.evaluateHeadlines(
+      [{ id: 'real-h1', title: 'A' }],
+      [{ id: 'real-m1', question: 'Q?', currentPrice: 0.5 }],
+    );
+
+    expect(result.evaluations).toHaveLength(1);
+    expect(result.evaluations[0].headlineId).toBe('h99');  // unresolved → passthrough
+    expect(result.evaluations[0].marketId).toBe('mZ');
+  });
 });

--- a/packages/data-collector/src/collectors/sources/LLMProvider.ts
+++ b/packages/data-collector/src/collectors/sources/LLMProvider.ts
@@ -76,8 +76,26 @@ export class AnthropicProvider implements LLMProvider {
   }
 
   async evaluateHeadlines(headlines: Headline[], markets: Market[]): Promise<EvaluationResult> {
-    const marketList = markets.map((m, i) => `${i + 1}. [${m.id}] "${m.question}" (price: ${m.currentPrice.toFixed(2)})`).join('\n');
-    const headlineList = headlines.map((h, i) => `${String.fromCharCode(65 + i)}. [${h.id}] "${h.title}"`).join('\n');
+    // Use short synthetic IDs (h1, h2, ..., m1, m2, ...) in the prompt. The
+    // previous version embedded full URLs and UUIDs as identifiers and the
+    // LLM consistently returned the leading letter/number tokens (A, B, 1, 2)
+    // instead, so headlineMap.get(...) in the caller missed every match and
+    // signalCount was 0 for ~21 days starting 2026-04-13. We translate the
+    // synthetic IDs back to the caller's real IDs before returning.
+    const headlineIdMap = new Map<string, string>();
+    const marketIdMap = new Map<string, string>();
+
+    const headlineList = headlines.map((h, i) => {
+      const synth = `h${i + 1}`;
+      headlineIdMap.set(synth, h.id);
+      return `[${synth}] "${h.title}"`;
+    }).join('\n');
+
+    const marketList = markets.map((m, i) => {
+      const synth = `m${i + 1}`;
+      marketIdMap.set(synth, m.id);
+      return `[${synth}] "${m.question}" (price: ${m.currentPrice.toFixed(2)})`;
+    }).join('\n');
 
     const prompt = `You are evaluating news headlines for their relevance to prediction markets.
 
@@ -89,7 +107,7 @@ ${headlineList}
 
 For each headline-market pair where the headline provides ACTIONABLE information about the market outcome, call the evaluate_headlines tool. Only include genuinely relevant pairs. Direction: LONG if the headline makes the YES outcome more likely, SHORT if less likely. Impact: 0.0-1.0 scale of how much the headline should move the market price.
 
-If no headlines are relevant to any market, call the tool with an empty matches array.`;
+When you call the tool, set headline_id and market_id to the bracketed identifier shown above (e.g. "h1", "m2") — exactly that token, nothing else. If no headlines are relevant to any market, call the tool with an empty matches array.`;
 
     const response = await this.client.messages.create({
       model: 'claude-haiku-4-5-20251001',
@@ -100,13 +118,23 @@ If no headlines are relevant to any market, call the tool with an empty matches 
     });
 
     const evaluations: HeadlineEvaluation[] = [];
+    let unresolved = 0;
     for (const block of response.content) {
       if (block.type === 'tool_use' && block.name === 'evaluate_headlines') {
         const input = block.input as { matches: Array<{ headline_id: string; market_id: string; direction: string; impact: number; reasoning?: string }> };
         for (const match of input.matches || []) {
+          // Translate synthetic IDs back to real IDs. If the LLM somehow
+          // returns an ID that isn't in our map (hallucinated, misformatted),
+          // pass it through verbatim — caller (NewsCollector) ignores rows
+          // that don't match its own map, so a stray ID becomes a no-op.
+          const realHeadlineId = headlineIdMap.get(match.headline_id) ?? match.headline_id;
+          const realMarketId = marketIdMap.get(match.market_id) ?? match.market_id;
+          if (!headlineIdMap.has(match.headline_id) || !marketIdMap.has(match.market_id)) {
+            unresolved++;
+          }
           evaluations.push({
-            headlineId: match.headline_id,
-            marketId: match.market_id,
+            headlineId: realHeadlineId,
+            marketId: realMarketId,
             direction: match.direction as 'LONG' | 'SHORT',
             impact: Math.max(0, Math.min(1, match.impact)),
             reasoning: match.reasoning,
@@ -115,6 +143,9 @@ If no headlines are relevant to any market, call the tool with an empty matches 
       }
     }
 
+    if (unresolved > 0) {
+      logger.warn({ unresolved, totalEvaluations: evaluations.length }, 'LLM returned unresolved synthetic IDs');
+    }
     logger.debug({ evaluationCount: evaluations.length }, 'Headlines evaluated');
 
     return {


### PR DESCRIPTION
\`external_signals.sentiment\` has been silently frozen at 3767 rows since 2026-04-13, and \`attention\` has zero rows ever. Verified today (2026-05-04):

| signal_type | rows total | oldest | newest | rows last 24h |
|---|---|---|---|---|
| sentiment | 3767 | 2026-04-10 | 2026-04-13 10:15 | **0** |
| attention | 0 | — | — | 0 |

NewsCollector's LLM evaluator runs every cycle, completes \`evaluations: ~9\` per call, and consistently logs \`signalCount: 0\`. This PR fixes \`sentiment\`. \`attention\` is out of scope (no collector writes it, deferred multi-session work).

## Root cause

\`LLMProvider.evaluateHeadlines\` (line 79-80, pre-fix) embedded the caller's full identifiers — long URLs for headlines, UUIDs for markets — directly in the prompt next to leading short tokens (A, B, 1, 2):

\`\`\`
HEADLINES:
A. [https://very-long-url.example.com/article/12345] "Title"
B. [https://another.example.com/x/y/z] "Title"

MARKETS:
1. [0x9f8f7d6c5b4a3928172616502f4e3d2c1b0a] "Q?" (price: 0.42)
\`\`\`

The tool-use schema asked the LLM for \`headline_id\` and \`market_id\`. With the URL/UUID identifiers cluttering each line and a clean short token sitting right next to them, the LLM consistently returned the leading token (\"A\", \"B\", \"1\") instead of the bracketed id. Downstream \`NewsCollector.ts:238\` did \`headlineMap.get(evaluation.headlineId)\` keyed on the real URL, missed every lookup, and \`continue\`d every loop iteration. Hence \`evaluations: 9, signalCount: 0\` for ~21 days.

## Fix

Render the prompt with short synthetic ids the LLM cannot \"shorten\":

\`\`\`
HEADLINES:
[h1] "Title"
[h2] "Title"

MARKETS:
[m1] "Q?" (price: 0.42)
\`\`\`

\`evaluateHeadlines\` keeps a synthetic→real id map and translates the LLM's response back to the caller's real ids before returning. \`NewsCollector\` callsite is unchanged. If the LLM hallucinates an id outside the map (e.g. \"h99\"), the provider passes it through verbatim and the caller's own \`headlineMap.get(...)\` safely drops it.

The prompt also adds an explicit instruction: *\"set headline_id and market_id to the bracketed identifier shown above (e.g. \\\"h1\\\", \\\"m2\\\") — exactly that token, nothing else.\"*

A \`logger.warn\` fires when the unresolved-id count > 0 so a future LLM-behaviour shift is visible instead of silent.

## Tests

868 pass. 3 new cases:
- prompt embeds \`[h1]\`/\`[m1]\` and does NOT leak the original URL/UUID
- synthetic ids in the LLM response are translated back to caller-supplied ids
- unresolved synthetic ids pass through verbatim (preserves the safety-net contract)

## Verification post-deploy

Run on the VM 30+ minutes after deploy:

\`\`\`sql
SELECT signal_type, COUNT(*), MIN(fetched_at), MAX(fetched_at)
FROM external_signals
WHERE fetched_at > NOW() - INTERVAL '30 minutes'
GROUP BY signal_type;
\`\`\`

Expected: at least one \`sentiment\` row with a recent \`fetched_at\` (one cycle is enough). If still 0, escalate — the bug is upstream in the entity-matching candidate filter, not in LLM ID parsing.