### PR TITLE
fix(optimizer): sync per-type dm to trading_config policy (where runtime reads)

### DIFF
--- a/packages/dashboard/src/services/OptimizationScheduler.test.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.test.ts
@@ -927,6 +927,69 @@ describe('Min-lift gate — undefined baseline edge case (2026-05-06 cycle 2 bug
     expect(dmCalls[0][2]).toBe(-1);
   });
 
+  it('syncs direction_multiplier_policy in trading_config when dm flip is applied', async () => {
+    process.env[ENV_KEY] = '0.05';
+    vi.mocked(signalWeightsRepo.getPerType).mockResolvedValue(1.0);
+    // Existing policy: dm=+1 across the board
+    vi.mocked(tradingConfigRepo.get).mockResolvedValue({
+      global: 1.0,
+      perMarketType: { event_financial: 1, event_long: 1 },
+      segments: [],
+    });
+    vi.mocked(tradingConfigRepo.set).mockClear();
+
+    const scheduler = new OptimizationScheduler();
+    (scheduler as any).state.bestSharpePerType = { event_financial: 0.05 };
+    (scheduler as any)._lastOOSResult = {
+      passed: true, sharpeOOS: 0.5, drawdownOOS: 0.05, tradesOOS: 30, winRateOOS: 0.6, marketsEvaluated: 12,
+    };
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: vi.fn() }));
+
+    await (scheduler as any).updateStrategy({
+      params: { 'combiner.directionMultiplier': -1 },
+      sharpe: 0.30,  // lift = 0.30 - 0.05 = 0.25 ≥ 0.05 → flip allowed
+      totalReturn: 0.05,
+      trades: 10,
+    }, 'event_financial');
+
+    // The sync function must have been called with the updated policy.
+    const dmPolicyCall = vi.mocked(tradingConfigRepo.set).mock.calls.find(
+      ([key]) => key === 'direction_multiplier_policy',
+    );
+    expect(dmPolicyCall).toBeDefined();
+    const updatedPolicy = dmPolicyCall![1] as { perMarketType: Record<string, number> };
+    expect(updatedPolicy.perMarketType.event_financial).toBe(-1);
+    // Other types untouched
+    expect(updatedPolicy.perMarketType.event_long).toBe(1);
+  });
+
+  it('does NOT sync direction_multiplier_policy when dm flip is blocked by gate', async () => {
+    process.env[ENV_KEY] = '0.5';
+    vi.mocked(signalWeightsRepo.getPerType).mockResolvedValue(1.0);
+    vi.mocked(tradingConfigRepo.set).mockClear();
+
+    const scheduler = new OptimizationScheduler();
+    (scheduler as any).state.bestSharpePerType = { event_financial: 0.20 };
+    (scheduler as any)._lastOOSResult = {
+      passed: true, sharpeOOS: 0.5, drawdownOOS: 0.05, tradesOOS: 30, winRateOOS: 0.6, marketsEvaluated: 12,
+    };
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: vi.fn() }));
+
+    await (scheduler as any).updateStrategy({
+      params: { 'combiner.directionMultiplier': -1 },
+      sharpe: 0.30,  // lift 0.10 < 0.5 → block
+      totalReturn: 0.05,
+      trades: 10,
+    }, 'event_financial');
+
+    const dmPolicyCall = vi.mocked(tradingConfigRepo.set).mock.calls.find(
+      ([key]) => key === 'direction_multiplier_policy',
+    );
+    expect(dmPolicyCall).toBeUndefined();
+  });
+
   it('blocks flip when previousBestSharpe is defined but lift < min_lift', async () => {
     process.env[ENV_KEY] = '0.5';
     vi.mocked(signalWeightsRepo.getPerType).mockResolvedValue(1.0);

--- a/packages/dashboard/src/services/OptimizationScheduler.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.ts
@@ -1247,6 +1247,17 @@ export class OptimizationScheduler {
             `optimization-${new Date().toISOString().slice(0, 10)}-${marketType}`
           );
           console.log(`[OptimizationScheduler] Updated signal weight: ${signalType}[${marketType}] = ${weight.toFixed(4)}`);
+
+          // direction_multiplier per-type live runtime is owned by
+          // DirectionResolver, which reads `direction_multiplier_policy.perMarketType[X]`
+          // from `trading_config` — NOT from `signal_weights`. Pre-2026-05-06
+          // every Optuna apply wrote to signal_weights only, so the runtime
+          // never picked up Optuna's per-type decisions (architectural
+          // mismatch). Sync the JSON policy here so the categorical {-1, +1}
+          // choice that the trial validated against actually takes effect.
+          if (signalType === 'direction_multiplier') {
+            await this.syncDirectionMultiplierPolicy(marketType, weight);
+          }
         } catch (err) {
           console.error(`[OptimizationScheduler] Failed to update weight ${signalType}:`, err);
         }
@@ -1265,6 +1276,38 @@ export class OptimizationScheduler {
     await this.persistMeanReversionReferenceMode(result.params);
 
     return { wasApplied: true };
+  }
+
+  /**
+   * Read-modify-write `trading_config.direction_multiplier_policy` so the
+   * per-type dm Optuna chose actually takes effect at runtime. Without this
+   * sync the value lives only in `signal_weights[direction_multiplier]`,
+   * which DirectionResolver does not read.
+   */
+  private async syncDirectionMultiplierPolicy(marketType: string, weight: number): Promise<void> {
+    if (!isDatabaseConfigured()) return;
+    try {
+      const current = await tradingConfigRepo.get<{
+        global?: number;
+        perMarketType?: Record<string, number>;
+        minMultiplier?: number;
+        maxMultiplier?: number;
+        segments?: unknown[];
+      }>('direction_multiplier_policy');
+      const base = current ?? { global: 1.0, perMarketType: {}, segments: [] };
+      const updated = {
+        ...base,
+        perMarketType: { ...(base.perMarketType ?? {}), [marketType]: weight },
+      };
+      await tradingConfigRepo.set(
+        'direction_multiplier_policy',
+        updated,
+        `optimization-${new Date().toISOString().slice(0, 10)}-${marketType}-dm-sync`,
+      );
+      console.log(`[OptimizationScheduler] Synced direction_multiplier_policy.perMarketType[${marketType}] = ${weight}`);
+    } catch (err) {
+      console.error(`[OptimizationScheduler] Failed to sync direction_multiplier_policy for ${marketType}:`, err);
+    }
   }
 
   private async persistMeanReversionReferenceMode(params: Record<string, any>): Promise<void> {


### PR DESCRIPTION
## Summary

Architectural mismatch: `OptimizationScheduler.updateStrategy` writes per-type `direction_multiplier` to `signal_weights`, but `DirectionResolver` (runtime) reads only from `trading_config.direction_multiplier_policy.perMarketType[X]`. Every Optuna per-type dm decision since per-type optimization shipped has been silently inert at runtime.

## Empirical confirmation

2026-05-06 cycle 2 wrote `signal_weights[direction_multiplier @ event_financial] = -1` after OOS PASS. But:

```
trading_config.direction_multiplier_policy.perMarketType.event_financial = 1
```

And `signal_predictions` post-flip showed only LONG signals on event_financial — runtime stayed at dm=+1.

## Fix

After `signalWeightsRepo.updatePerType('direction_multiplier', ...)`, read-modify-write the JSON policy in `trading_config`:

```typescript
if (signalType === 'direction_multiplier') {
  await this.syncDirectionMultiplierPolicy(marketType, weight);
}
```

`syncDirectionMultiplierPolicy` reads the current policy, patches only `perMarketType[marketType]`, writes back. Other keys (global, segments, minMultiplier, etc.) preserved.

Min-lift gate (PR #193) still upstream — sync runs only when flip is justified.

## Operational pairing

A SQL revert was applied to keep the two stores aligned:
```sql
UPDATE signal_weights SET weight=1
  WHERE signal_type='direction_multiplier' AND market_type='event_financial';
```
That value was inert at runtime (architectural mismatch) but the row was inconsistent with the policy.

## Tests

- 2 new cases: sync fires on legitimate flip, sync skipped when gate blocks. Plus regression tests for previous gate logic. 63/63 passing.

## Test plan

- [ ] Next Optuna apply that includes a dm flip → both `signal_weights` AND `trading_config.direction_multiplier_policy.perMarketType[X]` reflect the new value.
- [ ] `signal_predictions` post-flip should show direction inverted for that market_type.
- [ ] `[OptimizationScheduler] Synced direction_multiplier_policy.perMarketType[X] = N` log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)