### PR TITLE
fix(optimizer): epoch floor for post-dm-flip training data

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -170,6 +170,12 @@ services:
       # losses, which were structurally inverse signals (counter-WR=93.9%).
       # Remove once the rolling 7-day window has cleared (after 2026-05-11).
       EXECUTOR_LOSS_GATE_EPOCH: "2026-05-04T09:55:00Z"
+      # OPTIMIZER_EPOCH_START: floors Optuna training/OOS windows to the dm
+      # flip boundary (PR #178). Pre-flip backtest data trains the optimizer
+      # toward the wrong sign for every per-type weight; with this floor set
+      # only post-flip trades feed the optimizer. Remove once the rolling 14d
+      # training window has aged past the epoch organically (~2026-05-18).
+      OPTIMIZER_EPOCH_START: "2026-05-04T09:55:00Z"
       # Gate 0e: EventOTMGate — block opens on event_financial markets near expiry
       # with extreme-band prices. See docs/plans/2026-04-21-event-otm-gate-design.md
       EXECUTOR_EVENT_OTM_MARKET_TYPES: "event_financial"

--- a/packages/dashboard/src/services/OptimizationScheduler.test.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.test.ts
@@ -46,6 +46,9 @@ import {
   OOS_MIN_TRADES_PER_TYPE,
   REFINEMENT_PARAM_SPACE,
   OPTUNA_PARAM_SPACE,
+  parseOptimizerEpochStart,
+  buildTrainingWindow,
+  buildOOSWindow,
 } from './OptimizationScheduler.js';
 
 describe('OptimizationScheduler', () => {
@@ -218,6 +221,108 @@ describe('getOosMinTrades', () => {
     expect(getOosMinTrades('event_long')).toBe(5);
     process.env.OPTIMIZER_MIN_TRADES_EVENT_LONG = '-3';
     expect(getOosMinTrades('event_long')).toBe(5);
+  });
+});
+
+describe('OPTIMIZER_EPOCH_START regime filter', () => {
+  const ENV_KEY = 'OPTIMIZER_EPOCH_START';
+
+  beforeEach(() => {
+    delete process.env[ENV_KEY];
+  });
+
+  describe('parseOptimizerEpochStart', () => {
+    it('returns null when env var is unset', () => {
+      expect(parseOptimizerEpochStart()).toBeNull();
+    });
+
+    it('returns null on empty/whitespace value', () => {
+      process.env[ENV_KEY] = '';
+      expect(parseOptimizerEpochStart()).toBeNull();
+      process.env[ENV_KEY] = '   ';
+      expect(parseOptimizerEpochStart()).toBeNull();
+    });
+
+    it('returns parsed Date for ISO 8601 input', () => {
+      process.env[ENV_KEY] = '2026-05-04T09:55:00Z';
+      const result = parseOptimizerEpochStart();
+      expect(result).toBeInstanceOf(Date);
+      expect(result!.toISOString()).toBe('2026-05-04T09:55:00.000Z');
+    });
+
+    it('returns null on garbage input (no silent fallback)', () => {
+      process.env[ENV_KEY] = 'not-a-date';
+      expect(parseOptimizerEpochStart()).toBeNull();
+    });
+  });
+
+  describe('buildTrainingWindow', () => {
+    const now = new Date('2026-05-15T00:00:00Z');
+    const TRAINING = 10;
+    const OOS = 4;
+
+    it('returns the unchanged 10-day training window when epoch is null', () => {
+      const w = buildTrainingWindow(now, TRAINING, OOS, null);
+      expect(w.valid).toBe(true);
+      // endDate = now - 4d, startDate = endDate - 10d
+      expect(w.endDate.toISOString()).toBe('2026-05-11T00:00:00.000Z');
+      expect(w.startDate.toISOString()).toBe('2026-05-01T00:00:00.000Z');
+    });
+
+    it('floors startDate to epoch when epoch is inside the training window', () => {
+      const epoch = new Date('2026-05-04T09:55:00Z');
+      const w = buildTrainingWindow(now, TRAINING, OOS, epoch);
+      expect(w.valid).toBe(true);
+      expect(w.startDate.toISOString()).toBe(epoch.toISOString());
+      expect(w.endDate.toISOString()).toBe('2026-05-11T00:00:00.000Z');
+    });
+
+    it('leaves startDate unchanged when epoch precedes the natural window', () => {
+      const epoch = new Date('2026-04-01T00:00:00Z');
+      const w = buildTrainingWindow(now, TRAINING, OOS, epoch);
+      expect(w.valid).toBe(true);
+      expect(w.startDate.toISOString()).toBe('2026-05-01T00:00:00.000Z');
+    });
+
+    it('marks invalid when epoch leaves <1d of training window', () => {
+      // epoch 12h before endDate → window is 0.5d
+      const epoch = new Date('2026-05-10T12:00:00Z');
+      const w = buildTrainingWindow(now, TRAINING, OOS, epoch);
+      expect(w.valid).toBe(false);
+      expect(w.reason).toMatch(/Training window after epoch only/);
+    });
+
+    it('marks invalid when epoch is at/after the training endDate', () => {
+      const epoch = new Date('2026-05-12T00:00:00Z'); // after endDate (2026-05-11)
+      const w = buildTrainingWindow(now, TRAINING, OOS, epoch);
+      expect(w.valid).toBe(false);
+      expect(w.reason).toMatch(/no post-epoch training data yet/);
+    });
+  });
+
+  describe('buildOOSWindow', () => {
+    const now = new Date('2026-05-15T00:00:00Z');
+    const OOS = 4;
+
+    it('returns full 4-day OOS window when epoch is null', () => {
+      const w = buildOOSWindow(now, OOS, null);
+      expect(w.valid).toBe(true);
+      expect(w.endDate.toISOString()).toBe(now.toISOString());
+      expect(w.startDate.toISOString()).toBe('2026-05-11T00:00:00.000Z');
+    });
+
+    it('floors startDate to epoch when epoch is inside the OOS window', () => {
+      const epoch = new Date('2026-05-13T00:00:00Z');
+      const w = buildOOSWindow(now, OOS, epoch);
+      expect(w.valid).toBe(true);
+      expect(w.startDate.toISOString()).toBe(epoch.toISOString());
+    });
+
+    it('marks invalid when epoch >= now', () => {
+      const epoch = new Date('2026-05-15T00:00:00Z');
+      const w = buildOOSWindow(now, OOS, epoch);
+      expect(w.valid).toBe(false);
+    });
   });
 });
 

