### PR TITLE
feat(optimizer): parametrize PriceRangeWeightModifier matrix for Optuna

### DIFF
--- a/packages/backtest/src/engine/BacktestEngine.ts
+++ b/packages/backtest/src/engine/BacktestEngine.ts
@@ -19,12 +19,21 @@ import type {
 } from '../types/index.js';
 
 import type { ISignal, ISignalCombiner, SignalContext, SignalOutput, Trade } from '@polymarket-trader/signals';
+import type { PriceRangeWeightModifier } from '@polymarket-trader/signals';
 
 interface BacktestEngineOptions {
   config: BacktestConfig;
   marketData: MarketData[];
   signals: ISignal[];
   combiner: ISignalCombiner;
+  /**
+   * Optional PriceRangeWeightModifier — when supplied the engine modulates
+   * combiner weights by current price band before each combine call (and
+   * restores them after). Mirrors SignalEngine.combineSignalsForMarket so
+   * Optuna can learn matrix values that match production behaviour.
+   * Pass undefined to keep the legacy "raw weights" path.
+   */
+  priceRangeModifier?: PriceRangeWeightModifier;
 }
 
 export interface OrderBookEvent extends BacktestEvent {
@@ -78,6 +87,7 @@ export class BacktestEngine {
   private marketData: Map<string, MarketData> = new Map();
   private signals: ISignal[];
   private combiner: ISignalCombiner;
+  private priceRangeModifier?: PriceRangeWeightModifier;
   private eventBus: EventBus;
   private logger: pino.Logger;
 
@@ -98,6 +108,7 @@ export class BacktestEngine {
     this.config = options.config;
     this.signals = options.signals;
     this.combiner = options.combiner;
+    this.priceRangeModifier = options.priceRangeModifier;
     this.currentTime = new Date(options.config.startDate);
     this.eventBus = new EventBus();
     this.logger = pino({ name: 'BacktestEngine' });
@@ -810,7 +821,29 @@ export class BacktestEngine {
           timestamp: this.currentTime,
         }));
 
-        const combined = this.combiner.combine(updatedSignals, this.currentTime);
+        // Apply price-range weight modulation when a modifier was supplied.
+        // Mirrors SignalEngine.combineSignalsForMarket: stash original weights,
+        // overwrite with modulated ones, combine, restore. Without this branch
+        // Optuna would optimize against a "raw weights" universe that does not
+        // match production behaviour.
+        let originalWeights: Record<string, number> | null = null;
+        if (this.priceRangeModifier) {
+          const currentPrice = this.priceCache.get(marketId)?.currentBar.close;
+          if (typeof currentPrice === 'number' && Number.isFinite(currentPrice)) {
+            originalWeights = this.combiner.getWeights();
+            const modulated = this.priceRangeModifier.modifyWeights(originalWeights, currentPrice);
+            this.combiner.setWeights(modulated);
+          }
+        }
+
+        let combined;
+        try {
+          combined = this.combiner.combine(updatedSignals, this.currentTime);
+        } finally {
+          if (originalWeights !== null) {
+            this.combiner.setWeights(originalWeights);
+          }
+        }
 
         if (!combined) {
           this.combiningStats.combinerReturnedNull++;

--- a/packages/backtest/src/index.ts
+++ b/packages/backtest/src/index.ts
@@ -139,7 +139,7 @@ import { SlippageModel } from './simulation/SlippageModel.js';
 import { PortfolioManager } from './portfolio/PortfolioManager.js';
 import { RiskManager } from './risk/RiskManager.js';
 import type { BacktestConfig, MarketData, SlippageConfig, RiskConfig } from './types/index.js';
-import type { ISignal, ISignalCombiner } from '@polymarket-trader/signals';
+import type { ISignal, ISignalCombiner, PriceRangeWeightModifier } from '@polymarket-trader/signals';
 
 /**
  * Configuration for creating a backtest engine
@@ -152,6 +152,8 @@ export interface CreateBacktestOptions {
   slippageConfig?: SlippageConfig;
   riskConfig?: RiskConfig;
   snapshotIntervalMinutes?: number;
+  /** Optional price-range modifier — see BacktestEngineOptions.priceRangeModifier */
+  priceRangeModifier?: PriceRangeWeightModifier;
 }
 
 /**
@@ -185,6 +187,7 @@ export function createBacktestEngine(options: CreateBacktestOptions): BacktestEn
     marketData: options.marketData,
     signals: options.signals,
     combiner: options.combiner,
+    priceRangeModifier: options.priceRangeModifier,
   });
 
   // Inject components

--- a/packages/dashboard/src/database/repositories.ts
+++ b/packages/dashboard/src/database/repositories.ts
@@ -694,3 +694,53 @@ export const tradingConfigRepo = {
     return config;
   },
 };
+
+// ============================================
+// Price Range Matrix Repository
+// ============================================
+// Stores per-(signal_id, band) multipliers used by PriceRangeWeightModifier
+// at runtime. Optuna writes new values after each successful optimization
+// that passes the OOS gate; SignalEngine reads on boot. Table is created at
+// startup in server.ts (see CREATE TABLE IF NOT EXISTS price_range_matrix).
+// ============================================
+
+const PRICE_RANGE_BANDS = ['normal', 'transitional', 'uncertain'] as const;
+type PriceRangeBandLiteral = typeof PRICE_RANGE_BANDS[number];
+
+function isBand(value: string): value is PriceRangeBandLiteral {
+  return (PRICE_RANGE_BANDS as readonly string[]).includes(value);
+}
+
+export const priceRangeMatrixRepo = {
+  /**
+   * Read all rows and shape into the SignalId → { normal, transitional,
+   * uncertain } structure SignalEngine consumes. Missing bands are returned
+   * as null so callers can decide whether to fall back to the in-code default.
+   */
+  async getMatrix(): Promise<Record<string, Partial<Record<PriceRangeBandLiteral, number>>>> {
+    const result = await query<{ signal_id: string; band: string; multiplier: string }>(
+      'SELECT signal_id, band, multiplier FROM price_range_matrix'
+    );
+    const matrix: Record<string, Partial<Record<PriceRangeBandLiteral, number>>> = {};
+    for (const row of result.rows) {
+      if (!isBand(row.band)) continue;
+      if (!matrix[row.signal_id]) matrix[row.signal_id] = {};
+      matrix[row.signal_id][row.band] = Number(row.multiplier);
+    }
+    return matrix;
+  },
+
+  async setBand(signalId: string, band: PriceRangeBandLiteral, multiplier: number): Promise<void> {
+    if (!Number.isFinite(multiplier)) {
+      throw new Error(`Invalid multiplier for ${signalId}/${band}: ${multiplier}`);
+    }
+    await query(
+      `INSERT INTO price_range_matrix (signal_id, band, multiplier, updated_at)
+       VALUES ($1, $2, $3, NOW())
+       ON CONFLICT (signal_id, band) DO UPDATE SET
+         multiplier = EXCLUDED.multiplier,
+         updated_at = NOW()`,
+      [signalId, band, multiplier]
+    );
+  },
+};

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -8,7 +8,7 @@
 import pino from 'pino';
 import { createDashboardServer } from './api/server.js';
 import { initializeDatabase, closeDatabase, healthCheck, isDatabaseConfigured, query } from './database/index.js';
