### PR TITLE
feat(daily-review): split shadow_summary by direction to detect SHORT-bias

### DIFF
--- a/scripts/daily-review-prompt.md
+++ b/scripts/daily-review-prompt.md
@@ -120,32 +120,35 @@ The executor restricts live trades to `ALLOWED_MARKET_TYPES`. Other market types
 **JSON sections to use:**
 - `trades_by_type`: realized trades in last 24h, broken down by market_type (post-gate, opens should be crypto-only; closes can be any type)
 - `category_performance`: cumulative win_rate / Sharpe / prior per market_type
-- `shadow_summary`: blocked signals recorded as shadow trades
+- `shadow_summary`: blocked signals recorded as shadow trades, aggregated per market_type
+- `shadow_summary_by_direction`: same fields as shadow_summary, additionally split by `direction` ('long'|'short'). Use this to detect SHORT-bias inflation before recommending promotion.
 
 ### Shadow → Live promotion recommendation
 
-`shadow_summary` is per-`market_type` over a 30-day window with fields: `total`, `resolved`, `avg_pnl`, `win_rate`, `pnl_stddev`, `sharpe`.
+`shadow_summary` is per-`market_type` over a 30-day window with fields: `total`, `resolved`, `avg_pnl`, `win_rate`, `pnl_stddev`, `sharpe`. `shadow_summary_by_direction` is the same query grouped additionally by `direction` ('long' or 'short').
 
 **Shadow PnL is theoretical.** It's computed at the resolution price with no fees, no slippage, no early signal-driven exits. Empirical work in `project_shadow_execution_realism.md` measured a `live/shadow ≈ 0.33` Sharpe ratio on time-matched event_long data. Two structural biases inflate shadow further:
 - **SHORT-resolves-NO bias**: prediction markets resolve mostly to NO, so a SHORT entered at any price > 0 looks like a winner at resolution price 0. Today's empirical shadow shows 100% win rate on event_financial SHORT (60/60) and 94% on event_short SHORT (843/894) — neither is a strategy edge, both are sampling artifacts.
 - **Hold-to-resolution bias**: shadow "trades" never stop out, never take profit, never close on a counter-signal. Live exits earlier and more often at a loss.
 
-For each `market_type` row, evaluate against ALL of:
+For each `market_type` row in `shadow_summary`, evaluate against ALL of:
 
 - `resolved >= 50` (sufficient sample size)
 - `sharpe × 0.33 >= 0.20`, i.e. raw `shadow_sharpe >= 0.60` (haircut-adjusted sharpe ≥ live's promotion bar)
-- `win_rate >= 0.65` if shadow is SHORT-direction-skewed; `>= 0.55` otherwise. Default to 0.65 unless the shadow_summary has been broken out by direction and shows a non-SHORT-driven majority.
+- **Direction integrity** (uses `shadow_summary_by_direction`): the LONG-only row for this market_type must independently meet `resolved >= 30` and `sharpe >= 0.40`. The aggregated number must not be carried by a SHORT majority with > 90% win rate at resolution — that's the bias artifact. Reject when:
+  - SHORT direction shows `resolved >= 30` AND `win_rate > 0.90`, AND
+  - LONG direction shows `sharpe < 0.40` OR `resolved < 30`.
 - The market_type is NOT already in the live `ALLOWED_MARKET_TYPES` list (`crypto_intraday,crypto_daily,event_financial,event_short`)
 
 If all four hold, include a recommendation in the issue body:
 
-> **Promotion candidate:** `<market_type>`. Over 30 days of shadow data: N=<resolved>, raw_shadow_sharpe=<sharpe>, **haircut_sharpe=<sharpe×0.33>**, win_rate=<win_rate>, avg_pnl=<avg_pnl>. Consider adding to `ALLOWED_MARKET_TYPES` on the next deploy. Note: the haircut_sharpe is the upper-bound estimate of live performance — actual live Sharpe will be lower than this figure.
+> **Promotion candidate:** `<market_type>`. Over 30 days of shadow data: N=<resolved>, raw_shadow_sharpe=<sharpe>, **haircut_sharpe=<sharpe×0.33>**, LONG_only_sharpe=<long_sharpe>, LONG_only_n=<long_resolved>, avg_pnl=<avg_pnl>. Consider adding to `ALLOWED_MARKET_TYPES` on the next deploy. Note: the haircut_sharpe is the upper-bound estimate of live performance — actual live Sharpe will be lower than this figure.
 
 Do NOT auto-create a PR for the env change — promotion is a manual decision tied to a deploy.
 
 **Conversely**, for any `market_type` that IS currently in `ALLOWED_MARKET_TYPES` and where live performance over the same 30 days deviates materially from `shadow_sharpe × 0.33` (live Sharpe more than 0.5 below the haircut prediction), flag under "Possible regression — review allowlist for `<market_type>`". The haircut model says live should land near `shadow × 0.33`; large negative deviations are evidence the haircut is too generous for that type, not a reason to remove the type.
 
-The thresholds (50 resolved, raw_sharpe ≥ 0.60, win_rate ≥ 0.65) are calibrated to the empirical 0.33 haircut. If post-deploy live Sharpe consistently lands materially below `shadow × 0.33`, raise the raw_sharpe gate. Tune the win_rate floor when shadow_summary is broken out by direction (currently it isn't).
+The thresholds (50 resolved, raw_sharpe ≥ 0.60, LONG-only sharpe ≥ 0.40 with N ≥ 30) are calibrated to the empirical 0.33 haircut and the SHORT-resolves-NO bias. If post-deploy live Sharpe consistently lands materially below `shadow × 0.33`, raise the raw_sharpe gate.
 
 ## Step 0: Check Existing Work
 

--- a/scripts/daily-review.sh
+++ b/scripts/daily-review.sh
@@ -550,6 +550,37 @@ shadow_summary=$(query_json "
   ) t;
 ")
 
+# shadow_summary_by_direction — exposes the SHORT-resolves-NO sampling artifact
+# (shadow SHORT win rates run very high in prediction markets because most
+# markets resolve NO; not a strategy edge). Promotion logic uses this to
+# decide whether a high overall win_rate is genuine or SHORT-bias-inflated.
+shadow_summary_by_direction=$(query_json "
+  SELECT COALESCE(json_agg(row_to_json(t)), '[]') FROM (
+    SELECT market_type,
+           direction,
+           COUNT(*) AS total,
+           COUNT(*) FILTER (WHERE resolved_at IS NOT NULL) AS resolved,
+           ROUND(AVG(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)::numeric, 4) AS avg_pnl,
+           ROUND(
+             (COUNT(*) FILTER (WHERE resolved_at IS NOT NULL AND theoretical_pnl > 0)::numeric
+               / NULLIF(COUNT(*) FILTER (WHERE resolved_at IS NOT NULL), 0))::numeric,
+             3
+           ) AS win_rate,
+           ROUND(STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)::numeric, 4) AS pnl_stddev,
+           ROUND(
+             CASE WHEN STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL) > 0
+               THEN AVG(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)
+                    / STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)
+               ELSE 0 END::numeric,
+             3
+           ) AS sharpe
+    FROM shadow_trades
+    WHERE time >= NOW() - INTERVAL '30 days'
+    GROUP BY market_type, direction
+    ORDER BY market_type, direction
+  ) t;
+")
+
 # ── save review history ──────────────────────────────────────────────────────
 
 HISTORY_ENTRY=$(cat <<HISTEOF
@@ -610,6 +641,7 @@ jq -n \
   --argjson category_performance "$category_performance" \
   --argjson trades_by_type "$trades_by_type" \
   --argjson shadow_summary "$shadow_summary" \
+  --argjson shadow_summary_by_direction "$shadow_summary_by_direction" \
   --argjson review_history "$(cat "$HISTORY_FILE" 2>/dev/null | jq 'sort_by(.date) | .[-7:]' 2>/dev/null || echo "[]")" \
   '{
     generated_at: $ts,
@@ -641,5 +673,6 @@ jq -n \
     category_performance: $category_performance,
     trades_by_type: $trades_by_type,
     shadow_summary: $shadow_summary,
+    shadow_summary_by_direction: $shadow_summary_by_direction,
     review_history: $review_history
   }'


