### PR TITLE
fix(executor): regime-aware loss-gate epoch unblocks post-flip SHORT cohort

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -163,6 +163,13 @@ services:
       # materialize. Re-tighten only if post-flip live SHORT WR underperforms.
       EXECUTOR_SHORT_MAX_YES_PRICE: "1.0"
       EXECUTOR_SHORT_SIZE_MULT: "1.0"
+      # Loss-gate regime epoch: per-market consecutive-loss block (24h) and
+      # long-term persistent-loser ban (7d) ignore trades closed before this
+      # timestamp. Set to the dm=-1 → +1 flip (PR #178, 2026-05-04 09:55 UTC)
+      # so the post-flip SHORT cohort isn't blocked by its own pre-flip
+      # losses, which were structurally inverse signals (counter-WR=93.9%).
+      # Remove once the rolling 7-day window has cleared (after 2026-05-11).
+      EXECUTOR_LOSS_GATE_EPOCH: "2026-05-04T09:55:00Z"
       # Gate 0e: EventOTMGate — block opens on event_financial markets near expiry
       # with extreme-band prices. See docs/plans/2026-04-21-event-otm-gate-design.md
       EXECUTOR_EVENT_OTM_MARKET_TYPES: "event_financial"

--- a/packages/dashboard/src/services/AutoSignalExecutor.test.ts
+++ b/packages/dashboard/src/services/AutoSignalExecutor.test.ts
@@ -417,6 +417,97 @@ describe('AutoSignalExecutor', () => {
   });
 
   // =========================================================
+  // Loss-gate regime epoch
+  //
+  // 2026-05-05: gates 4b (per-market consecutive losses, 24h) and 4c
+  // (long-term persistent loser, 7-day rate) compute lookbacks against
+  // realized_pnl history. When a regime change inverts the system's signal
+  // direction (e.g. dm flip on 2026-05-04), the pre-flip losses are no
+  // longer predictive of post-flip performance — they're literally the
+  // inverse signal. Without an epoch filter, post-flip cohorts get blocked
+  // for weeks by their own pre-flip losses.
+  //
+  // EXECUTOR_LOSS_GATE_EPOCH (or ExecutorConfig.lossGateEpoch) sets the
+  // earliest closed_at considered. Trades closed before the epoch are
+  // ignored by these gates.
+  // =========================================================
+  describe('Loss-gate regime epoch', () => {
+    const findLossQueryCall = (sqlMatch: RegExp) => {
+      const calls = (query as any).mock.calls as unknown as Array<[string, unknown[]]>;
+      return calls.find(([sql]) => typeof sql === 'string' && sqlMatch.test(sql));
+    };
+
+    it('passes null as epoch parameter when not configured (gate 4b)', async () => {
+      // Default executor (no lossGateEpoch override). Stub: market metadata, then 24h
+      // loss check returns empty (no block), then 7-day check returns 0/0 (no block).
+      (query as any)
+        .mockResolvedValueOnce({ rows: [{ is_active: true, is_resolved: false, end_date: null }] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ losses: '0', wins: '0' }] });
+      (paperPositionsRepo.getAll as any).mockResolvedValue([]);
+
+      await executor.processSignal(makeSignal());
+
+      const call24h = findLossQueryCall(/closed_at >= NOW\(\) - \$2::interval/i);
+      expect(call24h, 'gate 4b query should have been called').toBeDefined();
+      // Params: [marketId, intervalString, lossGateEpoch, limit]
+      expect(call24h![1][2]).toBeNull();
+    });
+
+    it('passes the configured epoch through to gate 4b query', async () => {
+      const epoch = new Date('2026-05-04T09:55:00Z');
+      const exec = new AutoSignalExecutor({ enabled: true, cooldownMs: 0, lossGateEpoch: epoch });
+      (query as any)
+        .mockResolvedValueOnce({ rows: [{ is_active: true, is_resolved: false, end_date: null }] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ losses: '0', wins: '0' }] });
+      (paperPositionsRepo.getAll as any).mockResolvedValue([]);
+
+      await exec.processSignal(makeSignal());
+
+      const call24h = findLossQueryCall(/closed_at >= NOW\(\) - \$2::interval/i);
+      expect(call24h).toBeDefined();
+      expect(call24h![1][2]).toBe(epoch);
+    });
+
+    it('passes the configured epoch through to gate 4c query', async () => {
+      const epoch = new Date('2026-05-04T09:55:00Z');
+      const exec = new AutoSignalExecutor({ enabled: true, cooldownMs: 0, lossGateEpoch: epoch });
+      (query as any)
+        .mockResolvedValueOnce({ rows: [{ is_active: true, is_resolved: false, end_date: null }] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ losses: '0', wins: '0' }] });
+      (paperPositionsRepo.getAll as any).mockResolvedValue([]);
+
+      await exec.processSignal(makeSignal());
+
+      const call7d = findLossQueryCall(/COUNT\(\*\) FILTER \(WHERE realized_pnl < 0\) AS losses/);
+      expect(call7d).toBeDefined();
+      // Params: [marketId, intervalString, lossGateEpoch]
+      expect(call7d![1][2]).toBe(epoch);
+    });
+
+    it('still blocks when epoch is set but post-epoch losses still satisfy the gate', async () => {
+      // Even with epoch active, a market with 3 fresh post-epoch losses must still block.
+      // The epoch only filters out pre-epoch rows — it does not disable the gate logic.
+      const epoch = new Date('2026-05-04T09:55:00Z');
+      const exec = new AutoSignalExecutor({ enabled: true, cooldownMs: 0, lossGateEpoch: epoch });
+      (query as any)
+        .mockResolvedValueOnce({ rows: [{ is_active: true, is_resolved: false, end_date: null }] })
+        .mockResolvedValueOnce({ rows: [
+          { realized_pnl: '-5.00' },
+          { realized_pnl: '-3.50' },
+          { realized_pnl: '-8.00' },
+        ] });
+      (paperPositionsRepo.getAll as any).mockResolvedValue([]);
+
+      const result = await exec.processSignal(makeSignal());
+      expect(result.executed).toBe(false);
+      expect(result.reason).toMatch(/last 3 closed positions all lost/i);
+    });
+  });
+
+  // =========================================================
   // SHORT YES-price gate (asymmetric entry filter)
   //
   // 2026-05-04: defaults relaxed from 0.6 → 1.0 (effectively no gate). The