-import { signalWeightsRepo, tradingConfigRepo, paperPositionsRepo } from './database/repositories.js';
+import { signalWeightsRepo, tradingConfigRepo, paperPositionsRepo, priceRangeMatrixRepo } from './database/repositories.js';
 import { initializeOptimizationScheduler } from './services/OptimizationScheduler.js';
 import { initializeDirectionMultiplierLearningService } from './services/DirectionMultiplierLearningService.js';
 import { wipeDirectionMultiplierSegments } from './services/wipeDirectionMultiplierSegments.js';
@@ -471,6 +471,26 @@ async function main(): Promise<void> {
         console.error('[server] backtest-signal-coverage cleanup failed:', err);
       }
 
+      // PriceRangeWeightModifier matrix persistence (PR after #188). Stores
+      // per-(signal_id, band) multipliers Optuna has tuned; SignalEngine reads
+      // these on boot and after each successful optimization that passes OOS.
+      // CREATE IF NOT EXISTS only — no init SQL migration so existing VMs
+      // pick this up on the next deploy.
+      try {
+        await query(`
+          CREATE TABLE IF NOT EXISTS price_range_matrix (
+            signal_id  VARCHAR(50) NOT NULL,
+            band       VARCHAR(20) NOT NULL,
+            multiplier NUMERIC(5,4) NOT NULL DEFAULT 1.0,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            PRIMARY KEY (signal_id, band)
+          );
+        `);
+        console.log('[server] price_range_matrix table ensured');
+      } catch (err) {
+        console.error('[server] price_range_matrix migration failed:', err);
+      }
+
       // Issue #144: persist per-type bestSharpe ratchet across restarts.
       // Without this column, loadState rebuilds bestSharpePerType as
       // { __legacy__: <last_overall_score> } and every real market_type
@@ -677,6 +697,31 @@ async function main(): Promise<void> {
         consensusDiscountFloor,
         directionResolver,
       });
