### PR TITLE
docs(daily-review): recalibrate shadow promotion thresholds with 0.33 haircut

### DIFF
--- a/scripts/daily-review-prompt.md
+++ b/scripts/daily-review-prompt.md
@@ -124,24 +124,28 @@ The executor restricts live trades to `ALLOWED_MARKET_TYPES`. Other market types
 
 ### Shadow → Live promotion recommendation
 
-`shadow_summary` is now per-`market_type` over a 30-day window with fields: `total`, `resolved`, `avg_pnl`, `win_rate`, `pnl_stddev`, `sharpe`.
+`shadow_summary` is per-`market_type` over a 30-day window with fields: `total`, `resolved`, `avg_pnl`, `win_rate`, `pnl_stddev`, `sharpe`.
 
-For each `market_type` row in `shadow_summary`, evaluate against ALL of:
+**Shadow PnL is theoretical.** It's computed at the resolution price with no fees, no slippage, no early signal-driven exits. Empirical work in `project_shadow_execution_realism.md` measured a `live/shadow ≈ 0.33` Sharpe ratio on time-matched event_long data. Two structural biases inflate shadow further:
+- **SHORT-resolves-NO bias**: prediction markets resolve mostly to NO, so a SHORT entered at any price > 0 looks like a winner at resolution price 0. Today's empirical shadow shows 100% win rate on event_financial SHORT (60/60) and 94% on event_short SHORT (843/894) — neither is a strategy edge, both are sampling artifacts.
+- **Hold-to-resolution bias**: shadow "trades" never stop out, never take profit, never close on a counter-signal. Live exits earlier and more often at a loss.
 
-- `resolved >= 50` (sufficient sample size to draw a conclusion)
-- `sharpe >= 0.20` (positive risk-adjusted edge)
-- `win_rate >= 0.50`
+For each `market_type` row, evaluate against ALL of:
+
+- `resolved >= 50` (sufficient sample size)
+- `sharpe × 0.33 >= 0.20`, i.e. raw `shadow_sharpe >= 0.60` (haircut-adjusted sharpe ≥ live's promotion bar)
+- `win_rate >= 0.65` if shadow is SHORT-direction-skewed; `>= 0.55` otherwise. Default to 0.65 unless the shadow_summary has been broken out by direction and shows a non-SHORT-driven majority.
 - The market_type is NOT already in the live `ALLOWED_MARKET_TYPES` list (`crypto_intraday,crypto_daily,event_financial,event_short`)
 
 If all four hold, include a recommendation in the issue body:
 
-> **Promotion candidate:** `<market_type>`. Over 30 days of shadow data: N=<resolved> resolved, win_rate=<win_rate>, Sharpe=<sharpe>, avg_pnl=<avg_pnl>. Consider adding to `ALLOWED_MARKET_TYPES` on the next deploy.
+> **Promotion candidate:** `<market_type>`. Over 30 days of shadow data: N=<resolved>, raw_shadow_sharpe=<sharpe>, **haircut_sharpe=<sharpe×0.33>**, win_rate=<win_rate>, avg_pnl=<avg_pnl>. Consider adding to `ALLOWED_MARKET_TYPES` on the next deploy. Note: the haircut_sharpe is the upper-bound estimate of live performance — actual live Sharpe will be lower than this figure.
 
-Do NOT auto-create a PR for the env change — promotion is a manual decision tied to a deploy. The recommendation is informational only.
+Do NOT auto-create a PR for the env change — promotion is a manual decision tied to a deploy.
 
-Conversely, for any `market_type` that IS currently in `ALLOWED_MARKET_TYPES` and shows live performance over the same 30 days that contradicts the prior shadow signal (e.g. live Sharpe < 0 while shadow was > 0.20), flag it under "Possible regression — review allowlist for `<market_type>`".
+**Conversely**, for any `market_type` that IS currently in `ALLOWED_MARKET_TYPES` and where live performance over the same 30 days deviates materially from `shadow_sharpe × 0.33` (live Sharpe more than 0.5 below the haircut prediction), flag under "Possible regression — review allowlist for `<market_type>`". The haircut model says live should land near `shadow × 0.33`; large negative deviations are evidence the haircut is too generous for that type, not a reason to remove the type.
 
-The thresholds (50 resolved trades, Sharpe 0.20, win_rate 0.50) are starting points, not an optimized policy. Tune by observation when this recommendation has been running for ≥4 weekly reviews.
+The thresholds (50 resolved, raw_sharpe ≥ 0.60, win_rate ≥ 0.65) are calibrated to the empirical 0.33 haircut. If post-deploy live Sharpe consistently lands materially below `shadow × 0.33`, raise the raw_sharpe gate. Tune the win_rate floor when shadow_summary is broken out by direction (currently it isn't).
 
 ## Step 0: Check Existing Work
 


### PR DESCRIPTION
The previous promotion thresholds (\`resolved≥50\`, \`sharpe≥0.20\`, \`win_rate≥0.50\`) treated raw shadow numbers as if they were directly comparable to live performance. They aren't.

## Why recalibrate

1. **Empirical haircut**: time-matched analysis (\`project_shadow_execution_realism.md\`) measured live/shadow Sharpe ≈ 0.33 on event_long. So raw \`shadow_sharpe = 0.20\` → predicted \`live_sharpe ≈ 0.066\`, well below any reasonable promotion bar.

2. **SHORT-resolves-NO bias**: today's empirical \`shadow_trades\` query showed 100% win rate on event_financial SHORT (60/60) and 94% on event_short SHORT (843/894). Neither is a strategy edge — both are sampling artifacts of prediction markets mostly resolving to NO. With a 0.50 win_rate gate this passes trivially.

3. **Hold-to-resolution bias**: shadow trades never stop out, never take profit, never close on a counter-signal. Live exits earlier and more often at a loss.

## Changes

| Threshold | Before | After | Rationale |
|---|---|---|---|
| Sharpe (raw shadow) | ≥ 0.20 | ≥ 0.60 | so \`shadow_sharpe × 0.33 ≥ 0.20\` (prior live bar) |
| Win rate | ≥ 0.50 | ≥ 0.65 | defends against SHORT-bias inflation |
| Resolved sample | ≥ 50 | unchanged | still the right floor |
| Recommendation template | shows raw sharpe only | shows raw sharpe **and** \`haircut_sharpe\` | reader sees both numbers and the upper-bound nature |
| Reverse-direction flag | "consider removing type" | "haircut may be too generous for this type" | wrong response was to remove the type; right response is to refine the haircut |

## How thresholds were chosen

- 0.60 raw shadow Sharpe → 0.20 effective post-haircut, matching the prior live promotion bar
- 0.65 win_rate: high enough that pure SHORT-bias artifacts don't pass on their own; low enough that a genuine LONG-driven edge still can. event_long shadow shows ~74% raw WR (mix of LONG/SHORT) — won't trigger a regression flag spuriously

These remain *starting points*, not an optimized policy. The doc says to retune if live Sharpe lands materially below \`shadow × 0.33\`.

## Out of scope

- Breaking \`shadow_summary\` out by \`direction\` is the structural fix for the SHORT-bias inflation; requires a new query in \`daily-review.sh\`. Separate PR.
- Re-estimating the 0.33 haircut per market_type is deferred until per-type live samples are large enough (today event_long n=16 is the only data point).

Doc-only change, no tests.