--- a/packages/dashboard/src/services/OptimizationScheduler.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.ts
@@ -155,6 +155,99 @@ export function getOosMinTrades(marketType: string): number {
   return OOS_MIN_TRADES_PER_TYPE[marketType] ?? OOS_SAFETY_FLOOR.minTrades;
 }
 
+// ============================================================
+// Regime-epoch filter (training/OOS window)
+//
+// 2026-05-04: directionMultiplier flipped from -1 → +1 (PR #178). Signal
+// behaviour reverses across the boundary — pre-flip backtest data trains
+// Optuna toward the wrong sign for every per-type weight. Setting
+// OPTIMIZER_EPOCH_START floors training and OOS windows to the boundary so
+// the optimizer only ingests post-flip trades. Unset (or invalid) → no floor,
+// behaviour identical to before.
+//
+// Remove the env var once the rolling 14d window has aged past the epoch
+// organically (target ~2026-05-18).
+// ============================================================
+export interface OptimizerWindow {
+  startDate: Date;
+  endDate: Date;
+  valid: boolean;
+  reason?: string;
+}
+
+export function parseOptimizerEpochStart(): Date | null {
+  const raw = process.env.OPTIMIZER_EPOCH_START;
+  if (!raw || raw.trim() === '') return null;
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    console.warn(`[OptimizationScheduler] Invalid OPTIMIZER_EPOCH_START: ${raw}`);
+    return null;
+  }
+  return parsed;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export function buildTrainingWindow(
+  now: Date,
+  trainingPeriodDays: number,
+  oosPeriodDays: number,
+  epochStart: Date | null,
+): OptimizerWindow {
+  const endDate = new Date(now.getTime() - oosPeriodDays * MS_PER_DAY);
+  let startDate = new Date(endDate.getTime() - trainingPeriodDays * MS_PER_DAY);
+
+  if (epochStart) {
+    if (epochStart.getTime() >= endDate.getTime()) {
+      return {
+        startDate,
+        endDate,
+        valid: false,
+        reason: `Epoch ${epochStart.toISOString()} >= training endDate ${endDate.toISOString()} — no post-epoch training data yet`,
+      };
+    }
+    if (epochStart.getTime() > startDate.getTime()) {
+      startDate = epochStart;
+      const windowDays = (endDate.getTime() - startDate.getTime()) / MS_PER_DAY;
+      if (windowDays < 1) {
+        return {
+          startDate,
+          endDate,
+          valid: false,
+          reason: `Training window after epoch only ${windowDays.toFixed(1)}d (need ≥1d)`,
+        };
+      }
+    }
+  }
+
+  return { startDate, endDate, valid: true };
+}
+
+export function buildOOSWindow(
+  now: Date,
+  oosPeriodDays: number,
+  epochStart: Date | null,
+): OptimizerWindow {
+  const endDate = now;
+  let startDate = new Date(now.getTime() - oosPeriodDays * MS_PER_DAY);
+
+  if (epochStart) {
+    if (epochStart.getTime() >= endDate.getTime()) {
+      return {
+        startDate,
+        endDate,
+        valid: false,
+        reason: `Epoch ${epochStart.toISOString()} >= OOS endDate ${endDate.toISOString()}`,
+      };
+    }
+    if (epochStart.getTime() > startDate.getTime()) {
+      startDate = epochStart;
+    }
+  }
+
+  return { startDate, endDate, valid: true };
+}
+
 const MARKET_TYPES = ['crypto_intraday', 'crypto_daily', 'event_financial', 'event_short', 'event_long'] as const;
 type MarketType = typeof MARKET_TYPES[number];
 