+
+      // Hydrate PriceRangeWeightModifier matrix from DB so Optuna-tuned
+      // multipliers persist across restarts. Empty table → keeps in-code
+      // defaults from PriceRangeWeightModifier.DEFAULT_MATRIX.
+      try {
+        const persisted = await priceRangeMatrixRepo.getMatrix();
+        const updates: Partial<Record<string, { normal: number; transitional: number; uncertain: number }>> = {};
+        const baseline = signalEngine.getPriceRangeMatrix();
+        for (const [signalId, bands] of Object.entries(persisted)) {
+          const fallback = baseline[signalId] ?? { normal: 1.0, transitional: 1.0, uncertain: 1.0 };
+          updates[signalId] = {
+            normal: bands.normal ?? fallback.normal,
+            transitional: bands.transitional ?? fallback.transitional,
+            uncertain: bands.uncertain ?? fallback.uncertain,
+          };
+        }
+        if (Object.keys(updates).length > 0) {
+          signalEngine.updatePriceRangeMatrix(updates);
+          console.log(`[server] Loaded ${Object.keys(updates).length} price-range matrix overrides from DB`);
+        } else {
+          console.log('[server] price_range_matrix empty — using PriceRangeWeightModifier defaults');
+        }
+      } catch (err) {
+        console.warn('[server] Failed to hydrate price-range matrix from DB:', err);
+      }
 
       // Start market classifier (classifies new markets via Haiku every 30min)
       const { MarketClassifier } = await import('./services/MarketClassifier.js');

--- a/packages/dashboard/src/services/BacktestService.test.ts
+++ b/packages/dashboard/src/services/BacktestService.test.ts
@@ -133,3 +133,74 @@ describe('BacktestService — combinerConfig.directionMultiplier propagates to c
     }
   });
 });
+
+describe('BacktestService — buildPriceRangeModifier', () => {
+  const preloaded: MarketData[] = [
+    {
+      marketId: 'mkt-1',
+      tokenId: 'tok-1',
+      bars: [],
+      currentPriceYes: 0.5,
+      marketQuestion: 'q',
+      resolved: false,
+    } as unknown as MarketData,
+  ];
+
+  it('returns undefined when no priceRangeConfig is supplied (legacy path)', () => {
+    const service = new BacktestService();
+    const result = (service as any).buildPriceRangeModifier(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined when priceRangeConfig has no recognised keys', () => {
+    const service = new BacktestService();
+    const result = (service as any).buildPriceRangeModifier({});
+    expect(result).toBeUndefined();
+  });
+
+  it('builds a modifier and overrides only the bands provided', async () => {
+    const service = new BacktestService();
+    const result = (service as any).buildPriceRangeModifier({
+      momentum: { uncertain: 0.7 },
+      meanReversion: { transitional: 0.9 },
+    });
+    expect(result).toBeDefined();
+    const matrix = result.getMatrix();
+    // momentum.uncertain overridden, transitional/normal keep defaults (0.6 / 1.0)
+    expect(matrix.momentum).toEqual({ normal: 1.0, transitional: 0.6, uncertain: 0.7 });
+    // mean_reversion.transitional overridden, others keep defaults (0 / 1.0)
+    expect(matrix.mean_reversion).toEqual({ normal: 1.0, transitional: 0.9, uncertain: 0 });
+  });
+
+  it('forwards the modifier to createBacktestEngine', async () => {
+    const { createBacktestEngine } = await import('@polymarket-trader/backtest');
+    const service = new BacktestService();
+    const req: BacktestRequest = {
+      startDate: '2026-01-01',
+      endDate: '2026-01-02',
+      initialCapital: 10_000,
+      signalTypes: ['momentum'],
+      priceRangeConfig: { momentum: { uncertain: 0.8 } },
+    };
+    await service.runBacktest(req, preloaded);
+    const calls = (createBacktestEngine as unknown as { mock: { calls: any[] } }).mock.calls;
+    const lastCall = calls[calls.length - 1][0];
+    expect(lastCall.priceRangeModifier).toBeDefined();
+    expect(lastCall.priceRangeModifier.getMatrix().momentum.uncertain).toBe(0.8);
+  });
+
+  it('passes undefined when priceRangeConfig absent so the engine uses raw weights', async () => {
+    const { createBacktestEngine } = await import('@polymarket-trader/backtest');
+    (createBacktestEngine as unknown as { mock: { calls: any[] } }).mock.calls.length = 0;
+    const service = new BacktestService();
+    const req: BacktestRequest = {
+      startDate: '2026-01-01',
+      endDate: '2026-01-02',
+      initialCapital: 10_000,
+      signalTypes: ['momentum'],
+    };
+    await service.runBacktest(req, preloaded);
+    const calls = (createBacktestEngine as unknown as { mock: { calls: any[] } }).mock.calls;
+    expect(calls[calls.length - 1][0].priceRangeModifier).toBeUndefined();
+  });
+});

--- a/packages/dashboard/src/services/BacktestService.ts
+++ b/packages/dashboard/src/services/BacktestService.ts
@@ -29,8 +29,10 @@ import {
   VolumeAnomalyGenerator,
   MultiLevelOFISignal,
   SpreadCompressionGenerator,
+  PriceRangeWeightModifier,
   type ISignal,
   type OrderBookSnapshot,
+  type PriceBandMultipliers,
 } from '@polymarket-trader/signals';
 import { isDatabaseConfigured, query, transaction, type PoolClient } from '../database/index.js';
 
@@ -88,6 +90,22 @@ export interface BacktestRequest {
      *  trial can evaluate dm flips per market_type. Task 8 wires the apply
      *  side in BacktestService. */
     directionMultiplier?: number;
+  };
+  /**
+   * Price-range weight modifier overrides. When supplied, BacktestService
+   * builds a PriceRangeWeightModifier with the given multipliers and feeds it
+   * to the engine. Optuna samples these per trial to learn the matrix that
+   * matches production behaviour (the modifier is applied live in
+   * SignalEngine.combineSignalsForMarket but used to be invisible to the
+   * engine, leaving Optuna optimizing against a "raw weights" universe that
+   * did not match production).
+   */
+  priceRangeConfig?: {
+    momentum?: Partial<PriceBandMultipliers>;
+    meanReversion?: Partial<PriceBandMultipliers>;
+    crossMarketCorr?: Partial<PriceBandMultipliers>;
+    spreadCompression?: Partial<PriceBandMultipliers>;
+    newsSentiment?: Partial<PriceBandMultipliers>;
   };
 }
 
