### PR TITLE
feat(optimizer): wire consensus_discount_floor into Optuna param space (closes #129)

### DIFF
--- a/packages/dashboard/src/services/OptimizationScheduler.test.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.test.ts
@@ -105,6 +105,69 @@ describe('OptimizationScheduler', () => {
       expect.stringMatching(/^optimization-\d{4}-\d{2}-\d{2}$/),
     );
   });
+
+  it('includes combiner.consensusDiscountFloor in OPTUNA_PARAM_SPACE and REFINEMENT_PARAM_SPACE with [0,1] domain', () => {
+    // Issue #129: B.2 follow-up. Optimizer must sample consensusDiscountFloor
+    // per trial so trial-time backtests run with the same combiner config the
+    // operator might persist post-cycle.
+    const fullCdf = OPTUNA_PARAM_SPACE.find(p => p.name === 'combiner.consensusDiscountFloor');
+    expect(fullCdf).toBeDefined();
+    expect(fullCdf).toMatchObject({ type: 'float', low: 0.0, high: 1.0 });
+
+    const refinementCdf = REFINEMENT_PARAM_SPACE.find(p => p.name === 'combiner.consensusDiscountFloor');
+    expect(refinementCdf).toBeDefined();
+    expect(refinementCdf).toMatchObject({ type: 'float', low: 0.0, high: 1.0 });
+  });
+
+  it('persists combiner.consensusDiscountFloor to the __global__ row after a winning trial', async () => {
+    const scheduler = new OptimizationScheduler();
+    (scheduler as any)._lastOOSResult = {
+      passed: true,
+      sharpeOOS: 0.5,
+      drawdownOOS: 0.05,
+      tradesOOS: 20,
+      winRateOOS: 0.6,
+      marketsEvaluated: 10,
+    };
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: vi.fn() }));
+
+    await (scheduler as any).updateStrategy({
+      params: {
+        'combiner.consensusDiscountFloor': 0.72,
+      },
+      sharpe: 0.9,
+      totalReturn: 0.08,
+      trades: 25,
+    }, 'event_short');
+
+    // The combiner reads consensus_discount_floor only from the __global__
+    // row, so the write must use the global update path (not updatePerType).
+    expect(signalWeightsRepo.update).toHaveBeenCalledWith(
+      'consensus_discount_floor',
+      0.72,
+      expect.stringMatching(/^optimization-\d{4}-\d{2}-\d{2}-event_short$/),
+    );
+  });
+
+  it('clamps consensusDiscountFloor to [0, 1] before persisting (defensive)', async () => {
+    const scheduler = new OptimizationScheduler();
+    (scheduler as any)._lastOOSResult = {
+      passed: true, sharpeOOS: 0.5, drawdownOOS: 0.05, tradesOOS: 20, winRateOOS: 0.6, marketsEvaluated: 10,
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: vi.fn() }));
+
+    await (scheduler as any).updateStrategy({
+      params: { 'combiner.consensusDiscountFloor': 1.5 },  // out of nominal range
+      sharpe: 0.9, totalReturn: 0.08, trades: 25,
+    }, 'event_short');
+
+    expect(signalWeightsRepo.update).toHaveBeenCalledWith(
+      'consensus_discount_floor',
+      1.0,  // clamped
+      expect.stringMatching(/^optimization-\d{4}-\d{2}-\d{2}-event_short$/),
+    );
+  });
 });
 
 describe('getOosMinTrades', () => {

--- a/packages/dashboard/src/services/OptimizationScheduler.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.ts
@@ -55,6 +55,10 @@ export const OPTUNA_PARAM_SPACE: ParameterDef[] = [
   { name: 'combiner.volumeAnomalyWeight', type: 'float', low: 0.0, high: 2.0 },
   { name: 'combiner.mlofiWeight', type: 'float', low: 0.0, high: 2.0 },
   { name: 'combiner.spreadCompressionWeight', type: 'float', low: 0.0, high: 2.0 },
+  // Consensus discount floor (Sub-project B.2, see docs/plans/2026-04-25-signal-consensus-design.md).
+  // Combiner-layer confidence multiplier driven by entropy across active generators.
+  // 0.0 = full discount on disagreement; 1.0 = no-op. Live default in signal_weights is 0.5.
+  { name: 'combiner.consensusDiscountFloor', type: 'float', low: 0.0, high: 1.0 },
   // Risk
   { name: 'risk.maxPositionSizePct', type: 'float', low: 3.0, high: 15.0 },
   { name: 'risk.maxPositions', type: 'int', low: 5, high: 15 },
@@ -89,6 +93,7 @@ export const REFINEMENT_PARAM_SPACE: ParameterDef[] = [
   { name: 'combiner.volumeAnomalyWeight', type: 'float', low: 0.0, high: 2.0 },
   { name: 'combiner.mlofiWeight', type: 'float', low: 0.0, high: 2.0 },
   { name: 'combiner.spreadCompressionWeight', type: 'float', low: 0.0, high: 2.0 },
+  { name: 'combiner.consensusDiscountFloor', type: 'float', low: 0.0, high: 1.0 },
   { name: 'risk.maxPositionSizePct', type: 'float', low: 3.0, high: 15.0 },
   { name: 'risk.stopLossPct', type: 'float', low: 8.0, high: 30.0 },
   { name: 'meanReversion.zScoreThreshold', type: 'float', low: 1.5, high: 2.5 },
@@ -597,6 +602,10 @@ export class OptimizationScheduler {
         // Undefined for FULL strategy (OPTUNA_PARAM_SPACE excludes dm).
         // Task 8 wires BacktestService to actually apply this via the combiner.
         directionMultiplier: params['combiner.directionMultiplier'] as number | undefined,
+        // Sub-project B.2 (issue #129): consensus discount floor sampled per
+        // trial. BacktestService.runBacktest already accepts this on the
+        // combinerConfig field (commit 46dcf41).
+        consensusDiscountFloor: params['combiner.consensusDiscountFloor'] as number | undefined,
       },
     };
   }
@@ -932,6 +941,27 @@ export class OptimizationScheduler {
       console.log('[OptimizationScheduler] direction_multiplier __global__ reset to +1.0 (per-type values preserved)');
     } catch (err) {
       console.error('[OptimizationScheduler] Failed to reset __global__ direction_multiplier to +1.0:', err);
+    }
+
+    // Sub-project B.2 (issue #129): persist the trial's optimal consensus
+    // discount floor to the __global__ row of signal_weights. The combiner
+    // reads consensus_discount_floor only at startup from the __global__
+    // row (server.ts:661), so per-type writes have no runtime effect — the
+    // global write is the contract. Domain [0, 1] is enforced upstream by
+    // OPTUNA_PARAM_SPACE; clamp here is defensive against malformed params.
+    const cdfRaw = result.params['combiner.consensusDiscountFloor'];
+    if (cdfRaw !== undefined && cdfRaw !== null && Number.isFinite(Number(cdfRaw))) {
+      const cdf = Math.max(0, Math.min(1, Number(cdfRaw)));
+      try {
+        await signalWeightsRepo.update(
+          'consensus_discount_floor',
+          cdf,
+          `optimization-${new Date().toISOString().slice(0, 10)}-${marketType}`,
+        );
+        console.log(`[OptimizationScheduler] consensus_discount_floor __global__ updated to ${cdf.toFixed(4)} (winner: ${marketType})`);
+      } catch (err) {
+        console.error('[OptimizationScheduler] Failed to persist consensus_discount_floor:', err);
+      }
     }
 
     // Apply optimized signal weights to database


### PR DESCRIPTION
B.2 follow-up. The combiner-side consensus discount has been live since #130 but the Optuna optimizer wasn't sampling the floor — it stayed pinned at 0.5 with no learning signal.

## Three pieces (matching issue #129 checklist)

1. **\`combiner.consensusDiscountFloor\`** added to **both** \`OPTUNA_PARAM_SPACE\` (FULL strategy) and \`REFINEMENT_PARAM_SPACE\` (per-type cycles), as \`{ type: 'float', low: 0.0, high: 1.0 }\`.

2. **\`paramsToBacktestRequest\`** forwards the sampled value via \`combinerConfig.consensusDiscountFloor\`. \`BacktestService.runBacktest\` already accepts this on the request (commit \`46dcf41\`) and applies it through \`combiner.setParameters({ consensusDiscountFloor })\`, so each trial backtests with the floor it sampled.

3. **Write-back** to the \`__global__\` row of \`signal_weights\` with \`signal_type='consensus_discount_floor'\`. Combiner reads only \`__global__\` at startup (\`server.ts:661\`), so global is the contract. Uses \`signalWeightsRepo.update\` (global path), not \`updatePerType\` — same model as \`applyGlobalThresholds\` for minEdge/minConfidence: the cycle winner's value propagates globally.

Defensive clamp to [0, 1] on persist guards against malformed params even though the param-space domain already enforces it upstream.

## Tests (3 new, 27 pass total in OptimizationScheduler suite)

- Both spaces contain the param with \`[0, 1]\` domain.
- A winning trial with \`combiner.consensusDiscountFloor=0.72\` triggers \`signalWeightsRepo.update('consensus_discount_floor', 0.72, ...)\`.
- An out-of-range value (1.5) is clamped to 1.0 before persist.

871 pass overall.

## Out of scope

The issue mentions the Optuna optimizer running on Render. That code lives in a separate repo and would need its own update if it bypasses the local \`OptimizationScheduler\`. With \`OPTIMIZER_URL\` pointing to the local scheduler this isn't relevant. If the Render bypass is re-enabled, replicate this change there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new tunable parameter for consensus discount floor optimization, constrained to values between 0 and 1.
  * Parameter is now automatically validated and clamped to acceptable range during optimization runs.

* **Tests**
  * Added comprehensive test coverage for the new consensus discount floor parameter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->