### PR TITLE
fix(executor): relax SHORT asymmetric guards now that dm flip explains the 0% WR

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -156,6 +156,13 @@ services:
       EXECUTOR_MARKET_COOLDOWN_MS: "1800000"
       EXECUTOR_NEAR_RESOLVED_UPPER: "0.97"
       EXECUTOR_NEAR_RESOLVED_LOWER: "0.03"
+      # SHORT asymmetric guards (PRs #110/#111) relaxed 2026-05-04: the 0%
+      # SHORT WR they were defending against was the dm=-1 double-inversion
+      # (PR #178), not a real SHORT pathology. Counter-WR on the same cohort
+      # was 93.9%. Both set to 1.0 (no-op) to let the post-flip SHORT cohort
+      # materialize. Re-tighten only if post-flip live SHORT WR underperforms.
+      EXECUTOR_SHORT_MAX_YES_PRICE: "1.0"
+      EXECUTOR_SHORT_SIZE_MULT: "1.0"
       # Gate 0e: EventOTMGate — block opens on event_financial markets near expiry
       # with extreme-band prices. See docs/plans/2026-04-21-event-otm-gate-design.md
       EXECUTOR_EVENT_OTM_MARKET_TYPES: "event_financial"

--- a/packages/dashboard/src/services/AutoSignalExecutor.test.ts
+++ b/packages/dashboard/src/services/AutoSignalExecutor.test.ts
@@ -419,39 +419,37 @@ describe('AutoSignalExecutor', () => {
   // =========================================================
   // SHORT YES-price gate (asymmetric entry filter)
   //
-  // Rationale: empirical analysis (5 days, 24 SHORTs) showed 0% win rate when
-  // SHORTs entered against high-consensus markets (YES > 0.6). The consensus
-  // does not flip in our 60-min hold window; NO token decays from spread/fees.
-  // Block SHORT entries when YES price > shortMaxYesPrice. LONG unaffected.
-  // For SHORT signals, signal.price is the NO token price → YES = 1 - signal.price.
+  // 2026-05-04: defaults relaxed from 0.6 → 1.0 (effectively no gate). The
+  // 0% SHORT win rate that originally motivated the gate (PR #110) was caused
+  // by the dm=-1 double-inversion (PR #178). Counter-WR analysis on the same
+  // SHORT cohort shows 93.9% — keeping the gate post-flip just hides
+  // post-flip SHORTs from the cohort. The gate remains opt-in via
+  // EXECUTOR_SHORT_MAX_YES_PRICE / explicit config for any future re-tightening.
   // =========================================================
   describe('SHORT YES-price gate', () => {
-    it('should reject SHORT when YES consensus is too strong (YES > 0.6)', async () => {
+    it('default config does not block SHORT against high-consensus markets', async () => {
       mockMarketQuery();
-      // SHORT at NO=0.30 → YES=0.70 (consensus too strong)
+      // SHORT at NO=0.30 → YES=0.70. Pre-2026-05-04 this would have been blocked.
       const result = await executor.processSignal(makeSignal({ direction: 'short', price: 0.30 }));
-      expect(result.executed).toBe(false);
-      expect(result.reason).toMatch(/SHORT blocked.*consensus/i);
+      expect(result.reason || '').not.toMatch(/SHORT blocked.*consensus/i);
     });
 
-    it('should allow SHORT when YES consensus is moderate (YES <= 0.6)', async () => {
+    it('allows SHORT regardless of YES consensus by default', async () => {
       mockMarketQuery();
-      // SHORT at NO=0.45 → YES=0.55 (within threshold)
       const result = await executor.processSignal(makeSignal({ direction: 'short', price: 0.45 }));
       expect(result.reason || '').not.toMatch(/SHORT blocked.*consensus/i);
     });
 
-    it('should NOT gate LONG signals (gate is SHORT-only)', async () => {
+    it('does not gate LONG signals (gate is SHORT-only when configured)', async () => {
       mockMarketQuery();
-      // LONG at YES=0.70 — would be rejected if gate applied to LONG
       const result = await executor.processSignal(makeSignal({ direction: 'long', price: 0.70 }));
       expect(result.reason || '').not.toMatch(/SHORT blocked/i);
     });
 
-    it('should respect custom shortMaxYesPrice threshold via config', async () => {
+    it('respects custom shortMaxYesPrice threshold when set explicitly', async () => {
       const strictExecutor = new AutoSignalExecutor({ enabled: true, cooldownMs: 0, shortMaxYesPrice: 0.5 });
       mockMarketQuery();
-      // SHORT at NO=0.45 → YES=0.55, exceeds custom threshold 0.5
+      // SHORT at NO=0.45 → YES=0.55, exceeds opt-in threshold 0.5
       const result = await strictExecutor.processSignal(makeSignal({ direction: 'short', price: 0.45 }));
       expect(result.executed).toBe(false);
       expect(result.reason).toMatch(/SHORT blocked.*consensus/i);
@@ -461,10 +459,10 @@ describe('AutoSignalExecutor', () => {
   // =========================================================
   // Asymmetric position sizing (LONG vs SHORT)
   //
-  // Rationale: SHORTs lose 0% win rate empirically (24/24 losing in 5 days).
-  // Until Learning Service identifies winning SHORT segments, halve SHORT
-  // position size to limit damage while still collecting data. LONG sizing
-  // unaffected.
+  // 2026-05-04: default shortSizeMultiplier relaxed from 0.5 → 1.0. Same
+  // reasoning as the YES-price gate above — the original 0% SHORT WR was
+  // the dm=-1 inversion bug, not the SHORTs. Override via
+  // EXECUTOR_SHORT_SIZE_MULT or explicit config to restore asymmetric sizing.
   // =========================================================
   describe('Asymmetric SHORT position sizing', () => {
     function fullMockChain() {
@@ -484,7 +482,7 @@ describe('AutoSignalExecutor', () => {
       });
     }
 
-    it('should size SHORT positions smaller than LONG at same price (default 0.5x)', async () => {
+    it('default config sizes SHORT and LONG identically at same price', async () => {
       const exec = new AutoSignalExecutor({ enabled: true, cooldownMs: 0 });
       const simSpy = vi.spyOn((exec as any).simulator, 'simulateBuy');
 
@@ -499,9 +497,8 @@ describe('AutoSignalExecutor', () => {
 
       expect(longShares).toBeGreaterThan(0);
       expect(shortShares).toBeGreaterThan(0);
-      // SHORT should be ~50% of LONG (default 0.5 multiplier)
-      expect(shortShares).toBeLessThan(longShares * 0.6);
-      expect(shortShares).toBeGreaterThan(longShares * 0.4);
+      // 2026-05-04: default shortSizeMultiplier=1.0, so SHORT and LONG should match
+      expect(shortShares).toBe(longShares);
     });
 
     it('should respect custom shortSizeMultiplier via config', async () => {

--- a/packages/dashboard/src/services/AutoSignalExecutor.ts
+++ b/packages/dashboard/src/services/AutoSignalExecutor.ts
@@ -108,12 +108,19 @@ export interface ExecutorConfig {
   // Smart price validation based on ROI and probability
   minPotentialROI: number;      // Minimum potential ROI to accept (0.15 = 15%)
   minImpliedProbability: number; // Minimum market probability (0.10 = 10%)
-  // Asymmetric SHORT gate: block SHORT entries against high-consensus markets
-  // (YES price > shortMaxYesPrice). LONG entries are unaffected.
-  shortMaxYesPrice: number;     // Max YES price to allow SHORT entry (0.6 default)
-  // Asymmetric SHORT sizing: scale SHORT position size by this multiplier.
-  // Empirical: 5-day SHORT win rate is 0% — halve size while collecting data.
-  shortSizeMultiplier: number;  // Multiplier for SHORT position size (0.5 default)
+  // SHORT entry guard. Blocks SHORTs in markets with YES > shortMaxYesPrice.
+  // 2026-05-04: defaults relaxed from 0.6 → 1.0 (effectively no gate). The
+  // 0.6 cap was set by PR #110 in response to "SHORTs 0% WR over 5 days",
+  // but that 0% was caused by the dm=-1 double-inversion (PR #178). The
+  // counter-WR analysis on the same SHORT cohort showed 93.9% — i.e. the
+  // SHORTs would have been profitable in the right direction. Keeping the
+  // gate post-flip just hides post-flip SHORTs from the cohort. Override
+  // via EXECUTOR_SHORT_MAX_YES_PRICE if needed.
+  shortMaxYesPrice: number;     // Max YES price to allow SHORT entry
+  // SHORT position size multiplier. 2026-05-04: relaxed 0.5 → 1.0 for the
+  // same reason as the YES-price gate above. Override via
+  // EXECUTOR_SHORT_SIZE_MULT if asymmetric sizing is wanted again.
+  shortSizeMultiplier: number;  // Multiplier for SHORT position size
   // Hysteresis thresholds: higher to open, lower to exit
   openThreshold: number;        // Minimum confidence to OPEN a new position
   exitThreshold: number;        // Minimum confidence to CLOSE an existing position (lower)
@@ -135,10 +142,12 @@ const DEFAULT_CONFIG: ExecutorConfig = {
   // minImpliedProbability: 0.10 means market must show at least 10% chance → rejects prices < 0.10
   minPotentialROI: parseFloat(process.env.EXECUTOR_MIN_POTENTIAL_ROI || '0.15'),
   minImpliedProbability: parseFloat(process.env.EXECUTOR_MIN_IMPLIED_PROB || '0.10'),
-  // Empirical: 5-day analysis (Apr 13-18, 24 SHORTs) showed 0% win rate when
-  // SHORTs entered against YES > 0.6. Default optimizable via env.
-  shortMaxYesPrice: parseFloat(process.env.EXECUTOR_SHORT_MAX_YES_PRICE || '0.6'),
-  shortSizeMultiplier: parseFloat(process.env.EXECUTOR_SHORT_SIZE_MULT || '0.5'),
+  // 2026-05-04: dm=-1 double-inversion (PR #178) explained the 0% SHORT WR
+  // that originally motivated PRs #110 (YES gate at 0.6) and #111 (size×0.5).
+  // Counter-WR analysis on the same cohort shows 93.9% — the SHORTs were
+  // structurally profitable, not pathological. Defaults relaxed to no-op.
+  shortMaxYesPrice: parseFloat(process.env.EXECUTOR_SHORT_MAX_YES_PRICE || '1.0'),
+  shortSizeMultiplier: parseFloat(process.env.EXECUTOR_SHORT_SIZE_MULT || '1.0'),
   // Hysteresis thresholds: higher to open, lower to exit
   openThreshold: parseFloat(process.env.EXECUTOR_OPEN_THRESHOLD || '0.43'),
   exitThreshold: parseFloat(process.env.EXECUTOR_EXIT_THRESHOLD || '0.25'),
@@ -829,8 +838,8 @@ export class AutoSignalExecutor extends EventEmitter {
     }
 
     // Calculate position size based on confidence, strength (absolute), and weight.
-    // SHORT positions get scaled by shortSizeMultiplier (default 0.5x) to limit
-    // damage while empirical SHORT win rate remains low.
+    // shortSizeMultiplier is 1.0 by default since 2026-05-04; override via env
+    // if asymmetric sizing is wanted again.
     const baseSizeMultiplier = signal.confidence * Math.abs(signal.strength) * weight;
     const sideMultiplier = signal.direction === 'short' ? this.config.shortSizeMultiplier : 1.0;
     const sizeMultiplier = baseSizeMultiplier * sideMultiplier;


### PR DESCRIPTION
PRs #110 (\`EXECUTOR_SHORT_MAX_YES_PRICE=0.6\`) and #111 (\`EXECUTOR_SHORT_SIZE_MULT=0.5\`) were instituted to defend against a measured 0% SHORT win rate over 5 days. PR #178 today identified the cause: \`dm=-1\` was a double-inversion, so every SHORT was going in the inverse direction. Counter-WR analysis on the same 164-trade SHORT cohort returned **93.9%** — those SHORTs were structurally profitable.

## The trap

Keeping the guards post-flip blocks the very signals we now expect to be winners. Empirical evidence from the 3h since the flip:

| Metric | Pre-flip (cohort) | Post-flip (3h logs) |
|---|---|---|
| signal direction split | (TRADES) 58% LONG / 42% SHORT | 97% LONG / 3% SHORT |
| SHORT trades executed | 164 / 386 | 0 / 8 |

Most active markets sit at YES<0.5. Under dm=+1 those generate \`strength>0\` → LONG bias. The few SHORTs that do come through still hit the \`YES>0.6\` gate from #110 and never reach \`processSignal\`. **The cohort needed to validate the flip on the SHORT side cannot materialize while the gate stays at 0.6.** Removing the gate is what generates the data.

## Changes

- \`AutoSignalExecutor.ts\` defaults: \`shortMaxYesPrice\` 0.6 → 1.0, \`shortSizeMultiplier\` 0.5 → 1.0. Both env-overridable to re-tighten with evidence if needed.
- \`docker-compose.gcp.yml\`: explicit \`EXECUTOR_SHORT_MAX_YES_PRICE=1.0\` and \`EXECUTOR_SHORT_SIZE_MULT=1.0\`. Documented inline next to the override so any future re-tightening is deliberate, not a silent code-default change.
- \`AutoSignalExecutor.test.ts\`: defaults-tests rewritten to verify the no-op behaviour. Env-override tests retained to confirm the gate still works when configured explicitly.

## Why "do this now" not "wait for cohort"

The cohort cannot include SHORTs while the gate blocks them. Removing the gate is the experiment. If post-flip SHORT performance is genuinely poor (which would be a surprise given counter-WR=93.9%), live data shows it in days and we re-tighten with current evidence rather than data contaminated by the dm bug. The asymmetric defenses were always opt-in safety rails layered over a contaminated empirical premise.

## Tests

871 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated SHORT order executor default parameters to improve handling and enable symmetric sizing between SHORT and LONG orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->