@@ -202,12 +220,14 @@ export class BacktestService extends EventEmitter {
 
       // Create backtest engine
       this.updateProgress(backtestId, 40, 'Creating backtest engine');
+      const priceRangeModifier = this.buildPriceRangeModifier(request.priceRangeConfig);
       const engine = createBacktestEngine({
         config: storedBacktest.config,
         marketData,
         signals,
         combiner,
         riskConfig: storedBacktest.config.risk,
+        priceRangeModifier,
       });
 
       // Run backtest
@@ -519,6 +539,44 @@ export class BacktestService extends EventEmitter {
       console.error('[BacktestService] Failed to fetch historical data:', error);
       return this.generateMockData(startDate, endDate);
     }
+  }
+
+  /**
+   * Build a PriceRangeWeightModifier from optional config overrides. Returns
+   * undefined when no overrides are supplied so the engine keeps its legacy
+   * "raw weights" path (zero regression risk for callers that don't care).
+   *
+   * Optuna samples per-band multipliers (transitional/uncertain) for the 5
+   * direction-sensitive generators. Flow signals (ofi/mlofi/hawkes/...) keep
+   * their hardcoded defaults — they're flat 1.0 across bands by design and
+   * adding them to the param space would explode dimensionality with no ROI.
+   */
+  private buildPriceRangeModifier(
+    config: BacktestRequest['priceRangeConfig'],
+  ): PriceRangeWeightModifier | undefined {
+    if (!config) return undefined;
+    const customMatrix: Partial<Record<string, PriceBandMultipliers>> = {};
+    const map: Array<[keyof NonNullable<BacktestRequest['priceRangeConfig']>, string]> = [
+      ['momentum', 'momentum'],
+      ['meanReversion', 'mean_reversion'],
+      ['crossMarketCorr', 'cross_market_corr'],
+      ['spreadCompression', 'spread_compression'],
+      ['newsSentiment', 'news_sentiment'],
+    ];
+    const defaults = new PriceRangeWeightModifier().getMatrix();
+    let touched = false;
+    for (const [requestKey, signalId] of map) {
+      const overrides = config[requestKey];
+      if (!overrides) continue;
+      touched = true;
+      customMatrix[signalId] = {
+        normal: overrides.normal ?? defaults[signalId]?.normal ?? 1.0,
+        transitional: overrides.transitional ?? defaults[signalId]?.transitional ?? 1.0,
+        uncertain: overrides.uncertain ?? defaults[signalId]?.uncertain ?? 0.0,
+      };
+    }
+    if (!touched) return undefined;
+    return new PriceRangeWeightModifier(customMatrix);
   }
 
   /**

--- a/packages/dashboard/src/services/OptimizationScheduler.test.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.test.ts
@@ -11,6 +11,10 @@ vi.mock('../database/repositories.js', () => ({
     updatePerType: vi.fn().mockResolvedValue(undefined),
     getPerType: vi.fn().mockResolvedValue(null),
   },
+  priceRangeMatrixRepo: {
+    setBand: vi.fn().mockResolvedValue(undefined),
+    getMatrix: vi.fn().mockResolvedValue({}),
+  },
 }));
 
 vi.mock('./BacktestService.js', () => ({
@@ -38,7 +42,7 @@ vi.mock('../utils/vmHealth.js', () => ({
   logHealthStatus: vi.fn(),
 }));
 
-import { signalWeightsRepo } from '../database/repositories.js';
+import { signalWeightsRepo, priceRangeMatrixRepo } from '../database/repositories.js';
 import { query } from '../database/index.js';
 import {
   OptimizationScheduler,
@@ -624,5 +628,94 @@ describe('signalWeightsRepo.getPerType (helper for min-lift gate)', () => {
     expect(signalWeightsRepo).toBeDefined();
     // Only assert presence in the mock map; runtime behaviour is covered by integration tests.
     expect(typeof (signalWeightsRepo as any).updatePerType).toBe('function');
+  });
+});
+
+describe('PriceRange Optuna params + persistence', () => {
+  const FULL_PRICE_RANGE_PARAMS = [
+    'priceRange.momentumTransitional',
+    'priceRange.momentumUncertain',
+    'priceRange.meanReversionTransitional',
+    'priceRange.meanReversionUncertain',
+    'priceRange.crossMarketCorrTransitional',
+    'priceRange.crossMarketCorrUncertain',
+    'priceRange.spreadCompressionUncertain',
+    'priceRange.newsSentimentUncertain',
+  ];
+
+  it('OPTUNA_PARAM_SPACE includes all 8 priceRange multiplier params', () => {
+    const names = OPTUNA_PARAM_SPACE.map((p) => p.name);
+    for (const expected of FULL_PRICE_RANGE_PARAMS) {
+      expect(names).toContain(expected);
+    }
+  });
+
+  it('REFINEMENT_PARAM_SPACE includes the same 8 priceRange params (per-type cycles re-tune)', () => {
+    const names = REFINEMENT_PARAM_SPACE.map((p) => p.name);
+    for (const expected of FULL_PRICE_RANGE_PARAMS) {
+      expect(names).toContain(expected);
+    }
+  });
+
+  it('priceRange domains are sane: bounds within [0, 1.5] and float', () => {
+    const all = [...OPTUNA_PARAM_SPACE, ...REFINEMENT_PARAM_SPACE];
+    const priceRangeParams = all.filter((p) => p.name.startsWith('priceRange.'));
+    for (const param of priceRangeParams) {
+      expect(param.type).toBe('float');
+      expect((param as any).low).toBeGreaterThanOrEqual(0.0);
+      expect((param as any).high).toBeLessThanOrEqual(1.5);
+    }
+  });
+
+  it('mapOptunaParamsToRequest emits priceRangeConfig only for sampled bands', () => {
+    const scheduler = new OptimizationScheduler();
+    const params = {
+      'priceRange.momentumUncertain': 0.4,
+      'priceRange.meanReversionTransitional': 0.7,
+    };
+    const request = (scheduler as any).mapOptunaParamsToRequest(
+      params,
+      new Date('2026-05-01'),
+      new Date('2026-05-10'),
+    );
+    expect(request.priceRangeConfig).toBeDefined();
+    expect(request.priceRangeConfig.momentum).toEqual({ uncertain: 0.4 });
+    expect(request.priceRangeConfig.meanReversion).toEqual({ transitional: 0.7 });
+    // Generators with no sampled value must NOT appear (would otherwise zero-out their defaults)
+    expect(request.priceRangeConfig.crossMarketCorr).toBeUndefined();
+  });
+
+  it('mapOptunaParamsToRequest leaves priceRangeConfig undefined when no priceRange params sampled', () => {
+    const scheduler = new OptimizationScheduler();
+    const request = (scheduler as any).mapOptunaParamsToRequest(
+      { 'combiner.momentumWeight': 0.5 },
+      new Date('2026-05-01'),
+      new Date('2026-05-10'),
+    );
+    expect(request.priceRangeConfig).toBeUndefined();
+  });
+
+  it('persistPriceRangeMultipliers writes to price_range_matrix and clamps to [0, 2]', async () => {
+    const scheduler = new OptimizationScheduler();
+    vi.mocked(priceRangeMatrixRepo.setBand).mockClear();
+    await (scheduler as any).persistPriceRangeMultipliers({
+      'priceRange.momentumUncertain': 0.5,
+      'priceRange.meanReversionTransitional': 3.5, // out-of-range, must be clamped to 2.0
+      'priceRange.crossMarketCorrUncertain': -1, // out-of-range, must be clamped to 0
+    });
+
+    expect(priceRangeMatrixRepo.setBand).toHaveBeenCalledWith('momentum', 'uncertain', 0.5);
+    expect(priceRangeMatrixRepo.setBand).toHaveBeenCalledWith('mean_reversion', 'transitional', 2.0);
+    expect(priceRangeMatrixRepo.setBand).toHaveBeenCalledWith('cross_market_corr', 'uncertain', 0);
+  });
+
+  it('persistPriceRangeMultipliers ignores non-finite values (NaN / Infinity)', async () => {
+    const scheduler = new OptimizationScheduler();
+    vi.mocked(priceRangeMatrixRepo.setBand).mockClear();
+    await (scheduler as any).persistPriceRangeMultipliers({
+      'priceRange.momentumUncertain': Number.NaN,
+      'priceRange.meanReversionTransitional': Number.POSITIVE_INFINITY,
+    });
+    expect(priceRangeMatrixRepo.setBand).not.toHaveBeenCalled();
   });
 });

--- a/packages/dashboard/src/services/OptimizationScheduler.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.ts
@@ -12,7 +12,7 @@
  */
 
 import { query, isDatabaseConfigured } from '../database/index.js';
