### PR TITLE
fix(news-sentiment): aggregate articles across 4h window + recalibrate threshold (0.3→0.2)

### DIFF
--- a/packages/dashboard/src/services/SignalEngine.ts
+++ b/packages/dashboard/src/services/SignalEngine.ts
@@ -734,21 +734,34 @@ export class SignalEngine extends EventEmitter {
         // non-fatal
       }
 
-      // Fetch news sentiment data for NewsSentimentGenerator
+      // Fetch news sentiment data for NewsSentimentGenerator.
+      //
+      // NewsCollector writes one external_signals row per (market, headline)
+      // with metadata.articleCount hardcoded to 1. The previous LIMIT 1
+      // read silenced NewsSentimentGenerator entirely (its threshold is
+      // articleCount >= 2). Aggregating over the 4h window gives the true
+      // per-market article count and a confidence-weighted average sentiment.
       let newsSentiment = 0;
       let newsArticleCount = 0;
       try {
-        const sentimentData = await query(
-          `SELECT value, metadata FROM external_signals
-           WHERE market_id = $1 AND signal_type = 'sentiment'
-           AND fetched_at > NOW() - INTERVAL '4 hours'
-           ORDER BY fetched_at DESC LIMIT 1`,
+        const sentimentData = await query<{ article_count: string; sentiment: string | null }>(
+          `SELECT
+             COUNT(*)::int AS article_count,
+             COALESCE(
+               SUM(value * confidence) / NULLIF(SUM(confidence), 0),
+               AVG(value)
+             )::float AS sentiment
+           FROM external_signals
+           WHERE market_id = $1
+             AND signal_type = 'sentiment'
+             AND fetched_at > NOW() - INTERVAL '4 hours'`,
           [market.id]
         );
         if (sentimentData.rows[0]) {
-          newsSentiment = sentimentData.rows[0].value;
-          const meta = sentimentData.rows[0].metadata;
-          newsArticleCount = (typeof meta === 'object' ? meta?.articleCount : JSON.parse(meta)?.articleCount) ?? 0;
+          newsArticleCount = Number(sentimentData.rows[0].article_count) || 0;
+          newsSentiment = sentimentData.rows[0].sentiment === null
+            ? 0
+            : Number(sentimentData.rows[0].sentiment) || 0;
         }
       } catch {
         // non-fatal

--- a/packages/signals/src/signals/external/NewsSentimentGenerator.test.ts
+++ b/packages/signals/src/signals/external/NewsSentimentGenerator.test.ts
@@ -37,10 +37,20 @@ describe('NewsSentimentGenerator', () => {
     expect(generator.signalId).toBe('news_sentiment');
   });
 
-  it('returns null when |sentiment| < minSentimentMagnitude (0.3)', async () => {
-    const ctx = makeContext(0.2, 3);
+  it('returns null when |sentiment| < minSentimentMagnitude (0.2)', async () => {
+    const ctx = makeContext(0.15, 3);
     const result = await generator.compute(ctx);
     expect(result).toBeNull();
+  });
+
+  it('fires when |sentiment| just clears the 0.2 threshold (with enough articles)', async () => {
+    // 2026-05-05 calibration: aggregated weighted-average sentiment lands in
+    // 0.2-0.3 on real multi-article markets. The threshold was lowered
+    // specifically so this case fires.
+    const ctx = makeContext(0.25, 3);
+    const result = await generator.compute(ctx);
+    expect(result).not.toBeNull();
+    expect(result!.direction).toBe('LONG');
   });
 
   it('returns null when articleCount < minArticleCount (2)', async () => {

--- a/packages/signals/src/signals/external/NewsSentimentGenerator.ts
+++ b/packages/signals/src/signals/external/NewsSentimentGenerator.ts
@@ -19,8 +19,15 @@ export class NewsSentimentGenerator extends BaseSignal<NewsSentimentParams> {
   readonly name = 'News Headline Sentiment';
   readonly description = 'Infers market direction from recent news headline sentiment';
 
+  // Default threshold lowered 2026-05-05 from 0.3 → 0.2 to match observed
+  // weighted-average sentiment values produced by SignalEngine's aggregation
+  // over the 4h window. The LLM (Haiku) estimates per-article impact as
+  // ~0.2-0.4; weighted averages over 2-5 articles dilute toward 0.15-0.30.
+  // 0.3 silenced every market on live data; 0.2 lets coherent multi-article
+  // sentiment fire while still filtering out noise (single weak articles
+  // also fail because minArticleCount=2 still applies).
   protected parameters: NewsSentimentParams = {
-    minSentimentMagnitude: 0.3,
+    minSentimentMagnitude: 0.2,
     minArticleCount: 2,
   };
 


### PR DESCRIPTION
## Why

`NewsSentimentGenerator` has been silent for the entire history of the sentiment pipeline despite 4049 healthy rows in `external_signals`. Two compounding bugs were silencing it:

1. **`SignalEngine.buildContextFromDb` fetched the latest single row** (`LIMIT 1`) and read `metadata.articleCount` — but `NewsCollector` hardcodes `articleCount: 1` per-row (one row per matched article). The generator's `minArticleCount: 2` always failed → every market silenced.

2. **`minSentimentMagnitude: 0.3` was calibrated for a never-implemented writer-side aggregation.** Live data shows individual LLM (Haiku) impact estimates land in [0.20, 0.40]; weighted averages across 2–5 articles dilute toward [0.15, 0.30]. The 0.3 floor would still silence every market even after fixing (1).

## Empirical evidence (VM, last 4h)

```
 market_id | art | max_mag |  wavg
-----------+-----+---------+--------
 631140    |  5  |  0.400  |  0.255  ← LONG, would fire post-fix
 540816    |  3  |  0.350  | -0.294  ← SHORT, would fire post-fix
 1466016   |  4  |  0.300  | -0.238  ← SHORT, would fire post-fix
 1467143   |  2  |  0.350  |  0.294  ← LONG, would fire post-fix
 1484895   |  4  |  0.250  | -0.204  ← SHORT, just at threshold
 1896585   |  2  |  0.220  | -0.210  ← SHORT, just at threshold
 1571566   |  3  |  0.300  | -0.137  ← weak consensus, correctly filtered
 1652677   |  2  |  0.100  |  0.100  ← magnitude too low, correctly filtered
```

6 of 8 multi-article markets would emit signals post-fix (3 LONG, 3 SHORT). **This is the first signal source that's not LONG-biased** — material for breaking the post-flip 35:2 LONG:SHORT execution skew documented in `project_signal_diversity.md`.

## Fix

**`SignalEngine.buildContextFromDb`** — replace LIMIT-1 query with windowed aggregation:

```sql
SELECT
  COUNT(*)::int AS article_count,
  COALESCE(
    SUM(value * confidence) / NULLIF(SUM(confidence), 0),
    AVG(value)
  )::float AS sentiment
FROM external_signals
WHERE market_id = $1
  AND signal_type = 'sentiment'
  AND fetched_at > NOW() - INTERVAL '4 hours'
```

**`NewsSentimentGenerator`** — lower `minSentimentMagnitude` 0.3 → 0.2 with an inline-comment explaining the calibration. `minArticleCount: 2` retained: single weak articles are still filtered.

## Tests (1 added, 1 updated, 876 pass)

- Updated `returns null when |sentiment| < minSentimentMagnitude (0.2)` — uses 0.15 for the below-threshold case (was 0.2 ↔ 0.3).
- Added `fires when |sentiment| just clears the 0.2 threshold` — pins the new calibration so future regressions surface in CI.

## Out of scope

- Tuning `minSentimentMagnitude` via Optuna (param-space wiring is separate work — see Optuna follow-up after this lands).
- Fixing `NewsCollector`'s hardcoded `articleCount: 1` at the writer level. The consumer-side aggregation makes the writer's per-row metadata redundant for this generator. Cleaning it up is cosmetic.

## Verification post-deploy

```sql
-- 30 min after deploy, expect non-zero rows
SELECT COUNT(*) FROM signal_predictions
WHERE time >= NOW() - INTERVAL '30 minutes'
  AND metadata->'componentCounts'->>'long' IS NOT NULL;
-- And inspect a recent combined signal's contributors:
SELECT jsonb_pretty(metadata) FROM signal_predictions
WHERE time >= NOW() - INTERVAL '30 minutes'
ORDER BY time DESC LIMIT 1;
```

If `signalCount` jumps from 2 → 3 on markets with active news, the fix is working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * News sentiment signal detection now aggregates market sentiment data over a 4-hour rolling window, replacing single-point analysis for more comprehensive and stable signals
  * Lowered minimum sentiment magnitude threshold to increase signal sensitivity and capture smaller sentiment movements, enabling faster and more granular market reaction detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->