@@ -469,12 +562,23 @@ export class OptimizationScheduler {
     console.log(`[OptimizationScheduler] Created Optuna optimizer ${optimizerId}, running ${iterations} trials...`);
     console.log(`[OptimizationScheduler] Using ${effectiveParamSpace.length} parameters, ${nStartupTrials} startup trials`);
 
-    // Use training period only (exclude OOS period for honest validation)
-    const now = new Date();
-    const endDate = new Date(now.getTime() - WALKFORWARD_CONFIG.oosPeriodDays * 24 * 60 * 60 * 1000);
-    const startDate = new Date(endDate.getTime() - WALKFORWARD_CONFIG.trainingPeriodDays * 24 * 60 * 60 * 1000);
+    // Use training period only (exclude OOS period for honest validation).
+    // Apply epoch floor so post-flip runs ignore pre-flip data (PR #178).
+    const window = buildTrainingWindow(
+      new Date(),
+      WALKFORWARD_CONFIG.trainingPeriodDays,
+      WALKFORWARD_CONFIG.oosPeriodDays,
+      parseOptimizerEpochStart(),
+    );
+    if (!window.valid) {
+      console.log(`[OptimizationScheduler] Skipping ${marketType} run: ${window.reason}`);
+      await client.deleteOptimizer(optimizerId);
+      return [];
+    }
+    const { startDate, endDate } = window;
+    const trainingDays = (endDate.getTime() - startDate.getTime()) / (24 * 60 * 60 * 1000);
 
-    console.log(`[OptimizationScheduler] Training period: ${startDate.toISOString().slice(0,10)} to ${endDate.toISOString().slice(0,10)} (${WALKFORWARD_CONFIG.trainingPeriodDays} days)`);
+    console.log(`[OptimizationScheduler] Training period: ${startDate.toISOString().slice(0,10)} to ${endDate.toISOString().slice(0,10)} (${trainingDays.toFixed(1)} days)`);
 
     // Preload backtest data once for all trials (same training period)
     console.log('[OptimizationScheduler] Preloading backtest data...');
@@ -616,10 +720,18 @@ export class OptimizationScheduler {
   private async runGridOptimization(iterations: number, type: 'incremental' | 'full', marketType: string): Promise<OptimizationResult[]> {
     const runStartedAt = new Date();
     const results: OptimizationResult[] = [];
-    // Use training period only (exclude OOS period)
-    const now = new Date();
-    const endDate = new Date(now.getTime() - WALKFORWARD_CONFIG.oosPeriodDays * 24 * 60 * 60 * 1000);
-    const startDate = new Date(endDate.getTime() - WALKFORWARD_CONFIG.trainingPeriodDays * 24 * 60 * 60 * 1000);
+    // Use training period only (exclude OOS period). Apply epoch floor.
+    const window = buildTrainingWindow(
+      new Date(),
+      WALKFORWARD_CONFIG.trainingPeriodDays,
+      WALKFORWARD_CONFIG.oosPeriodDays,
+      parseOptimizerEpochStart(),
+    );
+    if (!window.valid) {
+      console.log(`[OptimizationScheduler] Skipping ${marketType} grid run: ${window.reason}`);
+      return [];
+    }
+    const { startDate, endDate } = window;
 
     const paramCombos = type === 'incremental'
       ? this.generateIncrementalParams()
@@ -730,9 +842,15 @@ export class OptimizationScheduler {
       return { passed: false, sharpeOOS: 0, drawdownOOS: 0, tradesOOS: 0, winRateOOS: 0, marketsEvaluated: 0, reason: 'IS Sharpe <= 0, nothing to validate' };
     }
 
-    const now = new Date();
-    const oosEndDate = now;
-    const oosStartDate = new Date(now.getTime() - WALKFORWARD_CONFIG.oosPeriodDays * 24 * 60 * 60 * 1000);
+    const oosWindow = buildOOSWindow(
+      new Date(),
+      WALKFORWARD_CONFIG.oosPeriodDays,
+      parseOptimizerEpochStart(),
+    );
+    if (!oosWindow.valid) {
+      return { passed: false, sharpeOOS: 0, drawdownOOS: 0, tradesOOS: 0, winRateOOS: 0, marketsEvaluated: 0, reason: oosWindow.reason };
+    }
+    const { startDate: oosStartDate, endDate: oosEndDate } = oosWindow;
 
     console.log(`[OptimizationScheduler] Running OOS validation from ${oosStartDate.toISOString().slice(0, 10)} to ${oosEndDate.toISOString().slice(0, 10)} (IS Sharpe: ${isScore.toFixed(3)})`);
 


### PR DESCRIPTION
## Summary

- Adds `OPTIMIZER_EPOCH_START` env var that floors Optuna training and OOS windows.
- When set (and valid), `buildTrainingWindow` and `buildOOSWindow` shift `startDate` to `max(startDate, epoch)` and abort the run if the resulting window is <1 day.
- Wired into `runOptunaOptimization`, `runGridOptimization`, and `validateOnOOS`.
- Compose now sets `OPTIMIZER_EPOCH_START=2026-05-04T09:55:00Z` (matches `EXECUTOR_LOSS_GATE_EPOCH`).

## Why now

Empirical state captured 2026-05-05 (~30h post dm-flip):

| Capa | LONG | SHORT |
|------|------|-------|
| Combined signals persistidas | 53 | 8 |
| Posiciones abiertas | 49 | 2 |
| LONG WR | 18% | — |

Diagnóstico: el combiner sesga 6.6:1 LONG porque los pesos `signal_weights` siguen reflejando la optimización pre-flip (Optuna corrió 2026-05-04 20:43 con backtest data 99% pre-flip). Mean_reversion peso ~1.83 en event_long + momentum negativo + markets drifting hacia 0 → todos los signals convergen a LONG en mercados que de hecho resuelven NO.

El epoch flag corta los datos pre-flip del entrenamiento. Se complementa con un reset SQL operacional de `signal_weights` a 1.0 baseline (ejecutado en runtime, fuera de este PR — ver memoria).

## Tests

- `parseOptimizerEpochStart`: 4 cases (unset, empty, valid ISO, garbage).
- `buildTrainingWindow`: 5 cases (no epoch, epoch inside window, epoch before window, epoch leaves <1d, epoch beyond endDate).
- `buildOOSWindow`: 3 cases (no epoch, epoch inside, epoch ≥ now).
- 39/39 dashboard tests pasan, tsc clean.

## Test plan

- [ ] Watch `[OptimizationScheduler] Training period: ...` log on next incremental run; expected `startDate >= 2026-05-04T09:55:00Z`.
- [ ] Confirm at least one cycle completes with the epoch floor active before deciding whether the dm flip thesis holds.
- [ ] Remove env var ~2026-05-18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)