-import { signalWeightsRepo } from '../database/repositories.js';
+import { signalWeightsRepo, priceRangeMatrixRepo } from '../database/repositories.js';
 import { getBacktestService, BacktestService, type BacktestRequest } from './BacktestService.js';
 import type { MarketData } from '@polymarket-trader/backtest';
 import { getValidationService, type ValidationService } from './ValidationService.js';
@@ -68,6 +68,21 @@ export const OPTUNA_PARAM_SPACE: ParameterDef[] = [
   { name: 'momentum.rsiPeriod', type: 'int', low: 10, high: 21 },
   { name: 'meanReversion.bollingerPeriod', type: 'int', low: 15, high: 30 },
   { name: 'meanReversion.zScoreThreshold', type: 'float', low: 1.5, high: 2.5 },
+  // PriceRangeWeightModifier per-band multipliers (8 params).
+  // Hardcoded defaults zeroed out momentum/mean_reversion in the uncertain
+  // band (0.45–0.55) and dampened them in the transitional band (0.40–0.45,
+  // 0.55–0.60). With a downward-drifting price universe this dampening
+  // contributed to the 6.6:1 LONG:SHORT skew observed 2026-05-05. Optuna now
+  // samples the matrix so post-flip data can override the hand-tuned values.
+  // See docs / project_optimizer_epoch_reset.md for context.
+  { name: 'priceRange.momentumTransitional', type: 'float', low: 0.0, high: 1.5 },
+  { name: 'priceRange.momentumUncertain', type: 'float', low: 0.0, high: 1.0 },
+  { name: 'priceRange.meanReversionTransitional', type: 'float', low: 0.0, high: 1.5 },
+  { name: 'priceRange.meanReversionUncertain', type: 'float', low: 0.0, high: 1.0 },
+  { name: 'priceRange.crossMarketCorrTransitional', type: 'float', low: 0.0, high: 1.5 },
+  { name: 'priceRange.crossMarketCorrUncertain', type: 'float', low: 0.0, high: 1.5 },
+  { name: 'priceRange.spreadCompressionUncertain', type: 'float', low: 0.0, high: 1.5 },
+  { name: 'priceRange.newsSentimentUncertain', type: 'float', low: 0.0, high: 1.5 },
 ];
 
 /**
@@ -98,6 +113,17 @@ export const REFINEMENT_PARAM_SPACE: ParameterDef[] = [
   { name: 'risk.stopLossPct', type: 'float', low: 8.0, high: 30.0 },
   { name: 'meanReversion.zScoreThreshold', type: 'float', low: 1.5, high: 2.5 },
   { name: 'combiner.directionMultiplier', type: 'categorical', choices: [-1.0, 1.0] },
+  // PriceRangeWeightModifier multipliers — same 8 params as full space.
+  // Refinement re-tunes them per-type each cycle (every 6h) so they track
+  // régime changes without waiting for the weekly full run.
+  { name: 'priceRange.momentumTransitional', type: 'float', low: 0.0, high: 1.5 },
+  { name: 'priceRange.momentumUncertain', type: 'float', low: 0.0, high: 1.0 },
+  { name: 'priceRange.meanReversionTransitional', type: 'float', low: 0.0, high: 1.5 },
+  { name: 'priceRange.meanReversionUncertain', type: 'float', low: 0.0, high: 1.0 },
+  { name: 'priceRange.crossMarketCorrTransitional', type: 'float', low: 0.0, high: 1.5 },
+  { name: 'priceRange.crossMarketCorrUncertain', type: 'float', low: 0.0, high: 1.5 },
+  { name: 'priceRange.spreadCompressionUncertain', type: 'float', low: 0.0, high: 1.5 },
+  { name: 'priceRange.newsSentimentUncertain', type: 'float', low: 0.0, high: 1.5 },
 ];
 
 // ============================================================
@@ -711,7 +737,41 @@ export class OptimizationScheduler {
         // combinerConfig field (commit 46dcf41).
         consensusDiscountFloor: params['combiner.consensusDiscountFloor'] as number | undefined,
       },
+      priceRangeConfig: this.buildPriceRangeConfigFromParams(params),
     };
+  }
+
+  /**
+   * Map flat priceRange.* params into the structured priceRangeConfig that
+   * BacktestService consumes. Only emits a key when at least one band
+   * multiplier was actually sampled (so absent params keep the default matrix
+   * untouched, not silently zeroed).
+   */
+  private buildPriceRangeConfigFromParams(
+    params: Record<string, any>,
+  ): BacktestRequest['priceRangeConfig'] {
+    const cfg: BacktestRequest['priceRangeConfig'] = {};
+    const setBand = (
+      genKey: keyof NonNullable<BacktestRequest['priceRangeConfig']>,
+      band: 'transitional' | 'uncertain',
+      paramName: string,
+    ) => {
+      const value = params[paramName];
+      if (typeof value !== 'number' || !Number.isFinite(value)) return;
+      const existing = cfg[genKey] ?? {};
+      cfg[genKey] = { ...existing, [band]: value };
+    };
+
+    setBand('momentum', 'transitional', 'priceRange.momentumTransitional');
+    setBand('momentum', 'uncertain', 'priceRange.momentumUncertain');
+    setBand('meanReversion', 'transitional', 'priceRange.meanReversionTransitional');
+    setBand('meanReversion', 'uncertain', 'priceRange.meanReversionUncertain');
+    setBand('crossMarketCorr', 'transitional', 'priceRange.crossMarketCorrTransitional');
+    setBand('crossMarketCorr', 'uncertain', 'priceRange.crossMarketCorrUncertain');
+    setBand('spreadCompression', 'uncertain', 'priceRange.spreadCompressionUncertain');
+    setBand('newsSentiment', 'uncertain', 'priceRange.newsSentimentUncertain');
+
+    return Object.keys(cfg).length > 0 ? cfg : undefined;
   }
 
   // ============================================================
