### PR TITLE
fix(ci): safety-net step uses github.token for reads, fails gracefully

### DIFF
--- a/.github/workflows/daily-trade-review-claude.yml
+++ b/.github/workflows/daily-trade-review-claude.yml
@@ -389,26 +389,49 @@ jobs:
         # the resulting push to main does NOT trigger Deploy to GCP because GitHub
         # blocks workflows triggered by GITHUB_TOKEN-originated pushes. This step
         # detects that case and dispatches Deploy manually with MERGE_PAT.
+        #
+        # Token scopes:
+        # - Read-only checks (pr list, run list) use github.token, which always has
+        #   the right scopes for the current repo. Earlier MERGE_PAT-only runs hit
+        #   401 Unauthorized on these endpoints because the PAT lacked actions:read.
+        # - The dispatch (workflow run) uses MERGE_PAT, since GitHub blocks workflow
+        #   dispatches from GITHUB_TOKEN-originated requests for security.
+        # The step is best-effort: any failure logs a warning but does not fail the
+        # workflow. The auto-merge step above already uses MERGE_PAT to push, which
+        # normally triggers Deploy on its own; this step is a backstop.
         if: always()
         env:
-          GH_TOKEN: ${{ secrets.MERGE_PAT }}
+          GH_TOKEN: ${{ github.token }}
+          MERGE_PAT: ${{ secrets.MERGE_PAT }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
+          warn() { echo "::warning::safety-net: $1"; }
+
           SINCE=$(date -u -d '2 hours ago' +%Y-%m-%dT%H:%M:%SZ)
-          LAST_MERGE=$(gh pr list --state merged --label daily-review \
-            --search "merged:>$SINCE" \
-            --json mergedAt --jq 'sort_by(.mergedAt) | last | .mergedAt // ""')
+          if ! LAST_MERGE=$(gh pr list --state merged --label daily-review \
+                --search "merged:>$SINCE" \
+                --json mergedAt --jq 'sort_by(.mergedAt) | last | .mergedAt // ""'); then
+            warn "gh pr list failed — skipping deploy verification"
+            exit 0
+          fi
           if [ -z "$LAST_MERGE" ]; then
             echo "No daily-review PRs merged in last 2h — nothing to verify"
             exit 0
           fi
-          LAST_DEPLOY=$(gh run list --workflow="Deploy to GCP" --branch main --limit 1 \
-            --json createdAt --jq '.[0].createdAt // ""')
+
+          if ! LAST_DEPLOY=$(gh run list --workflow="Deploy to GCP" --branch main --limit 1 \
+                --json createdAt --jq '.[0].createdAt // ""'); then
+            warn "gh run list failed — skipping deploy verification (merge happened, manual check recommended)"
+            exit 0
+          fi
           echo "Last daily-review merge: $LAST_MERGE"
           echo "Last Deploy run:        $LAST_DEPLOY"
+
           if [ -z "$LAST_DEPLOY" ] || [[ "$LAST_DEPLOY" < "$LAST_MERGE" ]]; then
             echo "::warning::Daily-review PR merged but no Deploy fired — dispatching manually"
-            gh workflow run "Deploy to GCP" --ref main
+            if ! GH_TOKEN="$MERGE_PAT" gh workflow run "Deploy to GCP" --ref main; then
+              warn "workflow dispatch failed — Deploy must be triggered manually"
+            fi
           else
             echo "Deploy already fired after the merge — no action needed"
           fi


### PR DESCRIPTION
## Why

The \"Trigger deploy if Claude merged PRs (safety net)\" step in `daily-trade-review-claude.yml` has been failing with 401 Unauthorized for **5 consecutive runs** (job IDs 25369394042, 25312954956, 25275112052, 25248342058, 25209499554). The Claude analysis itself and the auto-merge step always succeed; only this terminal safety-net 401s on read-only API calls.

```
non-200 OK status code: 401 Unauthorized body: {\"message\":\"Bad credentials\"}
##[error]Process completed with exit code 1.
```

The auto-merge step works because `gh pr merge` only needs `repo` scope (which MERGE_PAT has). The safety-net additionally calls `gh run list --workflow=...`, which needs `actions:read`. MERGE_PAT was apparently issued without it.

This step's job is purely a backstop: when Claude bypasses auto-merge and pushes directly with `github.token`, GitHub silently drops the on-push trigger for downstream workflows. Auto-merge already covers the normal path with MERGE_PAT, so the backstop firing-or-not has no impact in practice — but the failing status pollutes the run history and would mask a real issue if one ever surfaced.

## Changes

1. **Reads use `github.token`.** `gh pr list --search 'merged:>...'` and `gh run list --workflow='Deploy to GCP'` are read-only, scoped to this repo — `github.token` always has the right scopes here. MERGE_PAT is no longer touched on these calls.
2. **Dispatch keeps MERGE_PAT.** `gh workflow run` is still GitHub's tightest endpoint: dispatches from GITHUB_TOKEN-originated requests are blocked. MERGE_PAT is injected for that one call only via inline `GH_TOKEN=\"\$MERGE_PAT\"`.
3. **Best-effort semantics.** `set -uo pipefail` (no `-e`), each gh call wrapped in `if ! ... ; then warn; exit 0; fi`. The step now reports success with a warning when partial failures happen, instead of failing the whole job.

## What this does NOT do

- Does not extend MERGE_PAT scopes (no UI access from CI).
- Does not change the auto-merge primary path. Deploy still kicks off via the auto-merge step's PAT-driven push, exactly as before.
- Does not rewrite the safety-net into a different mechanism. The current backstop is fine; it just shouldn't fail loudly when the PAT scopes are imperfect.

## Verification

The next `Daily Trade Review (Claude Analysis)` run should report green on this step. If MERGE_PAT really is invalid, the inline dispatch will print a warning instead of erroring — visible in the run logs but not paging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)