### PR DESCRIPTION
## Why

PR #181 set the shadow promotion thresholds (raw_sharpe ≥ 0.60, win_rate ≥ 0.65) and noted the structural fix — splitting `shadow_summary` by direction — was out of scope. Without that split, an aggregate `win_rate` is gameable by the SHORT-resolves-NO bias: prediction markets mostly resolve NO, so SHORT shadow positions enter at any price > 0 and "win" at resolution price 0. The aggregate Sharpe inherits that inflation.

Today's empirical shadow on the VM (last 30d):

```
 market_type     | direction | resolved | win_rate | sharpe
 event_financial | long      |      390 |    0.000 |  −3.644
 event_financial | short     |       60 |    1.000 |  +2.931  ← SHORT-bias
 event_short     | long      |      660 |    0.595 |  +0.720
 event_short     | short     |      894 |    0.943 |  +2.653  ← SHORT-bias
 event_long      | long      |      637 |    0.370 |  −0.403
 event_long      | short     |    1,324 |    0.396 |  −0.369
```

`event_financial` aggregated would look attractive (mix of −3.6 and +2.9 Sharpe is positive on volume-weighted average) — but the SHORT side is the bias artifact and the LONG side is unequivocally bad. With a direction-aware gate the prompt correctly rejects it.

## Changes

- `scripts/daily-review.sh`: adds a new `shadow_summary_by_direction` query that mirrors `shadow_summary`'s aggregation but groups by `(market_type, direction)`. Existing `shadow_summary` is untouched (additive change — no consumers break).
- `scripts/daily-review-prompt.md`: extends the promotion criteria with a direction-integrity gate. A market_type only passes when its LONG-only row independently meets `resolved >= 30` AND `sharpe >= 0.40`. The promotion is rejected when SHORT shows `resolved >= 30` AND `win_rate > 0.90` AND LONG fails its own bar — that's the SHORT-bias signature.

## Verification with current data

Applying the new gate to the table above:

- **event_financial**: SHORT win_rate 1.000 > 0.90, n=60 ≥ 30, AND LONG sharpe −3.6 < 0.40 → **rejected** (correct).
- **event_short**: LONG sharpe 0.72 ≥ 0.40, n=660 ≥ 30 → passes direction integrity (still subject to other gates and ALLOWED_MARKET_TYPES already including it).
- **event_long**: SHORT win_rate 0.396 < 0.90 → no SHORT-bias rejection, but fails the raw_sharpe ≥ 0.60 gate anyway (correct).

## Out of scope

- Re-estimating the 0.33 haircut per market_type. Still deferred until per-type live samples are large enough.
- Updating `format-review.js` to render the new field in the email. The auto-review issue body will include it directly via the prompt; the email is intentionally a summary and doesn't need every JSON section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)