### PR TITLE
fix(optimizer): disable OPTIMIZER_EPOCH_START — abort-loop bug

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -170,12 +170,21 @@ services:
       # losses, which were structurally inverse signals (counter-WR=93.9%).
       # Remove once the rolling 7-day window has cleared (after 2026-05-11).
       EXECUTOR_LOSS_GATE_EPOCH: "2026-05-04T09:55:00Z"
-      # OPTIMIZER_EPOCH_START: floors Optuna training/OOS windows to the dm
-      # flip boundary (PR #178). Pre-flip backtest data trains the optimizer
-      # toward the wrong sign for every per-type weight; with this floor set
-      # only post-flip trades feed the optimizer. Remove once the rolling 14d
-      # training window has aged past the epoch organically (~2026-05-18).
-      OPTIMIZER_EPOCH_START: "2026-05-04T09:55:00Z"
+      # OPTIMIZER_EPOCH_START — DISABLED 2026-05-06.
+      # Originally set to floor training/OOS windows to the dm flip boundary
+      # (PR #188). Made redundant by the SQL reset of signal_weights to
+      # baseline 1.0 the same day: trial Optuna runs always use dm=+1 (global
+      # is hard-pinned) and signal-raw outputs are independent of dm, so the
+      # epoch filter was excluding 4d of usable training data without
+      # protective benefit. Empirically the filter aborted every Optuna
+      # cycle for 14h+, leaving PRs #189-#191 inert. Re-enable only if a
+      # future regression is traced back to pre-flip contamination.
+      # OPTIMIZER_EPOCH_START: "2026-05-04T09:55:00Z"
+      # Min-lift gate for direction_multiplier per-type flips. Optuna can
+      # only flip dm{-1,+1} per market_type when the trial's Sharpe exceeds
+      # the previous best by this much. Activated alongside epoch removal so
+      # mixed pre/post-flip backtests cannot re-flip dm spuriously.
+      OPTIMIZER_DM_FLIP_MIN_LIFT: "0.10"
       # Gate 0e: EventOTMGate — block opens on event_financial markets near expiry
       # with extreme-band prices. See docs/plans/2026-04-21-event-otm-gate-design.md
       EXECUTOR_EVENT_OTM_MARKET_TYPES: "event_financial"


### PR DESCRIPTION
## Summary

PR #188 added an epoch floor on Optuna training/OOS windows. With `oosPeriodDays=4` and `epoch=2026-05-04 09:55`, `endDate = now − 4d` lands BEFORE the epoch until 2026-05-08, so every cycle aborts. 14h+ post-deploy of #189-#191 produced zero updates to `signal_weights`, `price_range_matrix`, or `trading_config`. PRs #189-#191 are inert.

The filter is redundant once the same-day SQL reset of `signal_weights` to baseline 1.0 is in place. Trials run with `dm=+1` (global pinned); signal-raw outputs are independent of `dm`; mixed training data converges to régime-current weights.

## Mitigation against residual risk

`REFINEMENT_PARAM_SPACE` has `direction_multiplier` as categorical `{-1, +1}` per-type. A mixed backtest could spuriously flip back to -1. We activate `OPTIMIZER_DM_FLIP_MIN_LIFT=0.10` so any flip requires a Sharpe lift of at least 0.10 over the previous best.

## Test plan

- [ ] Watch for `[OptimizationScheduler] Training period: ... (10.0 days)` log on next cycle (no "Skipping" line).
- [ ] After ~30-60min: at least one OOS-passing cycle with `signal_weights_history` rows or `optimization_runs` updates.
- [ ] No spurious dm flips: `direction_multiplier` rows in `signal_weights` stay at +1.0 unless a flip's lift exceeds 0.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dashboard API service optimizer configuration to adjust threshold values and disable certain startup behaviors. These changes refine how the service processes data during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->