@@ -1147,7 +1207,63 @@ export class OptimizationScheduler {
       }
     }
 
+    // Persist priceRange.* multipliers to price_range_matrix and live-update
+    // the SignalEngine modifier so production picks them up without a restart.
+    // Matrix is global (not per-type) — the per-type loop runs N times per
+    // cycle and the last-in winner determines the persisted matrix. That's
+    // intentional for a first cut; per-type matrices would multiply storage
+    // and Optuna trials with marginal ROI until empirics demand it.
+    await this.persistPriceRangeMultipliers(result.params);
+
     return { wasApplied: true };
+  }
+
+  private static readonly PRICE_RANGE_PARAM_MAP: Array<{ param: string; signalId: string; band: 'transitional' | 'uncertain' }> = [
+    { param: 'priceRange.momentumTransitional', signalId: 'momentum', band: 'transitional' },
+    { param: 'priceRange.momentumUncertain', signalId: 'momentum', band: 'uncertain' },
+    { param: 'priceRange.meanReversionTransitional', signalId: 'mean_reversion', band: 'transitional' },
+    { param: 'priceRange.meanReversionUncertain', signalId: 'mean_reversion', band: 'uncertain' },
+    { param: 'priceRange.crossMarketCorrTransitional', signalId: 'cross_market_corr', band: 'transitional' },
+    { param: 'priceRange.crossMarketCorrUncertain', signalId: 'cross_market_corr', band: 'uncertain' },
+    { param: 'priceRange.spreadCompressionUncertain', signalId: 'spread_compression', band: 'uncertain' },
+    { param: 'priceRange.newsSentimentUncertain', signalId: 'news_sentiment', band: 'uncertain' },
+  ];
+
+  private async persistPriceRangeMultipliers(params: Record<string, any>): Promise<void> {
+    if (!isDatabaseConfigured()) return;
+    const liveUpdates: Record<string, Partial<Record<'transitional' | 'uncertain', number>>> = {};
+    for (const { param, signalId, band } of OptimizationScheduler.PRICE_RANGE_PARAM_MAP) {
+      const raw = params[param];
+      if (typeof raw !== 'number' || !Number.isFinite(raw)) continue;
+      const clamped = Math.max(0, Math.min(2.0, raw));
+      try {
+        await priceRangeMatrixRepo.setBand(signalId, band, clamped);
+        liveUpdates[signalId] = { ...(liveUpdates[signalId] ?? {}), [band]: clamped };
+        console.log(`[OptimizationScheduler] price_range_matrix[${signalId}/${band}] = ${clamped.toFixed(4)}`);
+      } catch (err) {
+        console.error(`[OptimizationScheduler] Failed to persist priceRange ${signalId}/${band}:`, err);
+      }
+    }
+
+    if (Object.keys(liveUpdates).length === 0) return;
+    try {
+      const { getSignalEngine } = await import('./SignalEngine.js');
+      const engine = getSignalEngine();
+      const baseline = engine.getPriceRangeMatrix();
+      const matrixUpdates: Record<string, { normal: number; transitional: number; uncertain: number }> = {};
+      for (const [signalId, bandUpdates] of Object.entries(liveUpdates)) {
+        const current = baseline[signalId] ?? { normal: 1.0, transitional: 1.0, uncertain: 1.0 };
+        matrixUpdates[signalId] = {
+          normal: current.normal,
+          transitional: bandUpdates.transitional ?? current.transitional,
+          uncertain: bandUpdates.uncertain ?? current.uncertain,
+        };
+      }
+      engine.updatePriceRangeMatrix(matrixUpdates);
+      console.log(`[OptimizationScheduler] Live-updated SignalEngine priceRange matrix for ${Object.keys(matrixUpdates).length} generators`);
+    } catch (err) {
+      console.error('[OptimizationScheduler] Failed to live-update SignalEngine priceRange matrix:', err);
+    }
   }
 
   // ============================================================

