### PR TITLE
fix(optimizer): guard empty Optuna params + tighten min-lift gate baseline

### DIFF
--- a/packages/dashboard/src/services/OptimizationScheduler.test.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.test.ts
@@ -815,3 +815,139 @@ describe('resolution_prior wiring', () => {
     expect(request.combinerConfig.resolutionPriorWeight).toBe(0.7);
   });
 });
+
+describe('Optuna empty-params guard (2026-05-06 cycle 2 bug)', () => {
+  it('treats empty {} params as failed trial — does not push to results, increments consecutive failures', async () => {
+    const scheduler = new OptimizationScheduler();
+    const suggest = vi.fn().mockResolvedValue({ trialId: 0, params: {} });
+    const report = vi.fn();
+    const ping = vi.fn().mockResolvedValue(true);
+    const createOptimizer = vi.fn().mockResolvedValue('opt-1');
+    const deleteOptimizer = vi.fn().mockResolvedValue(undefined);
+
+    (scheduler as any).optunaClient = { suggest, report, ping, createOptimizer, deleteOptimizer };
+
+    // Stub fetchHistoricalData to return data so the run isn't aborted early.
+    const fetchHistoricalData = vi.fn().mockResolvedValue([{ marketId: 'mkt' } as any]);
+    (scheduler as any).backtestService = {
+      fetchHistoricalData,
+      runBacktest: vi.fn(),
+    };
+
+    const results = await (scheduler as any).runOptunaOptimization(5, 'incremental', 'crypto_intraday');
+
+    // 3 consecutive empty-params trials → loop aborts → 0 results
+    expect(results).toEqual([]);
+    expect(report).not.toHaveBeenCalled();
+  });
+
+  it('accepts non-empty params normally', async () => {
+    const scheduler = new OptimizationScheduler();
+    const suggest = vi.fn()
+      .mockResolvedValueOnce({ trialId: 0, params: { 'combiner.momentumWeight': 0.5 } })
+      .mockResolvedValueOnce({ trialId: 1, params: { 'combiner.momentumWeight': 0.7 } });
+    const report = vi.fn().mockResolvedValue(undefined);
+    const ping = vi.fn().mockResolvedValue(true);
+    const createOptimizer = vi.fn().mockResolvedValue('opt-2');
+    const deleteOptimizer = vi.fn().mockResolvedValue(undefined);
+    const getBest = vi.fn().mockResolvedValue({ best_params: {}, best_score: 0 });
+    (scheduler as any).optunaClient = { suggest, report, ping, createOptimizer, deleteOptimizer, getBest };
+
+    (scheduler as any).backtestService = {
+      fetchHistoricalData: vi.fn().mockResolvedValue([{ marketId: 'mkt' } as any]),
+      runBacktest: vi.fn().mockResolvedValue({
+        result: {
+          metrics: { sharpeRatio: 0.3, totalReturn: 0.1, maxDrawdown: 0 },
+          trades: [],
+        },
+      }),
+    };
+
+    const results = await (scheduler as any).runOptunaOptimization(2, 'incremental', 'event_financial');
+    expect(results).toHaveLength(2);
+    expect(report).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('Min-lift gate — undefined baseline edge case (2026-05-06 cycle 2 bug)', () => {
+  const ENV_KEY = 'OPTIMIZER_DM_FLIP_MIN_LIFT';
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env[ENV_KEY];
+  });
+
+  it('blocks dm flip when previousBestSharpe is undefined (post-ratchet-reset case)', async () => {
+    process.env[ENV_KEY] = '0.5';
+    vi.mocked(signalWeightsRepo.getPerType).mockResolvedValue(1.0);  // current dm = +1
+    const scheduler = new OptimizationScheduler();
+    (scheduler as any).state.bestSharpePerType = {};  // ratchet reset → undefined
+    (scheduler as any)._lastOOSResult = {
+      passed: true, sharpeOOS: 0.5, drawdownOOS: 0.05, tradesOOS: 30, winRateOOS: 0.6, marketsEvaluated: 12,
+    };
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: vi.fn() }));
+
+    await (scheduler as any).updateStrategy({
+      params: { 'combiner.directionMultiplier': -1 },
+      sharpe: 0.1,
+      totalReturn: 0.05,
+      trades: 10,
+    }, 'event_financial');
+
+    // dm flip must NOT have been written — the gate's "no baseline" branch
+    // should have hit `continue` and skipped this signal_type.
+    const dmCalls = vi.mocked(signalWeightsRepo.updatePerType).mock.calls.filter(
+      ([signalType]) => signalType === 'direction_multiplier'
+    );
+    expect(dmCalls).toHaveLength(0);
+  });
+
+  it('proceeds with flip when previousBestSharpe is defined and lift >= min_lift', async () => {
+    process.env[ENV_KEY] = '0.1';
+    vi.mocked(signalWeightsRepo.getPerType).mockResolvedValue(1.0);
+    const scheduler = new OptimizationScheduler();
+    (scheduler as any).state.bestSharpePerType = { event_financial: 0.05 };  // baseline 0.05
+    (scheduler as any)._lastOOSResult = {
+      passed: true, sharpeOOS: 0.5, drawdownOOS: 0.05, tradesOOS: 30, winRateOOS: 0.6, marketsEvaluated: 12,
+    };
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: vi.fn() }));
+
+    await (scheduler as any).updateStrategy({
+      params: { 'combiner.directionMultiplier': -1 },
+      sharpe: 0.30,  // lift = 0.30 - 0.05 = 0.25 ≥ 0.1 → flip allowed
+      totalReturn: 0.05,
+      trades: 10,
+    }, 'event_financial');
+
+    const dmCalls = vi.mocked(signalWeightsRepo.updatePerType).mock.calls.filter(
+      ([signalType]) => signalType === 'direction_multiplier'
+    );
+    expect(dmCalls).toHaveLength(1);
+    expect(dmCalls[0][2]).toBe(-1);
+  });
+
+  it('blocks flip when previousBestSharpe is defined but lift < min_lift', async () => {
+    process.env[ENV_KEY] = '0.5';
+    vi.mocked(signalWeightsRepo.getPerType).mockResolvedValue(1.0);
+    const scheduler = new OptimizationScheduler();
+    (scheduler as any).state.bestSharpePerType = { event_financial: 0.20 };
+    (scheduler as any)._lastOOSResult = {
+      passed: true, sharpeOOS: 0.5, drawdownOOS: 0.05, tradesOOS: 30, winRateOOS: 0.6, marketsEvaluated: 12,
+    };
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: vi.fn() }));
+
+    await (scheduler as any).updateStrategy({
+      params: { 'combiner.directionMultiplier': -1 },
+      sharpe: 0.30,  // lift = 0.30 - 0.20 = 0.10 < 0.5 → block
+      totalReturn: 0.05,
+      trades: 10,
+    }, 'event_financial');
+
+    const dmCalls = vi.mocked(signalWeightsRepo.updatePerType).mock.calls.filter(
+      ([signalType]) => signalType === 'direction_multiplier'
+    );
+    expect(dmCalls).toHaveLength(0);
+  });
+});

