### PR TITLE
feat(signals): add ResolutionPriorGenerator — terminal-resolution prior

### DIFF
--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -433,6 +433,17 @@ async function main(): Promise<void> {
       `);
       console.log('signal_weights.consensus_discount_floor row ensured');
 
+      // resolution_prior bootstrap row (PR after #190). Optuna writes the
+      // optimal weight after each successful OOS-passing cycle. Default 0.0
+      // so the generator is wired but inactive until Optuna provides
+      // empirical evidence of value.
+      await query(`
+        INSERT INTO signal_weights (signal_type, weight, market_type, is_enabled, min_confidence, updated_at)
+        VALUES ('resolution_prior', 0.0, '__global__', true, 0.0, NOW())
+        ON CONFLICT (signal_type, market_type) DO NOTHING;
+      `);
+      console.log('[server] signal_weights.resolution_prior row ensured');
+
       // direction_multiplier per-(market_type) bootstrap. Mirror init/028_*.sql
       // for existing VMs whose volume already initialized (so 028 won't re-run).
       // See docs/plans/2026-04-30-direction-multiplier-per-type-design.md.

--- a/packages/dashboard/src/services/BacktestService.ts
+++ b/packages/dashboard/src/services/BacktestService.ts
@@ -29,6 +29,7 @@ import {
   VolumeAnomalyGenerator,
   MultiLevelOFISignal,
   SpreadCompressionGenerator,
+  ResolutionPriorGenerator,
   PriceRangeWeightModifier,
   type ISignal,
   type OrderBookSnapshot,
@@ -82,6 +83,7 @@ export interface BacktestRequest {
     volumeAnomalyWeight?: number;
     mlofiWeight?: number;
     spreadCompressionWeight?: number;
+    resolutionPriorWeight?: number;
     minCombinedConfidence?: number;
     minCombinedStrength?: number;
     onlyDirection?: string | null;
@@ -203,6 +205,7 @@ export class BacktestService extends EventEmitter {
         volume_anomaly: cc?.volumeAnomalyWeight ?? 0,
         mlofi: cc?.mlofiWeight ?? 0,
         spread_compression: cc?.spreadCompressionWeight ?? 0,
+        resolution_prior: cc?.resolutionPriorWeight ?? 0,
         wallet_tracking: 0.3,
       };
       const combiner = new WeightedAverageCombiner(weights, cc ? {
@@ -674,6 +677,9 @@ export class BacktestService extends EventEmitter {
           break;
         case 'spread_compression':
           signals.push(new SpreadCompressionGenerator());
+          break;
+        case 'resolution_prior':
+          signals.push(new ResolutionPriorGenerator());
           break;
         default:
           console.warn(`[BacktestService] Unknown signal type: ${type}`);

--- a/packages/dashboard/src/services/OptimizationScheduler.test.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.test.ts
@@ -789,3 +789,29 @@ describe('mean_reversion.referenceMode wiring', () => {
     expect(tradingConfigRepo.set).not.toHaveBeenCalled();
   });
 });
+
+describe('resolution_prior wiring', () => {
+  it('OPTUNA_PARAM_SPACE includes combiner.resolutionPriorWeight in [0, 2]', () => {
+    const param = OPTUNA_PARAM_SPACE.find((p) => p.name === 'combiner.resolutionPriorWeight');
+    expect(param).toBeDefined();
+    expect(param?.type).toBe('float');
+    expect((param as any).low).toBe(0.0);
+    expect((param as any).high).toBe(2.0);
+  });
+
+  it('REFINEMENT_PARAM_SPACE includes combiner.resolutionPriorWeight (per-type cycles)', () => {
+    const param = REFINEMENT_PARAM_SPACE.find((p) => p.name === 'combiner.resolutionPriorWeight');
+    expect(param).toBeDefined();
+    expect(param?.type).toBe('float');
+  });
+
+  it('mapOptunaParamsToRequest forwards resolutionPriorWeight to combinerConfig', () => {
+    const scheduler = new OptimizationScheduler();
+    const request = (scheduler as any).mapOptunaParamsToRequest(
+      { 'combiner.resolutionPriorWeight': 0.7 },
+      new Date('2026-05-01'),
+      new Date('2026-05-10'),
+    );
+    expect(request.combinerConfig.resolutionPriorWeight).toBe(0.7);
+  });
+});

--- a/packages/dashboard/src/services/OptimizationScheduler.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.ts
@@ -55,6 +55,11 @@ export const OPTUNA_PARAM_SPACE: ParameterDef[] = [
   { name: 'combiner.volumeAnomalyWeight', type: 'float', low: 0.0, high: 2.0 },
   { name: 'combiner.mlofiWeight', type: 'float', low: 0.0, high: 2.0 },
   { name: 'combiner.spreadCompressionWeight', type: 'float', low: 0.0, high: 2.0 },
+  // Resolution prior — directional voice from time-to-end + price (no SMA
+  // anchor). Closes the LONG-bias path that mean_reversion+momentum miss in
+  // markets drifting toward NO/YES. Allow full [0, 2] range; OOS gate
+  // protects against bad applies.
+  { name: 'combiner.resolutionPriorWeight', type: 'float', low: 0.0, high: 2.0 },
   // Consensus discount floor (Sub-project B.2, see docs/plans/2026-04-25-signal-consensus-design.md).
   // Combiner-layer confidence multiplier driven by entropy across active generators.
   // 0.0 = full discount on disagreement; 1.0 = no-op. Live default in signal_weights is 0.5.
@@ -115,6 +120,7 @@ export const REFINEMENT_PARAM_SPACE: ParameterDef[] = [
   { name: 'combiner.volumeAnomalyWeight', type: 'float', low: 0.0, high: 2.0 },
   { name: 'combiner.mlofiWeight', type: 'float', low: 0.0, high: 2.0 },
   { name: 'combiner.spreadCompressionWeight', type: 'float', low: 0.0, high: 2.0 },
+  { name: 'combiner.resolutionPriorWeight', type: 'float', low: 0.0, high: 2.0 },
   { name: 'combiner.consensusDiscountFloor', type: 'float', low: 0.0, high: 1.0 },
   { name: 'risk.maxPositionSizePct', type: 'float', low: 3.0, high: 15.0 },
   { name: 'risk.stopLossPct', type: 'float', low: 8.0, high: 30.0 },
@@ -734,6 +740,7 @@ export class OptimizationScheduler {
         volumeAnomalyWeight: params['combiner.volumeAnomalyWeight'],
         mlofiWeight: params['combiner.mlofiWeight'],
         spreadCompressionWeight: params['combiner.spreadCompressionWeight'],
+        resolutionPriorWeight: params['combiner.resolutionPriorWeight'],
         minCombinedConfidence: params['combiner.minCombinedConfidence'],
         minCombinedStrength: params['combiner.minCombinedStrength'],
         onlyDirection: params['combiner.onlyDirection'],
@@ -1160,6 +1167,7 @@ export class OptimizationScheduler {
       'combiner.volumeAnomalyWeight': 'volume_anomaly',
       'combiner.mlofiWeight': 'mlofi',
       'combiner.spreadCompressionWeight': 'spread_compression',
+      'combiner.resolutionPriorWeight': 'resolution_prior',
       // Per-type dm (REFINEMENT_PARAM_SPACE only). Categorical {-1, +1} so the
       // generic clamp below trivially preserves the value. Min-lift gate
       // (OPTIMIZER_DM_FLIP_MIN_LIFT) gates flips when configured.

--- a/packages/dashboard/src/services/SignalEngine.ts
+++ b/packages/dashboard/src/services/SignalEngine.ts
@@ -32,6 +32,7 @@ import {
   PriceDivergenceGenerator,
   AttentionSpikeGenerator,
   NewsSentimentGenerator,
+  ResolutionPriorGenerator,
   WeightedAverageCombiner,
   DurationWeightModifier,
   PriceRangeWeightModifier,
@@ -199,6 +200,7 @@ export class SignalEngine extends EventEmitter {
     this.signals.set('volume_anomaly', new VolumeAnomalyGenerator());
     this.signals.set('spread_compression', new SpreadCompressionGenerator());
     this.signals.set('cross_market_corr', new CrossMarketCorrelationGenerator());
+    this.signals.set('resolution_prior', new ResolutionPriorGenerator());
 
     // External data signals
     this.signals.set('price_divergence', new PriceDivergenceGenerator());

--- a/packages/signals/src/index.ts
+++ b/packages/signals/src/index.ts
@@ -82,6 +82,11 @@ export {
 export { VolumeAnomalyGenerator } from './signals/market-structure/VolumeAnomalyGenerator.js';
 export { SpreadCompressionGenerator } from './signals/market-structure/SpreadCompressionGenerator.js';
 export { CrossMarketCorrelationGenerator } from './signals/market-structure/CrossMarketCorrelationGenerator.js';
+export {
+  ResolutionPriorGenerator,
+  DEFAULT_RESOLUTION_PRIOR_PARAMS,
+  type ResolutionPriorParams,
+} from './signals/market-structure/ResolutionPriorGenerator.js';
 
 // External Data Signals
 export { PriceDivergenceGenerator } from './signals/external/PriceDivergenceGenerator.js';
@@ -261,6 +266,7 @@ import { HawkesSignal } from './signals/microstructure/HawkesSignal.js';
 import { SentimentSignal } from './signals/sentiment/SentimentSignal.js';
 import { EventDrivenSignal } from './signals/event/EventDrivenSignal.js';
 import { RLSignal } from './signals/rl/RLSignal.js';
+import { ResolutionPriorGenerator } from './signals/market-structure/ResolutionPriorGenerator.js';
 import type { ISignal, SignalConfig } from './core/types/signal.types.js';
 
 const signalRegistry: Record<string, () => ISignal> = {
@@ -274,6 +280,7 @@ const signalRegistry: Record<string, () => ISignal> = {
   sentiment: () => new SentimentSignal(),
   event_driven: () => new EventDrivenSignal(),
   rl: () => new RLSignal(),
+  resolution_prior: () => new ResolutionPriorGenerator(),
 };
 
 /**

--- a/packages/signals/src/signals/market-structure/ResolutionPriorGenerator.test.ts
+++ b/packages/signals/src/signals/market-structure/ResolutionPriorGenerator.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ResolutionPriorGenerator,
+  DEFAULT_RESOLUTION_PRIOR_PARAMS,
+} from './ResolutionPriorGenerator.js';
+import type { SignalContext, PriceBar } from '../../core/types/signal.types.js';
+
+const NOW = new Date('2026-05-05T12:00:00Z');
+
+function bars(closes: number[]): PriceBar[] {
+  return closes.map((close, i) => ({
+    time: new Date(NOW.getTime() - (closes.length - i) * 60_000),
+    open: close,
+    high: close * 1.01,
+    low: close * 0.99,
+    close,
+    volume: 1000,
+    tradeCount: 1,
+  }));
+}
+
+function context(
+  closes: number[],
+  daysToResolution: number,
+): SignalContext {
+  const priceBars = bars(closes);
+  return {
+    market: {
+      id: 'mkt',
+      question: 'q',
+      isActive: true,
+      isResolved: false,
+      tokenIdYes: 'tok-yes',
+      endDate: new Date(NOW.getTime() + daysToResolution * 24 * 60 * 60 * 1000),
+    },
+    priceBars,
+    recentTrades: [],
+    currentTime: NOW,
+  };
+}
+
+describe('ResolutionPriorGenerator', () => {
+  describe('basic behaviour', () => {
+    it('signalId is "resolution_prior"', () => {
+      const gen = new ResolutionPriorGenerator();
+      expect(gen.signalId).toBe('resolution_prior');
+    });
+
+    it('uses sensible defaults: cutoffDays=14, minPriceDistance=0.05', () => {
+      expect(DEFAULT_RESOLUTION_PRIOR_PARAMS.cutoffDays).toBe(14);
+      expect(DEFAULT_RESOLUTION_PRIOR_PARAMS.minPriceDistance).toBe(0.05);
+    });
+
+    it('isReady returns false without an endDate', () => {
+      const gen = new ResolutionPriorGenerator();
+      const ctx = context([0.3], 5);
+      delete (ctx.market as { endDate?: Date }).endDate;
+      expect(gen.isReady(ctx)).toBe(false);
+    });
+  });
+
+  describe('LONG bias for price > 0.5 near expiry', () => {
+    it('emits LONG when price=0.85 and 2d to resolution', async () => {
+      const gen = new ResolutionPriorGenerator();
+      const result = await gen.compute(context([0.85], 2));
+      expect(result).not.toBeNull();
+      expect(result!.direction).toBe('LONG');
+      expect(result!.strength).toBeGreaterThan(0);
+    });
+
+    it('strength scales with time proximity (closer to expiry = stronger)', async () => {
+      const gen = new ResolutionPriorGenerator();
+      const close = await gen.compute(context([0.85], 1));
+      const far = await gen.compute(context([0.85], 12));
+      expect(close).not.toBeNull();
+      expect(far).not.toBeNull();
+      expect(close!.strength).toBeGreaterThan(far!.strength);
+    });
+
+    it('strength scales with price distance (extremes = stronger)', async () => {
+      const gen = new ResolutionPriorGenerator();
+      const extreme = await gen.compute(context([0.95], 5));
+      const moderate = await gen.compute(context([0.65], 5));
+      expect(extreme).not.toBeNull();
+      expect(moderate).not.toBeNull();
+      expect(extreme!.strength).toBeGreaterThan(moderate!.strength);
+    });
+  });
+
+  describe('SHORT bias for price < 0.5 near expiry', () => {
+    it('emits SHORT when price=0.20 and 3d to resolution', async () => {
+      const gen = new ResolutionPriorGenerator();
+      const result = await gen.compute(context([0.20], 3));
+      expect(result).not.toBeNull();
+      expect(result!.direction).toBe('SHORT');
+      expect(result!.strength).toBeLessThan(0);
+    });
+
+    it('emits SHORT for price=0.10 with 1d (very strong)', async () => {
+      const gen = new ResolutionPriorGenerator();
+      const result = await gen.compute(context([0.10], 1));
+      expect(result).not.toBeNull();
+      expect(result!.direction).toBe('SHORT');
+      expect(Math.abs(result!.strength)).toBeGreaterThan(0.7);
+    });
+  });
+
+  describe('null/skip cases', () => {
+    it('returns null when daysToResolution > cutoffDays', async () => {
+      const gen = new ResolutionPriorGenerator();
+      expect(await gen.compute(context([0.20], 30))).toBeNull();
+    });
+
+    it('returns null when market already expired (daysToResolution <= 0)', async () => {
+      const gen = new ResolutionPriorGenerator();
+      expect(await gen.compute(context([0.20], 0))).toBeNull();
+      expect(await gen.compute(context([0.20], -1))).toBeNull();
+    });
+
+    it('returns null when price is at the coin-flip prior (within minPriceDistance)', async () => {
+      const gen = new ResolutionPriorGenerator();
+      expect(await gen.compute(context([0.50], 5))).toBeNull();
+      expect(await gen.compute(context([0.48], 5))).toBeNull();
+      expect(await gen.compute(context([0.52], 5))).toBeNull();
+    });
+
+    it('returns null at extreme prices already at resolution (0 / 1)', async () => {
+      const gen = new ResolutionPriorGenerator();
+      expect(await gen.compute(context([0.0], 5))).toBeNull();
+      expect(await gen.compute(context([1.0], 5))).toBeNull();
+    });
+
+    it('returns null when no price bars available', async () => {
+      const gen = new ResolutionPriorGenerator();
+      const ctx = context([], 5);
+      expect(await gen.compute(ctx)).toBeNull();
+    });
+
+    it('returns null when no endDate set on market', async () => {
+      const gen = new ResolutionPriorGenerator();
+      const ctx = context([0.20], 5);
+      delete (ctx.market as { endDate?: Date }).endDate;
+      expect(await gen.compute(ctx)).toBeNull();
+    });
+  });
+
+  describe('strength bounds', () => {
+    it('|strength| stays within [0, 1] across the parameter ranges', async () => {
+      const gen = new ResolutionPriorGenerator();
+      for (const price of [0.05, 0.20, 0.40, 0.60, 0.80, 0.95]) {
+        for (const days of [0.1, 1, 5, 10, 13]) {
+          const result = await gen.compute(context([price], days));
+          if (result) {
+            expect(Math.abs(result.strength)).toBeLessThanOrEqual(1);
+            expect(Math.abs(result.strength)).toBeGreaterThanOrEqual(0);
+          }
+        }
+      }
+    });
+
+    it('confidence stays within [0, 1]', async () => {
+      const gen = new ResolutionPriorGenerator();
+      for (const price of [0.05, 0.20, 0.80, 0.95]) {
+        for (const days of [0.1, 5, 13]) {
+          const result = await gen.compute(context([price], days));
+          if (result) {
+            expect(result.confidence).toBeGreaterThanOrEqual(0);
+            expect(result.confidence).toBeLessThanOrEqual(1);
+          }
+        }
+      }
+    });
+  });
+
+  describe('config overrides', () => {
+    it('accepts a smaller cutoffDays', async () => {
+      const gen = new ResolutionPriorGenerator({ cutoffDays: 5 });
+      expect(await gen.compute(context([0.20], 6))).toBeNull();
+      expect(await gen.compute(context([0.20], 4))).not.toBeNull();
+    });
+
+    it('accepts a larger minPriceDistance', async () => {
+      const gen = new ResolutionPriorGenerator({ minPriceDistance: 0.30 });
+      // priceDistance is |price - 0.5| / 0.5. minPriceDistance=0.30 → require
+      // |price - 0.5| >= 0.15 → price ∉ (0.35, 0.65).
+      expect(await gen.compute(context([0.42], 5))).toBeNull();   // 0.16 < 0.30
+      expect(await gen.compute(context([0.15], 5))).not.toBeNull(); // 0.70 > 0.30
+    });
+  });
+
+  describe('metadata', () => {
+    it('emits the inputs as metadata for downstream debug', async () => {
+      const gen = new ResolutionPriorGenerator();
+      const result = await gen.compute(context([0.20], 3));
+      expect(result?.metadata).toMatchObject({
+        currentPrice: 0.20,
+        daysToResolution: expect.any(Number),
+        priceDistance: expect.any(Number),
+        timeProximity: expect.any(Number),
+      });
+    });
+  });
+});

--- a/packages/signals/src/signals/market-structure/ResolutionPriorGenerator.ts
+++ b/packages/signals/src/signals/market-structure/ResolutionPriorGenerator.ts
@@ -1,0 +1,122 @@
+import { BaseSignal } from '../../core/base/BaseSignal.js';
+import type {
+  SignalContext,
+  SignalOutput,
+} from '../../core/types/signal.types.js';
+
+export interface ResolutionPriorParams extends Record<string, unknown> {
+  /**
+   * Maximum days to resolution at which the generator still fires. Beyond
+   * this window the prior contains too little information vs price-action
+   * signals — return null instead of emitting weak noise. Default 14 days.
+   */
+  cutoffDays: number;
+  /**
+   * Minimum |price - 0.5| to fire. Markets near the coin-flip prior have no
+   * directional content from the resolution prior. Default 0.05 (i.e. price
+   * outside [0.45, 0.55]).
+   */
+  minPriceDistance: number;
+  /**
+   * Minimum strength to emit the signal. Default 0.05 — the same low gate
+   * used elsewhere in the system; the combiner threshold filters further.
+   */
+  minStrength: number;
+}
+
+export const DEFAULT_RESOLUTION_PRIOR_PARAMS: ResolutionPriorParams = {
+  cutoffDays: 14,
+  minPriceDistance: 0.05,
+  minStrength: 0.05,
+};
+
+/**
+ * ResolutionPriorGenerator
+ *
+ * Codifies the terminal-resolution prior of a binary prediction market. As
+ * a market approaches its end date, price → outcome (0 or 1). A market
+ * trading at 0.20 with two days to expiry has a strong prior toward NO;
+ * mean-reversion / SMA-based generators read the same information as
+ * "buy the dip" because their reference is the rolling average. This
+ * generator gives the system a directional voice that is *not* anchored
+ * to recent price action.
+ *
+ * Mathematical structure:
+ *
+ *   - daysToResolution > cutoffDays  → null (prior too weak)
+ *   - daysToResolution ≤ 0           → null (market expired)
+ *   - direction       = price > 0.5 ? 'LONG' : 'SHORT'
+ *   - priceDistance   = clamp(|price - 0.5| / 0.5, 0, 1)
+ *   - timeProximity   = 1 - daysToResolution / cutoffDays
+ *   - strength        = priceDistance × timeProximity × sign(direction)
+ *   - confidence      = 0.4 + 0.5 × priceDistance × timeProximity
+ *
+ * Strength is signed to match the SignalOutput convention (positive = LONG,
+ * negative = SHORT). `confidence` floor is 0.4 so the generator contributes
+ * meaningfully to the combiner consensus computation when it does fire.
+ */
+export class ResolutionPriorGenerator extends BaseSignal<ResolutionPriorParams> {
+  readonly signalId = 'resolution_prior';
+  readonly name = 'Resolution Prior';
+  readonly description =
+    'Codifies the terminal-resolution prior — markets drift to 0/1 near expiry';
+
+  protected parameters: ResolutionPriorParams;
+
+  constructor(config?: Partial<ResolutionPriorParams>) {
+    super();
+    this.parameters = {
+      ...DEFAULT_RESOLUTION_PRIOR_PARAMS,
+      ...config,
+    };
+  }
+
+  getRequiredLookback(): number {
+    return 0;
+  }
+
+  isReady(context: SignalContext): boolean {
+    return Boolean(context.market.endDate) && context.priceBars.length > 0;
+  }
+
+  async compute(context: SignalContext): Promise<SignalOutput | null> {
+    const { cutoffDays, minPriceDistance, minStrength } = this.parameters;
+    const endDate = context.market.endDate;
+    if (!endDate) return null;
+
+    const daysToResolution =
+      (endDate.getTime() - context.currentTime.getTime()) / (1000 * 60 * 60 * 24);
+
+    if (daysToResolution <= 0 || daysToResolution > cutoffDays) {
+      return null;
+    }
+
+    const bars = context.priceBars;
+    if (bars.length === 0) return null;
+    const currentPrice = bars[bars.length - 1].close;
+    if (currentPrice <= 0 || currentPrice >= 1) return null;
+
+    const priceDistance = Math.min(1, Math.abs(currentPrice - 0.5) / 0.5);
+    if (priceDistance < minPriceDistance) return null;
+
+    const timeProximity = 1 - daysToResolution / cutoffDays;
+    const direction = currentPrice > 0.5 ? 'LONG' : 'SHORT';
+    const directionSign = currentPrice > 0.5 ? 1 : -1;
+    const magnitude = priceDistance * timeProximity;
+    const strength = magnitude * directionSign;
+
+    if (Math.abs(strength) < minStrength) return null;
+
+    const confidence = Math.min(1, 0.4 + 0.5 * magnitude);
+
+    return this.createOutput(context, direction, strength, confidence, {
+      features: [currentPrice, priceDistance, timeProximity],
+      metadata: {
+        currentPrice,
+        daysToResolution,
+        priceDistance,
+        timeProximity,
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary

New signal generator that codifies the binary prediction-market terminal-resolution prior. Markets drifting toward NO (price → 0) or YES (price → 1) near expiry generate informative directional signals that no SMA-anchored generator can produce — by definition, mean_reversion and momentum reference recent price, while the resolution prior references the asymmetric terminal distribution.

## Mathematical structure

```
daysToResolution > cutoffDays  → null (prior too weak)
daysToResolution ≤ 0           → null (market expired)
direction       = price > 0.5 ? 'LONG' : 'SHORT'
priceDistance   = clamp(|price - 0.5| / 0.5, 0, 1)
timeProximity   = 1 - daysToResolution / cutoffDays
strength        = priceDistance × timeProximity × sign(direction)
confidence      = clamp(0.4 + 0.5 × magnitude, 0, 1)
```

A market at price=0.20 with 1d to expiry: priceDistance=0.6, timeProximity≈1, strength≈−0.6 → **SHORT with high conviction**. The same market read by `mean_reversion` would say "price < SMA, buy the dip" → LONG. They directly disagree, which is the point.

Defaults: `cutoffDays=14`, `minPriceDistance=0.05`, `minStrength=0.05`.

## Why now

Closes the second of three open follow-ups from `project_optimizer_epoch_reset.md` ("Resolution-prior generator: no existe. Markets cerca de expiry con price extremo necesitan un signal que codifique el prior terminal"). With PR #188 (epoch + reset), #189 (PriceRangeWeightModifier matrix) and #190 (mean_reversion referenceMode), Optuna already has many levers to optimize post-flip. This adds one more — a structurally-different directional voice — so if the LONG bias persists after the price-action levers re-tune, Optuna has a non-SMA-anchored generator to lean on.

## Architecture

```
ResolutionPriorGenerator → SignalEngine (live) + BacktestService (backtest)
   → combiner.resolutionPriorWeight  (0.0 default — Optuna fills it)
   → OPTUNA_PARAM_SPACE + REFINEMENT_PARAM_SPACE
   → mapOptunaParamsToRequest
   → WEIGHT_PARAM_MAP routes Optuna's choice to signal_weights[resolution_prior]
   → boot seeds the signal_weights row at 0.0
```

The seed at 0.0 means the generator runs but contributes nothing until Optuna provides empirical evidence of value. Standard pattern from previous additions (`spread_compression`, etc.).

## Tests

- 19 unit tests on the generator: default config, LONG bias for price > 0.5 near expiry (with strength scaling), SHORT bias for price < 0.5, null cases (beyond cutoff, expired, near 0.5, extreme prices, missing bars, missing endDate), strength/confidence bounds, config overrides, metadata.
- 3 wiring tests on `OptimizationScheduler`: param-space presence (full + refinement), mapping forward.
- 75/75 passing across affected files. Tsc clean.

## Test plan

- [ ] `[server] signal_weights.resolution_prior row ensured` log on next deploy.
- [ ] `[SignalEngine] Initialized 12 signal generators` (was 11).
- [ ] After ~6h: Optuna trial logs include `combiner.resolutionPriorWeight`.
- [ ] After OOS pass: `signal_weights.resolution_prior` row updated to a non-zero value, `signal_weights_history` row with `change_reason='optimization-...'`.
- [ ] After 5-7d post-flip: re-run direction distribution diagnostic. If `resolution_prior` is contributing meaningfully, expect more SHORT signals on event_financial markets near expiry with low prices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)