--- a/packages/dashboard/src/services/SignalEngine.ts
+++ b/packages/dashboard/src/services/SignalEngine.ts
@@ -36,6 +36,7 @@ import {
   DurationWeightModifier,
   PriceRangeWeightModifier,
   type DurationBand,
+  type PriceBandMultipliers,
   type ISignal,
   type SignalContext,
   type SignalOutput,
@@ -1193,6 +1194,21 @@ export class SignalEngine extends EventEmitter {
   setWeights(weights: Record<string, number>): void {
     this.combiner.setWeights(weights);
     this.emit('weights:updated', weights);
+  }
+
+  /**
+   * Replace the price-range modifier matrix at runtime. Called at startup
+   * after loading persisted Optuna-tuned multipliers from
+   * price_range_matrix, and after each successful optimization run that
+   * passes the OOS gate.
+   */
+  updatePriceRangeMatrix(updates: Partial<Record<string, PriceBandMultipliers>>): void {
+    this.priceRangeModifier.updateMatrix(updates);
+  }
+
+  /** Returns the current price-range matrix (defensive copy). */
+  getPriceRangeMatrix(): Record<string, PriceBandMultipliers> {
+    return this.priceRangeModifier.getMatrix();
   }
 
   /**


### PR DESCRIPTION
## Summary

The live SignalEngine modulates combiner weights via `PriceRangeWeightModifier` (uncertain band 0.45-0.55 zeroes momentum/mean_reversion; transitional 0.40-0.45/0.55-0.60 dampens them). The BacktestEngine never applied this modifier, so Optuna optimized against a *raw weights* universe that did not match production. Combined with PR #188 (epoch floor + neutral baseline), this PR closes the loop: Optuna can now sample matrix multipliers and have them actually affect simulated PnL.

## Why now

2026-05-05 diagnostic: combiner produced 6.6:1 LONG:SHORT signals on 51 closed trades (LONG WR collapsed to 18%). Pesos heredados pre-flip eran una mitad del sesgo (cubierto por PR #188); el otro contribuidor son los multipliers hardcoded del modifier que penalizan los direccionales en bandas medias — y Optuna nunca los había visto en sus simulaciones para corregirlos.

## Changes

| File | Change |
|------|--------|
| `BacktestEngine` | Optional `priceRangeModifier` opt-in; modulates weights per market before each `combine()` (try/finally to restore) |
| `BacktestRequest.priceRangeConfig` | New optional field with 5 generator slots × 3 bands |
| `BacktestService.buildPriceRangeModifier` | Builds modifier from config; returns undefined when no override (zero regression risk for callers) |
| `OPTUNA_PARAM_SPACE` / `REFINEMENT_PARAM_SPACE` | +8 `priceRange.*` params |
| `mapOptunaParamsToRequest` | Emits `priceRangeConfig` only for sampled bands |
| `price_range_matrix` table | `CREATE TABLE IF NOT EXISTS` at startup |
| `priceRangeMatrixRepo` | `getMatrix` / `setBand` |
| `OptimizationScheduler.persistPriceRangeMultipliers` | Writes after OOS pass + live-updates SignalEngine |
| `SignalEngine.updatePriceRangeMatrix` / `getPriceRangeMatrix` | Public hooks for hydration + live updates |
| `server.ts` | Hydrates matrix from DB on boot before SignalEngine.start() |

## Tests

- 74/74 passing (vitest dashboard + signals + backtest).
- New: BacktestService modifier wire (4 cases), Optuna param presence (3 cases), persistPriceRangeMultipliers (clamping, NaN/Infinity rejection).
- Tsc clean across all 3 affected packages.

## Test plan

- [ ] Watch `[server] price_range_matrix table ensured` on next deploy.
- [ ] Watch `[server] price_range_matrix empty — using PriceRangeWeightModifier defaults` on first boot post-deploy.
- [ ] After ~6h: confirm an Optuna incremental cycle samples `priceRange.*` params (logs).
- [ ] After OOS pass: `[OptimizationScheduler] price_range_matrix[<gen>/<band>] = X` log + `[OptimizationScheduler] Live-updated SignalEngine priceRange matrix for N generators`.
- [ ] After 5-7d of post-flip data: re-run direction distribution diagnostic; expect ratio LONG:SHORT closer to balanced (not 6.6:1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added price-range-based weight modulation for trading signals (momentum, mean reversion, cross-market correlation, spread compression, news sentiment)
  * Backtesting now supports customizable price range multiplier configurations
  * Price range settings now persist and can be updated at runtime without system restart
  * Optimization scheduler now tunes price range multipliers alongside other parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->