### PR TITLE
feat(mean-reversion): parametrize reference anchor (sma | fixed_50)

### DIFF
--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -698,6 +698,22 @@ async function main(): Promise<void> {
         directionResolver,
       });
 
+      // Hydrate mean_reversion.referenceMode from trading_config so a
+      // previously persisted Optuna decision survives restart. Missing key
+      // → keeps the constructor default ('sma'). Invalid stored value (not
+      // 'sma'|'fixed_50') is logged and ignored.
+      try {
+        const persistedMode = await tradingConfigRepo.get<string>('mean_reversion.reference_mode');
+        if (persistedMode === 'sma' || persistedMode === 'fixed_50') {
+          signalEngine.setMeanReversionReferenceMode(persistedMode);
+          console.log(`[server] mean_reversion.referenceMode hydrated from DB: ${persistedMode}`);
+        } else if (persistedMode != null) {
+          console.warn(`[server] Ignoring invalid persisted mean_reversion.reference_mode: ${persistedMode}`);
+        }
+      } catch (err) {
+        console.warn('[server] Failed to hydrate mean_reversion.referenceMode:', err);
+      }
+
       // Hydrate PriceRangeWeightModifier matrix from DB so Optuna-tuned
       // multipliers persist across restarts. Empty table → keeps in-code
       // defaults from PriceRangeWeightModifier.DEFAULT_MATRIX.

--- a/packages/dashboard/src/services/BacktestService.ts
+++ b/packages/dashboard/src/services/BacktestService.ts
@@ -68,6 +68,10 @@ export interface BacktestRequest {
     bbPeriod?: number;
     bbStdDev?: number;
     zScoreThreshold?: number;
+    /** Reference anchor: 'sma' (default, classic SMA) or 'fixed_50'
+     *  (anchor to coin-flip prior — better for prediction markets that drift
+     *  toward a terminal resolution). */
+    referenceMode?: 'sma' | 'fixed_50';
   };
   /** Combiner config for Optuna optimization */
   combinerConfig?: {
@@ -650,6 +654,7 @@ export class BacktestService extends EventEmitter {
             bbPeriod: meanReversionConfig.bbPeriod,
             bbStdDev: meanReversionConfig.bbStdDev,
             zScoreThreshold: meanReversionConfig.zScoreThreshold,
+            referenceMode: meanReversionConfig.referenceMode,
           } : undefined));
           break;
         case 'wallet_tracking':