--- a/packages/dashboard/src/services/AutoSignalExecutor.ts
+++ b/packages/dashboard/src/services/AutoSignalExecutor.ts
@@ -124,6 +124,12 @@ export interface ExecutorConfig {
   // Hysteresis thresholds: higher to open, lower to exit
   openThreshold: number;        // Minimum confidence to OPEN a new position
   exitThreshold: number;        // Minimum confidence to CLOSE an existing position (lower)
+  // Optional regime epoch: when set, the retroactive loss-based gates (per-market
+  // consecutive-loss block, long-term persistent-loser ban) only count trades closed
+  // AFTER this timestamp. Lets the system invalidate stale regime data after a flip
+  // (e.g. directionMultiplier inversion on 2026-05-04) without disabling the gates.
+  // Null = no epoch filter (default; gates use rolling windows only).
+  lossGateEpoch: Date | null;
 }
 
 const DEFAULT_CONFIG: ExecutorConfig = {
@@ -151,7 +157,21 @@ const DEFAULT_CONFIG: ExecutorConfig = {
   // Hysteresis thresholds: higher to open, lower to exit
   openThreshold: parseFloat(process.env.EXECUTOR_OPEN_THRESHOLD || '0.43'),
   exitThreshold: parseFloat(process.env.EXECUTOR_EXIT_THRESHOLD || '0.25'),
+  lossGateEpoch: parseLossGateEpoch(process.env.EXECUTOR_LOSS_GATE_EPOCH),
 };
+
+// Parses an ISO-8601 timestamp string to Date; returns null on empty/invalid input.
+// A typo'd env var should not silently disable the loss gates' regime filter, but
+// it should also not crash startup — so warn and fall back to no-filter behaviour.
+function parseLossGateEpoch(raw: string | undefined): Date | null {
+  if (!raw || !raw.trim()) return null;
+  const d = new Date(raw);
+  if (Number.isNaN(d.getTime())) {
+    console.warn(`[AutoExecutor] Invalid EXECUTOR_LOSS_GATE_EPOCH=${raw}; ignoring (gates will use rolling windows only)`);
+    return null;
+  }
+  return d;
+}
 
 const STOP_LOSS_COOLDOWN_MS = 4 * 60 * 60 * 1000; // 4 hours
 // Any position close with realized loss >= this threshold triggers the same 4h cooldown,
@@ -642,9 +662,10 @@ export class AutoSignalExecutor extends EventEmitter {
            WHERE market_id = $1
              AND closed_at IS NOT NULL
              AND closed_at >= NOW() - $2::interval
+             AND ($3::timestamptz IS NULL OR closed_at >= $3::timestamptz)
            ORDER BY closed_at DESC
-           LIMIT $3`,
-          [signal.marketId, `${PER_MARKET_LOSS_BLOCK_WINDOW_MS} milliseconds`, PER_MARKET_CONSECUTIVE_LOSS_BLOCK]
+           LIMIT $4`,
+          [signal.marketId, `${PER_MARKET_LOSS_BLOCK_WINDOW_MS} milliseconds`, this.config.lossGateEpoch, PER_MARKET_CONSECUTIVE_LOSS_BLOCK]
         );
         if (lossResult.rows.length >= PER_MARKET_CONSECUTIVE_LOSS_BLOCK) {
           const allLosing = lossResult.rows.every(r => parseFloat(r.realized_pnl) < 0);
@@ -671,8 +692,9 @@ export class AutoSignalExecutor extends EventEmitter {
            FROM paper_positions
            WHERE market_id = $1
              AND closed_at IS NOT NULL
-             AND closed_at >= NOW() - $2::interval`,
-          [signal.marketId, `${LONG_TERM_LOSS_WINDOW_MS} milliseconds`]
+             AND closed_at >= NOW() - $2::interval
+             AND ($3::timestamptz IS NULL OR closed_at >= $3::timestamptz)`,
+          [signal.marketId, `${LONG_TERM_LOSS_WINDOW_MS} milliseconds`, this.config.lossGateEpoch]
         );
         if (longTermResult.rows.length > 0) {
           const losses = parseInt(longTermResult.rows[0].losses, 10);


### PR DESCRIPTION
## Why

The auto-review for 2026-05-04 (issue #179) confirmed PR #178 inverted the dm flip from −1 → +1. But empirical post-flip data on the VM today shows the **SHORT cohort is being systematically blocked**, even after PR #183 removed the asymmetric SHORT entry guard:

```
Post-flip 24h (signal_predictions, since 2026-05-04 09:55 UTC):
 direction | combined signals | executed
 long      |       36         |    35   (97%)
 short     |        7         |     2   (29%)  ← 71% blocked
```

6h aggregate of executor reject reasons:
```
 88  last 3 positions all lost money   ← gate 4b
 44  5 losses, 0% win rate in 7-day window  ← gate 4c
 96  market_type_not_allowed (event_long)  (expected)
```

The pre-flip losses driving these gates are **inverse signals** under the new regime — counter-WR on the dm=−1 SHORT cohort was 93.9% per the same review's diagnostic. Without an epoch filter, those losses keep poisoning the gates for days (7-day window) — exactly the cohort starvation problem PR #183 tried to solve from a different angle.

## Fix

Adds opt-in `EXECUTOR_LOSS_GATE_EPOCH` env var (ISO timestamp, also exposed as `lossGateEpoch` on `ExecutorConfig`). When set, gates 4b/4c add a clause:

```sql
AND ($3::timestamptz IS NULL OR closed_at >= $3::timestamptz)
```

Trades closed before the epoch are dropped from the gate window. `null` (default) is backward-compatible — gates use rolling windows only, exactly as before.

`docker-compose.gcp.yml` sets the epoch to **2026-05-04T09:55:00Z** (the PR #178 deploy). Should be removed once the 7-day rolling window naturally clears the dm=−1 cohort (after 2026-05-11), so the gates resume their long-window protection.

## Why an env var instead of a code-level "regime change" lookup

- The dm flip is a one-off rare event; permanent infra to track regime epochs is over-design.
- The env var is opt-in: omitting it preserves prior behaviour in tests and any other deploy.
- `docker-compose.gcp.yml` is the right place to record "this is the active regime epoch" — it's reviewable and reverts cleanly.

## Tests (4 new)

- `passes null as epoch parameter when not configured (gate 4b)` — default ExecutorConfig sends `null` as the third query param.
- `passes the configured epoch through to gate 4b query` — Date-typed epoch flows through.
- `passes the configured epoch through to gate 4c query` — same for the 7-day gate.
- `still blocks when epoch is set but post-epoch losses still satisfy the gate` — epoch filters rows, does not disable the gate logic.

875/889 pass total (14 unrelated `.skip` preserved).

## Verification post-deploy

On the VM ~30 min after deploy:

```sql
-- Should rise from 2 to a reasonable share of generated SHORT signals
SELECT direction, COUNT(*)
FROM signal_predictions
WHERE time >= '2026-05-04 09:55:00+00'
GROUP BY direction;
```

Reject-reason aggregate over 6h log window should show
`last 3 positions all lost` and `7-day window` counts dropping materially
(non-zero is fine — fresh post-flip losses can still trigger).

## Removal plan

Once `EXTRACT(EPOCH FROM (NOW() - '2026-05-04 09:55:00+00')) > 7*86400`
(after 2026-05-11), unset `EXECUTOR_LOSS_GATE_EPOCH` in
`docker-compose.gcp.yml` so the gates' rolling windows resume normal
behaviour — by then the pre-flip cohort has aged out organically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loss-gate epoch configuration now available, enabling timestamp-based filtering for loss-based blocking logic

* **Tests**
  * Added test coverage validating loss-gate epoch behavior for consecutive-loss and persistent-loser blocking mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->