--- a/packages/dashboard/src/services/OptimizationScheduler.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.ts
@@ -656,6 +656,21 @@ export class OptimizationScheduler {
           const { trialId, params } = await client.suggest(optimizerId);
           console.log(`[OptimizationScheduler] Trial ${i + 1}/${iterations} (id=${trialId}):`, JSON.stringify(params));
 
+          // Guard against the Optuna server returning empty params (observed
+          // 2026-05-06 cycle 2 for crypto_intraday — every trial returned {}
+          // and the resulting "winner" had no params to persist, silently
+          // no-op'ing updateStrategy). Treat as a failed trial so the
+          // consecutive-failure counter trips and we abort early.
+          if (!params || typeof params !== 'object' || Object.keys(params).length === 0) {
+            console.warn(`[OptimizationScheduler] Trial ${i + 1} (id=${trialId}): empty params — treating as failed trial`);
+            consecutiveFailures++;
+            if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+              console.error(`[OptimizationScheduler] ${MAX_CONSECUTIVE_FAILURES} consecutive failures — Optuna server returned empty params, aborting run`);
+              break;
+            }
+            continue;
+          }
+
           // 2. Map Optuna params → BacktestRequest
           const request = this.mapOptunaParamsToRequest(params, startDate, endDate);
 
@@ -1194,7 +1209,21 @@ export class OptimizationScheduler {
               const currentDm = await signalWeightsRepo.getPerType('direction_multiplier', marketType);
               if (currentDm !== null && currentDm !== weight) {
                 const prev = previousBestSharpe;
-                const lift = (result.sharpe ?? 0) - (prev ?? -Infinity);
+                // Block the flip when no baseline Sharpe exists yet — the
+                // OOS gate has only validated this single trial without
+                // anything to compare against. Letting it flip would defeat
+                // the purpose of the min-lift gate (observed 2026-05-06: a
+                // post-ratchet-reset cycle flipped event_financial dm to -1
+                // because lift=Infinity bypassed Number.isFinite). Wait one
+                // more cycle to establish baseline before allowing a flip.
+                if (prev === undefined || !Number.isFinite(prev)) {
+                  console.log(
+                    `[OptimizationScheduler] Skipping direction_multiplier flip for ${marketType}: ` +
+                    `no baseline Sharpe yet (current=${currentDm}, candidate=${weight}, min_lift=${minLift})`
+                  );
+                  continue;
+                }
+                const lift = (result.sharpe ?? 0) - prev;
                 if (Number.isFinite(lift) && lift < minLift) {
                   console.log(
                     `[OptimizationScheduler] Skipping direction_multiplier flip for ${marketType}: ` +


### PR DESCRIPTION
## Summary

Two bugs surfaced during validation of PRs #188-#191 cycle 2 today.

### 1) Empty-params silent no-op

Optuna server returned `params={}` for every trial of `crypto_intraday`. All 15 trials produced identical `Sharpe=0.06` (default-config backtest, no parameter exploration). The "winner" had `params={}`, so `updateStrategy` logged `Persisting per-type weights for crypto_intraday...` but every subsequent block silently no-op'd:

- `cdfRaw = result.params['combiner.consensusDiscountFloor']` → undefined → skip
- `WEIGHT_PARAM_MAP` loop → all `result.params[paramKey]` undefined → skip everything
- `persistPriceRangeMultipliers({})` → all `setBand` calls skip (raw not a number)
- `persistMeanReversionReferenceMode({})` → raw not 'sma'|'fixed_50' → skip

Net: zero rows written, no error logged, flow continued to next type.

**Fix**: guard at trial-suggest time. Empty params → warn, treat as failed trial, increment `consecutiveFailures`. Three in a row → run aborts as designed by `MAX_CONSECUTIVE_FAILURES`.

### 2) Min-lift gate fails safe-open with undefined baseline

```typescript
const prev = previousBestSharpe;            // undefined post-ratchet-reset
const lift = (result.sharpe ?? 0) - (prev ?? -Infinity);  // Infinity
if (Number.isFinite(lift) && lift < minLift) {  // Number.isFinite(Infinity) === false
  // skip block — but Infinity is not finite, so this branch is dead
}
// flip proceeds
```

Observed 2026-05-06: after I reset `best_sharpe_per_type = {}` to unblock applies, event_financial trial with `IS Sharpe 0.095` flipped `dm` to `-1` despite `OPTIMIZER_DM_FLIP_MIN_LIFT=0.5`. The flip survived because `lift=Infinity` bypassed the finite check.

**Fix**: explicit early-return when `prev` is undefined or non-finite. Block the flip until a baseline is established. The first OOS-passing cycle persists the baseline; the second can consider a flip.

## Test plan

- [ ] Watch logs on next cycle for `Trial X: empty params — treating as failed trial` if Optuna server hiccups again.
- [ ] After a state reset (ratchet wipe), verify `dm` flips are blocked with `Skipping direction_multiplier flip for X: no baseline Sharpe yet` log.
- [ ] No spurious dm flips on cycles where IS Sharpe is below the previous baseline + min_lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed optimization scheduler to properly handle edge cases when optimizer returns invalid parameter sets, now treating them as failed attempts and aborting after threshold.
  * Fixed baseline validation logic to prevent calculation errors when baseline data is unavailable, improving stability during strategy updates.

* **Tests**
  * Added comprehensive test coverage for empty parameter handling and undefined baseline scenarios in optimization workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->