--- a/packages/dashboard/src/services/OptimizationScheduler.test.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.test.ts
@@ -15,6 +15,10 @@ vi.mock('../database/repositories.js', () => ({
     setBand: vi.fn().mockResolvedValue(undefined),
     getMatrix: vi.fn().mockResolvedValue({}),
   },
+  tradingConfigRepo: {
+    set: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn().mockResolvedValue(null),
+  },
 }));
 
 vi.mock('./BacktestService.js', () => ({
@@ -42,7 +46,7 @@ vi.mock('../utils/vmHealth.js', () => ({
   logHealthStatus: vi.fn(),
 }));
 
-import { signalWeightsRepo, priceRangeMatrixRepo } from '../database/repositories.js';
+import { signalWeightsRepo, priceRangeMatrixRepo, tradingConfigRepo } from '../database/repositories.js';
 import { query } from '../database/index.js';
 import {
   OptimizationScheduler,
@@ -717,5 +721,71 @@ describe('PriceRange Optuna params + persistence', () => {
       'priceRange.meanReversionTransitional': Number.POSITIVE_INFINITY,
     });
     expect(priceRangeMatrixRepo.setBand).not.toHaveBeenCalled();
+  });
+});
+
+describe('mean_reversion.referenceMode wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('OPTUNA_PARAM_SPACE includes meanReversion.referenceMode as categorical {sma, fixed_50}', () => {
+    const param = OPTUNA_PARAM_SPACE.find((p) => p.name === 'meanReversion.referenceMode');
+    expect(param).toBeDefined();
+    expect(param?.type).toBe('categorical');
+    expect((param as any).choices).toEqual(['sma', 'fixed_50']);
+  });
+
+  it('REFINEMENT_PARAM_SPACE includes meanReversion.referenceMode (per-type cycles re-tune)', () => {
+    const param = REFINEMENT_PARAM_SPACE.find((p) => p.name === 'meanReversion.referenceMode');
+    expect(param).toBeDefined();
+    expect(param?.type).toBe('categorical');
+    expect((param as any).choices).toEqual(['sma', 'fixed_50']);
+  });
+
+  it('mapOptunaParamsToRequest forwards referenceMode to meanReversionConfig', () => {
+    const scheduler = new OptimizationScheduler();
+    const request = (scheduler as any).mapOptunaParamsToRequest(
+      { 'meanReversion.referenceMode': 'fixed_50' },
+      new Date('2026-05-01'),
+      new Date('2026-05-10'),
+    );
+    expect(request.meanReversionConfig.referenceMode).toBe('fixed_50');
+  });
+
+  it('mapOptunaParamsToRequest leaves referenceMode undefined when not sampled', () => {
+    const scheduler = new OptimizationScheduler();
+    const request = (scheduler as any).mapOptunaParamsToRequest(
+      {},
+      new Date('2026-05-01'),
+      new Date('2026-05-10'),
+    );
+    expect(request.meanReversionConfig.referenceMode).toBeUndefined();
+  });
+
+  it('persistMeanReversionReferenceMode writes valid mode to trading_config', async () => {
+    const scheduler = new OptimizationScheduler();
+    await (scheduler as any).persistMeanReversionReferenceMode({
+      'meanReversion.referenceMode': 'fixed_50',
+    });
+    expect(tradingConfigRepo.set).toHaveBeenCalledWith(
+      'mean_reversion.reference_mode',
+      'fixed_50',
+      expect.any(String),
+    );
+  });
+
+  it('persistMeanReversionReferenceMode ignores invalid values', async () => {
+    const scheduler = new OptimizationScheduler();
+    await (scheduler as any).persistMeanReversionReferenceMode({
+      'meanReversion.referenceMode': 'invalid_mode',
+    });
+    expect(tradingConfigRepo.set).not.toHaveBeenCalled();
+  });
+
+  it('persistMeanReversionReferenceMode no-ops when param absent', async () => {
+    const scheduler = new OptimizationScheduler();
+    await (scheduler as any).persistMeanReversionReferenceMode({});
+    expect(tradingConfigRepo.set).not.toHaveBeenCalled();
   });
 });

--- a/packages/dashboard/src/services/OptimizationScheduler.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.ts
@@ -12,7 +12,7 @@
  */
 
 import { query, isDatabaseConfigured } from '../database/index.js';
-import { signalWeightsRepo, priceRangeMatrixRepo } from '../database/repositories.js';
+import { signalWeightsRepo, priceRangeMatrixRepo, tradingConfigRepo } from '../database/repositories.js';
 import { getBacktestService, BacktestService, type BacktestRequest } from './BacktestService.js';
 import type { MarketData } from '@polymarket-trader/backtest';
 import { getValidationService, type ValidationService } from './ValidationService.js';
@@ -68,6 +68,13 @@ export const OPTUNA_PARAM_SPACE: ParameterDef[] = [
   { name: 'momentum.rsiPeriod', type: 'int', low: 10, high: 21 },
   { name: 'meanReversion.bollingerPeriod', type: 'int', low: 15, high: 30 },
   { name: 'meanReversion.zScoreThreshold', type: 'float', low: 1.5, high: 2.5 },
+  // mean-reversion reference anchor. 'sma' (legacy) vs 'fixed_50' (anchor to
+  // the coin-flip prior). In a portfolio dominated by markets that drift to
+  // a terminal NO/YES resolution, the SMA itself drifts and the generator
+  // never expects regression to a stable point. 'fixed_50' tests the
+  // alternative hypothesis. Categorical so drift is impossible by
+  // construction; persisted via trading_config.
+  { name: 'meanReversion.referenceMode', type: 'categorical', choices: ['sma', 'fixed_50'] },
   // PriceRangeWeightModifier per-band multipliers (8 params).
   // Hardcoded defaults zeroed out momentum/mean_reversion in the uncertain
   // band (0.45–0.55) and dampened them in the transitional band (0.40–0.45,
@@ -112,6 +119,7 @@ export const REFINEMENT_PARAM_SPACE: ParameterDef[] = [
   { name: 'risk.maxPositionSizePct', type: 'float', low: 3.0, high: 15.0 },
   { name: 'risk.stopLossPct', type: 'float', low: 8.0, high: 30.0 },
   { name: 'meanReversion.zScoreThreshold', type: 'float', low: 1.5, high: 2.5 },
+  { name: 'meanReversion.referenceMode', type: 'categorical', choices: ['sma', 'fixed_50'] },
   { name: 'combiner.directionMultiplier', type: 'categorical', choices: [-1.0, 1.0] },
   // PriceRangeWeightModifier multipliers — same 8 params as full space.
   // Refinement re-tunes them per-type each cycle (every 6h) so they track
@@ -716,6 +724,7 @@ export class OptimizationScheduler {
       meanReversionConfig: {
         bbPeriod: params['meanReversion.bollingerPeriod'],
         zScoreThreshold: params['meanReversion.zScoreThreshold'],
+        referenceMode: params['meanReversion.referenceMode'] as 'sma' | 'fixed_50' | undefined,
       },
       combinerConfig: {
         momentumWeight: params['combiner.momentumWeight'],
@@ -1215,7 +1224,34 @@ export class OptimizationScheduler {
     // and Optuna trials with marginal ROI until empirics demand it.
     await this.persistPriceRangeMultipliers(result.params);
 
+    // Persist mean_reversion.referenceMode + live-update SignalEngine.
+    await this.persistMeanReversionReferenceMode(result.params);
+
     return { wasApplied: true };
+  }
+
+  private async persistMeanReversionReferenceMode(params: Record<string, any>): Promise<void> {
+    if (!isDatabaseConfigured()) return;
+    const raw = params['meanReversion.referenceMode'];
+    if (raw !== 'sma' && raw !== 'fixed_50') return;
+    try {
+      await tradingConfigRepo.set(
+        'mean_reversion.reference_mode',
+        raw,
+        'Optuna-tuned mean_reversion reference anchor (sma | fixed_50)',
+      );
+      console.log(`[OptimizationScheduler] mean_reversion.reference_mode = ${raw}`);
+    } catch (err) {
+      console.error('[OptimizationScheduler] Failed to persist mean_reversion.reference_mode:', err);
+      return;
+    }
+    try {
+      const { getSignalEngine } = await import('./SignalEngine.js');
+      getSignalEngine().setMeanReversionReferenceMode(raw);
+      console.log('[OptimizationScheduler] Live-updated SignalEngine mean_reversion.referenceMode');
+    } catch (err) {
+      console.error('[OptimizationScheduler] Failed to live-update mean_reversion.referenceMode:', err);
+    }
   }
 
   private static readonly PRICE_RANGE_PARAM_MAP: Array<{ param: string; signalId: string; band: 'transitional' | 'uncertain' }> = [

--- a/packages/dashboard/src/services/SignalEngine.ts
+++ b/packages/dashboard/src/services/SignalEngine.ts
@@ -1212,6 +1212,32 @@ export class SignalEngine extends EventEmitter {
   }
 
   /**
+   * Swap the mean_reversion reference anchor at runtime. 'sma' (default,
+   * legacy) or 'fixed_50' (anchor to coin-flip prior — better for
+   * prediction markets that drift toward terminal resolution). Called at
+   * boot from trading_config and after each successful Optuna cycle that
+   * passes the OOS gate.
+   */
+  setMeanReversionReferenceMode(mode: 'sma' | 'fixed_50'): void {
+    const generator = this.signals.get('mean_reversion') as unknown as
+      { setReferenceMode?: (m: 'sma' | 'fixed_50') => void } | undefined;
+    if (!generator || typeof generator.setReferenceMode !== 'function') {
+      console.warn('[SignalEngine] mean_reversion generator missing setReferenceMode — skipping');
+      return;
+    }
+    generator.setReferenceMode(mode);
+  }
+
+  getMeanReversionReferenceMode(): 'sma' | 'fixed_50' | null {
+    const generator = this.signals.get('mean_reversion') as unknown as
+      { getReferenceMode?: () => 'sma' | 'fixed_50' } | undefined;
+    if (!generator || typeof generator.getReferenceMode !== 'function') {
+      return null;
+    }
+    return generator.getReferenceMode();
+  }
+
+  /**
    * Update configuration
    */
   updateConfig(updates: Partial<SignalEngineConfig>): void {

--- a/packages/signals/src/signals/technical/MeanReversionSignal.test.ts
+++ b/packages/signals/src/signals/technical/MeanReversionSignal.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MeanReversionSignal,
+  DEFAULT_MEAN_REVERSION_PARAMS,
+  FIXED_REFERENCE_PRICE,
+  type MeanReversionReferenceMode,
+} from './MeanReversionSignal.js';
+import type { SignalContext, PriceBar } from '../../core/types/signal.types.js';
+
+function bars(closes: number[]): PriceBar[] {
+  const start = Date.now();
+  return closes.map((close, i) => ({
+    time: new Date(start + i * 60_000),
+    open: close,
+    high: close * 1.01,
+    low: close * 0.99,
+    close,
+    volume: 1000,
+    tradeCount: 1,
+  }));
+}
+
+function context(closes: number[], overrides: Partial<SignalContext> = {}): SignalContext {
+  const priceBars = bars(closes);
+  return {
+    market: {
+      id: 'mkt',
+      question: 'q',
+      isActive: true,
+      isResolved: false,
+      tokenIdYes: 'tok-yes',
+      endDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    },
+    priceBars,
+    recentTrades: [],
+    currentTime: priceBars[priceBars.length - 1].time,
+    ...overrides,
+  };
+}
+
+describe('MeanReversionSignal — referenceMode', () => {
+  it('defaults to "sma" mode (preserves legacy behaviour)', () => {
+    const signal = new MeanReversionSignal();
+    expect(signal.getReferenceMode()).toBe('sma');
+    expect(DEFAULT_MEAN_REVERSION_PARAMS.referenceMode).toBe('sma');
+  });
+
+  it('accepts referenceMode in constructor', () => {
+    const signal = new MeanReversionSignal({ referenceMode: 'fixed_50' });
+    expect(signal.getReferenceMode()).toBe('fixed_50');
+  });
+
+  it('setReferenceMode swaps mode at runtime', () => {
+    const signal = new MeanReversionSignal();
+    signal.setReferenceMode('fixed_50');
+    expect(signal.getReferenceMode()).toBe('fixed_50');
+    signal.setReferenceMode('sma');
+    expect(signal.getReferenceMode()).toBe('sma');
+  });
+
+  it('exports FIXED_REFERENCE_PRICE = 0.5 (prediction-market coin-flip prior)', () => {
+    expect(FIXED_REFERENCE_PRICE).toBe(0.5);
+  });
+
+  describe('directional contrast on a market drifting toward NO', () => {
+    // Synthetic series: price drifts from 0.45 down to 0.20 over 50 bars.
+    // SMA tracks the drift downward → SMA-mode reads "price ≈ SMA, no signal".
+    // fixed_50 anchors at 0.5 → reads "price < 0.5 by a lot, oversold signal".
+    const closes: number[] = [];
+    for (let i = 0; i < 50; i++) {
+      closes.push(0.45 - (i / 49) * 0.25);
+    }
+
+    it('"sma" mode returns near-zero strength on a steady drift (mean tracks price)', async () => {
+      const signal = new MeanReversionSignal();
+      const result = await signal.compute(context(closes));
+      // The drift is gentle: bb-mode strength stays low or null.
+      // null = below 0.03 strength threshold internal to compute().
+      if (result) {
+        expect(Math.abs(result.strength)).toBeLessThan(0.5);
+      }
+    });
+
+    it('"fixed_50" mode produces a stronger LONG signal on the same series', async () => {
+      const signal = new MeanReversionSignal({ referenceMode: 'fixed_50' });
+      const result = await signal.compute(context(closes));
+      expect(result).not.toBeNull();
+      expect(result!.direction).toBe('LONG');
+    });
+  });
+
+  describe('directional contrast on a stable mean-reverting series', () => {
+    // Series oscillating around 0.50 with 0.05 amplitude — both modes should
+    // agree (centre is ~0.5 in both views) and produce small/null signals.
+    const closes: number[] = [];
+    for (let i = 0; i < 60; i++) {
+      closes.push(0.50 + 0.05 * Math.sin(i * 0.4));
+    }
+
+    it('modes do not contradict on a series whose SMA already sits at 0.5', async () => {
+      const sma = await new MeanReversionSignal({ referenceMode: 'sma' }).compute(context(closes));
+      const fixed = await new MeanReversionSignal({ referenceMode: 'fixed_50' }).compute(context(closes));
+      // Contract: when both fire, they must not call opposite directions.
+      // NEUTRAL is allowed for either mode. LONG vs SHORT is the only failure.
+      if (sma && fixed && sma.direction !== 'NEUTRAL' && fixed.direction !== 'NEUTRAL') {
+        expect(sma.direction).toBe(fixed.direction);
+      }
+    });
+  });
+
+  describe('z-score sub-signal', () => {
+    it('"fixed_50" with price << 0.5 produces a positive z-score deviation (price < centre → expect up)', async () => {
+      const closes = Array(40).fill(0).map((_, i) => 0.20 + 0.001 * Math.sin(i)); // tight series at 0.20
+      const fixed = await new MeanReversionSignal({ referenceMode: 'fixed_50' }).compute(context(closes));
+      // fixed mode sees "price 0.20 << 0.5" and signals LONG.
+      // sma mode sees "price ≈ SMA" → very weak signal.
+      if (fixed) {
+        expect(fixed.direction).toBe('LONG');
+      }
+    });
+
+    it('"fixed_50" with price >> 0.5 produces a SHORT bias', async () => {
+      const closes = Array(40).fill(0).map((_, i) => 0.85 + 0.001 * Math.sin(i));
+      const fixed = await new MeanReversionSignal({ referenceMode: 'fixed_50' }).compute(context(closes));
+      if (fixed) {
+        expect(fixed.direction).toBe('SHORT');
+      }
+    });
+  });
+
+  describe('regression: "sma" mode preserves classical behaviour', () => {
+    it('still rejects extreme prices near 0 / 1', async () => {
+      const signal = new MeanReversionSignal();
+      const closes = Array(35).fill(0.005);
+      expect(await signal.compute(context(closes))).toBeNull();
+    });
+  });
+});

--- a/packages/signals/src/signals/technical/MeanReversionSignal.ts
+++ b/packages/signals/src/signals/technical/MeanReversionSignal.ts
@@ -5,6 +5,27 @@ import type {
 } from '../../core/types/signal.types.js';
 
 /**
+ * Reference anchor for the mean-reversion signal.
+ *
+ *   'sma'      — classic moving-average anchor (default; original behaviour).
+ *   'fixed_50' — anchor to 0.5, the prediction-market terminal-prior midpoint.
+ *
+ * In prediction markets that drift toward 0 or 1, an SMA anchor itself drifts,
+ * so the generator never expects regression to a stable point. Anchoring to
+ * 0.5 instead asks "is this market overbought/oversold relative to the prior
+ * coin-flip"? In a portfolio dominated by markets with avg price 0.36–0.47
+ * this can flip the directional bias of the generator. Optuna chooses per
+ * cycle which anchor produces better OOS Sharpe.
+ *
+ * Std-dev (volatility proxy) is always computed from the SMA — only the
+ * mean centre changes. This keeps band widths and z-score variance coherent
+ * regardless of mode.
+ */
+export type MeanReversionReferenceMode = 'sma' | 'fixed_50';
+
+export const FIXED_REFERENCE_PRICE = 0.5;
+
+/**
  * Configuration parameters for Mean Reversion Signal
  */
 export interface MeanReversionSignalConfig extends Record<string, unknown> {
@@ -26,6 +47,8 @@ export interface MeanReversionSignalConfig extends Record<string, unknown> {
   zScoreWeight?: number;
   /** Weight for historical mean reversion - default: 0.25 */
   historicalWeight?: number;
+  /** Reference anchor — 'sma' (default) or 'fixed_50' */
+  referenceMode?: MeanReversionReferenceMode;
 }
 
 interface MeanReversionParams extends Record<string, unknown> {
@@ -47,6 +70,8 @@ interface MeanReversionParams extends Record<string, unknown> {
   zScoreWeight: number;
   /** Weight for historical mean reversion */
   historicalWeight: number;
+  /** Reference anchor — 'sma' or 'fixed_50' */
+  referenceMode: MeanReversionReferenceMode;
 }
 
 /** Default parameters for Mean Reversion Signal */
@@ -60,6 +85,7 @@ export const DEFAULT_MEAN_REVERSION_PARAMS: MeanReversionParams = {
   bbWeight: 0.4,
   zScoreWeight: 0.35,
   historicalWeight: 0.25,
+  referenceMode: 'sma',
 };
 
 /**
@@ -95,6 +121,31 @@ export class MeanReversionSignal extends BaseSignal {
 
   getRequiredLookback(): number {
     return Math.max(this.parameters.bbPeriod, this.parameters.maPeriod) + 10;
+  }
+
+  /**
+   * Replace the reference-anchor mode at runtime. Used by SignalEngine to
+   * apply Optuna decisions without restarting the dashboard. Other params
+   * are not exposed via setter — they are constructor-time only.
+   */
+  setReferenceMode(mode: MeanReversionReferenceMode): void {
+    this.parameters.referenceMode = mode;
+  }
+
+  getReferenceMode(): MeanReversionReferenceMode {
+    return this.parameters.referenceMode;
+  }
+
+  /**
+   * Resolve the reference centre for a given window. SMA-anchored mode uses
+   * the rolling mean (original behaviour); fixed_50 returns 0.5 regardless
+   * of recent prices, anchoring the generator to the prediction-market
+   * coin-flip prior.
+   */
+  private resolveReference(closes: number[], period: number): number {
+    return this.parameters.referenceMode === 'fixed_50'
+      ? FIXED_REFERENCE_PRICE
+      : this.sma(closes, period);
   }
 
   async compute(context: SignalContext): Promise<SignalOutput | null> {
@@ -172,16 +223,29 @@ export class MeanReversionSignal extends BaseSignal {
 
   /**
    * Calculate Bollinger Bands signal
+   *
+   * In 'fixed_50' mode the band centre is forced to 0.5 (the prediction-market
+   * coin-flip prior) while the band width still reflects realized volatility
+   * around the SMA. percentB is recomputed against the chosen centre so a
+   * market trading at 0.20 with σ=0.05 reads "very oversold relative to 0.5"
+   * even when its SMA is 0.18 (which 'sma' mode would call "in-band").
    */
   private calculateBollingerSignal(
     closes: number[],
     params: MeanReversionParams
   ): { strength: number; percentB: number; bandwidth: number } {
-    const { upper, middle, lower, percentB } = this.bollingerBands(
+    const { upper: smaUpper, middle: smaMiddle, lower: smaLower } = this.bollingerBands(
       closes,
       params.bbPeriod,
       params.bbStdDev
     );
+    const halfWidth = (smaUpper - smaLower) / 2;
+    const middle = params.referenceMode === 'fixed_50' ? FIXED_REFERENCE_PRICE : smaMiddle;
+    const upper = middle + halfWidth;
+    const lower = middle - halfWidth;
+    const currentPrice = closes[closes.length - 1];
+    const range = upper - lower;
+    const percentB = range > 0 ? (currentPrice - lower) / range : 0.5;
 
     // Calculate bandwidth as volatility indicator
     const bandwidth = middle > 0 ? (upper - lower) / middle : 0;
@@ -213,12 +277,17 @@ export class MeanReversionSignal extends BaseSignal {
 
   /**
    * Calculate Z-score signal
+   *
+   * Std-dev (volatility proxy) is always SMA-derived. Only the centre swaps
+   * — see resolveReference. This keeps the z-score scale comparable across
+   * modes; only the direction of "deviation" relative to the chosen centre
+   * differs.
    */
   private calculateZScoreSignal(
     closes: number[],
     params: MeanReversionParams
   ): { strength: number; zScore: number } {
-    const mean = this.sma(closes, params.maPeriod);
+    const mean = this.resolveReference(closes, params.maPeriod);
     const std = this.stdDev(closes, params.maPeriod);
 
     if (std === 0) {
@@ -249,6 +318,11 @@ export class MeanReversionSignal extends BaseSignal {
 
   /**
    * Calculate historical mean reversion tendency
+   *
+   * In 'fixed_50' mode each rolling window measures reversion toward 0.5
+   * rather than toward its own SMA. The empirical reversion rate is then
+   * directly comparable across markets that drift to NO (price→0) vs YES
+   * (price→1) — both look like "anti-reverting" relative to 0.5.
    */
   private calculateHistoricalReversion(
     closes: number[],
@@ -258,13 +332,16 @@ export class MeanReversionSignal extends BaseSignal {
       return { strength: 0, avgReversion: 0 };
     }
 
-    // Look at past deviations and how quickly they reverted
-    const mean = this.sma(closes.slice(-params.maPeriod * 2), params.maPeriod);
+    // Reference centre for the current bar.
+    const mean = this.resolveReference(closes.slice(-params.maPeriod * 2), params.maPeriod);
     const reversionRates: number[] = [];
 
-    // Analyze reversion in rolling windows
+    // Analyze reversion in rolling windows.
     for (let i = params.maPeriod; i < closes.length - 5; i++) {
-      const windowMean = this.sma(closes.slice(i - params.maPeriod, i), params.maPeriod);
+      const windowSlice = closes.slice(i - params.maPeriod, i);
+      const windowMean = params.referenceMode === 'fixed_50'
+        ? FIXED_REFERENCE_PRICE
+        : this.sma(windowSlice, params.maPeriod);
       const deviation = closes[i] - windowMean;
       const futurePrice = closes[Math.min(i + 5, closes.length - 1)];
       const futureDeviation = futurePrice - windowMean;
@@ -280,9 +357,9 @@ export class MeanReversionSignal extends BaseSignal {
       ? reversionRates.reduce((a, b) => a + b, 0) / reversionRates.length
       : 0;
 
-    // Current deviation
+    // Current deviation. Avoid divide-by-zero when the centre lands at 0.
     const currentPrice = closes[closes.length - 1];
-    const currentDeviation = (currentPrice - mean) / mean;
+    const currentDeviation = mean !== 0 ? (currentPrice - mean) / mean : (currentPrice - mean);
 
     // If historical reversion is strong and we're deviated, signal reversion
     const strength = avgReversion > 0.3 && Math.abs(currentDeviation) > params.minDeviationPct / 100


### PR DESCRIPTION
## Summary

Adds `referenceMode: 'sma' | 'fixed_50'` to `MeanReversionSignal`. Default `'sma'` preserves legacy behaviour. `'fixed_50'` anchors all three sub-signals (Bollinger centre, z-score mean, historical-reversion mean) to 0.5 — the prediction-market coin-flip prior — instead of the rolling SMA that drifts with the price.

## Why now

In a portfolio dominated by markets that drift toward terminal NO/YES resolution, an SMA anchor itself drifts and the generator never expects regression to a stable point. This contributes to the post-flip LONG bias documented in `project_optimizer_epoch_reset.md` (the "raw signals direccionales sesgados" follow-up). Optuna chooses the anchor each cycle.

## Architecture

```
Optuna trial → meanReversion.referenceMode  (categorical {sma, fixed_50})
   → mapOptunaParamsToRequest → BacktestRequest.meanReversionConfig.referenceMode
   → BacktestService.createSignals  → new MeanReversionSignal({referenceMode})
   → trial PnL → Optuna learns the right anchor for the régime

Tras OOS pass:
  → tradingConfigRepo.set('mean_reversion.reference_mode', value)
  → SignalEngine.setMeanReversionReferenceMode (live update)

server.ts boot:
  → tradingConfigRepo.get → SignalEngine.setMeanReversionReferenceMode
```

## Mathematical detail

Only the **centre** swaps between modes. Std-dev (volatility proxy) stays SMA-derived in both modes, so:

- Bollinger band **width** is identical, only the **centre** moves to 0.5.
- Z-score **scale** unchanged, only the **deviation reference** moves to 0.5.
- Historical-reversion measures reversion **toward 0.5** instead of toward each window's local SMA.

This keeps the geometry coherent across modes — same volatility units, different anchor.

## Tests

- 10 unit tests on the generator: default mode, constructor override, runtime swap, directional contrast on a market drifting toward NO (fixed_50 fires LONG, sma stays near-zero), stable series near 0.5 (modes don't contradict), z-score directional bias for `price << 0.5` and `price >> 0.5`, regression on the extreme-price gate.
- 7 wiring tests on `OptimizationScheduler`: param-space presence (full + refinement), mapping forward, persistence to trading_config, invalid-value rejection.
- 63 total tests pass between affected files. Tsc clean.

## Test plan

- [ ] Watch `[server] mean_reversion.referenceMode hydrated from DB: ...` log on next deploy (won't fire first time — config row absent).
- [ ] Next Optuna incremental cycle (~6h): expect `meanReversion.referenceMode` to appear in trial params logs.
- [ ] After first OOS pass: `[OptimizationScheduler] mean_reversion.reference_mode = X` log + `Live-updated SignalEngine mean_reversion.referenceMode`.
- [ ] After 5-7d post-flip: re-run direction distribution diagnostic. If `fixed_50` is the better anchor empirically, expect LONG:SHORT ratio to drop materially (combined effect with PR #188 + #189).

🤖 Generated with [Claude Code](https://claude.com/claude-code)