### PR TITLE
feat(signals): persist per-generator predictions for edge analysis

### DIFF
--- a/packages/dashboard/src/database/repositories.test.ts
+++ b/packages/dashboard/src/database/repositories.test.ts
@@ -7,7 +7,7 @@ vi.mock('./index.js', () => ({
 }));
 
 import { query, transaction } from './index.js';
-import { paperPositionsRepo } from './repositories.js';
+import { paperPositionsRepo, generatorPredictionsRepo } from './repositories.js';
 
 describe('paperPositionsRepo.insert', () => {
   beforeEach(() => {
@@ -233,5 +233,84 @@ describe('paperPositionsRepo.openPositionAtomically', () => {
     // Third query is the INSERT — param index 8 is realized_pnl
     const insertParams = mockClient.query.mock.calls[2][1] as unknown[];
     expect(insertParams[8]).toBe(0);
+  });
+});
+
+describe('generatorPredictionsRepo.bulkCreate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(query).mockResolvedValue({ rows: [], rowCount: 0 } as any);
+  });
+
+  it('does nothing on empty input', async () => {
+    await generatorPredictionsRepo.bulkCreate([]);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('emits a single multi-row INSERT for N predictions', async () => {
+    await generatorPredictionsRepo.bulkCreate([
+      {
+        market_id: 'mkt1',
+        market_type: 'crypto_intraday',
+        signal_id: 'momentum',
+        direction: 'long',
+        strength: 0.5,
+        confidence: 0.7,
+        yes_price_at_signal: 0.42,
+        metadata: { foo: 'bar' },
+      },
+      {
+        market_id: 'mkt1',
+        market_type: 'crypto_intraday',
+        signal_id: 'mean_reversion',
+        direction: 'short',
+        strength: -0.6,
+        confidence: 0.8,
+        yes_price_at_signal: 0.42,
+      },
+    ]);
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const sql = vi.mocked(query).mock.calls[0][0] as string;
+    expect(sql).toContain('INSERT INTO generator_predictions');
+    expect(sql).toContain('($1, $2, $3, $4, $5, $6, $7, $8)');
+    expect(sql).toContain('($9, $10, $11, $12, $13, $14, $15, $16)');
+  });
+
+  it('serializes metadata as JSON and defaults to empty object', async () => {
+    await generatorPredictionsRepo.bulkCreate([
+      {
+        market_id: 'mkt1',
+        market_type: null,
+        signal_id: 'ofi',
+        direction: 'neutral',
+        strength: 0,
+        confidence: 0.5,
+        yes_price_at_signal: 0.5,
+        // no metadata field
+      },
+    ]);
+
+    const params = vi.mocked(query).mock.calls[0][1] as unknown[];
+    // 8 cols: market_id, market_type, signal_id, direction, strength, confidence, yes_price_at_signal, metadata
+    expect(params[7]).toBe('{}');
+  });
+
+  it('preserves signed strength values (negative for SHORT)', async () => {
+    await generatorPredictionsRepo.bulkCreate([
+      {
+        market_id: 'mkt1',
+        market_type: 'event_financial',
+        signal_id: 'hawkes',
+        direction: 'short',
+        strength: -0.85,
+        confidence: 0.9,
+        yes_price_at_signal: 0.7,
+      },
+    ]);
+
+    const params = vi.mocked(query).mock.calls[0][1] as unknown[];
+    expect(params[4]).toBe(-0.85); // strength preserved with negative sign
+    expect(params[3]).toBe('short'); // direction lowercase
   });
 });

--- a/packages/dashboard/src/database/repositories.ts
+++ b/packages/dashboard/src/database/repositories.ts
@@ -135,6 +135,75 @@ export const signalPredictionsRepo = {
 };
 
 // ============================================
+// Generator Predictions Repository
+// ============================================
+//
+// Captures the raw output of each individual signal generator (input to the
+// combiner). signal_predictions stores the *combined* signal; this stores its
+// inputs so we can measure per-generator edge without weighting/dm interference.
+
+export interface GeneratorPrediction {
+  id?: number;
+  time?: Date;
+  market_id: string;
+  market_type: string | null;
+  signal_id: string;
+  direction: 'long' | 'short' | 'neutral';
+  strength: number;
+  confidence: number;
+  yes_price_at_signal: number;
+  metadata?: Record<string, unknown>;
+}
+
+export const generatorPredictionsRepo = {
+  /**
+   * Batched insert for one market's per-generator outputs in a single cycle.
+   * Uses VALUES expansion (single round-trip) to keep cycle latency low.
+   */
+  async bulkCreate(predictions: GeneratorPrediction[]): Promise<void> {
+    if (predictions.length === 0) return;
+
+    const cols = ['market_id', 'market_type', 'signal_id', 'direction',
+      'strength', 'confidence', 'yes_price_at_signal', 'metadata'];
+    const placeholders: string[] = [];
+    const values: unknown[] = [];
+    predictions.forEach((p, i) => {
+      const base = i * cols.length;
+      placeholders.push(`($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7}, $${base + 8})`);
+      values.push(
+        p.market_id,
+        p.market_type,
+        p.signal_id,
+        p.direction,
+        p.strength,
+        p.confidence,
+        p.yes_price_at_signal,
+        JSON.stringify(p.metadata ?? {}),
+      );
+    });
+
+    await query(
+      `INSERT INTO generator_predictions
+       (${cols.join(', ')})
+       VALUES ${placeholders.join(', ')}`,
+      values,
+    );
+  },
+
+  async getRecentBySignal(signalId: string, hours = 24, limit = 1000): Promise<GeneratorPrediction[]> {
+    const result = await query<GeneratorPrediction>(
+      `SELECT * FROM generator_predictions
+       WHERE signal_id = $1
+         AND time >= NOW() - $2::interval
+       ORDER BY time DESC
+       LIMIT $3`,
+      [signalId, `${hours} hours`, limit],
+    );
+    return result.rows;
+  },
+};
+
+// ============================================
 // Signal Weights Repository
 // ============================================
 

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -517,6 +517,52 @@ async function main(): Promise<void> {
         throw err;
       }
 
+      // Per-generator predictions table (mirrors init/030_generator_predictions.sql).
+      // Init SQL only runs on first volume init, so existing VMs need this
+      // bootstrap to pick up the new table on next deploy.
+      try {
+        await query(`
+          CREATE TABLE IF NOT EXISTS generator_predictions (
+            id BIGSERIAL,
+            time TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            market_id VARCHAR(128) NOT NULL,
+            market_type VARCHAR(32),
+            signal_id VARCHAR(50) NOT NULL,
+            direction VARCHAR(8) NOT NULL,
+            strength NUMERIC(7,4) NOT NULL,
+            confidence NUMERIC(5,4) NOT NULL,
+            yes_price_at_signal NUMERIC(10,6) NOT NULL,
+            metadata JSONB DEFAULT '{}',
+            PRIMARY KEY (time, id)
+          );
+        `);
+        await query(`
+          SELECT create_hypertable('generator_predictions', 'time',
+            chunk_time_interval => INTERVAL '1 day',
+            if_not_exists => TRUE
+          );
+        `);
+        await query(`
+          CREATE INDEX IF NOT EXISTS idx_gen_predictions_signal_time
+            ON generator_predictions (signal_id, time DESC);
+        `);
+        await query(`
+          CREATE INDEX IF NOT EXISTS idx_gen_predictions_market_time
+            ON generator_predictions (market_id, time DESC);
+        `);
+        await query(`
+          ALTER TABLE generator_predictions SET (
+            timescaledb.compress_after = '3 days'
+          );
+        `);
+        await query(`
+          SELECT add_retention_policy('generator_predictions', INTERVAL '30 days', if_not_exists => TRUE);
+        `);
+        console.log('[server] generator_predictions table ensured');
+      } catch (err) {
+        console.error('[server] generator_predictions migration failed:', err);
+      }
+
       // Concentration gate prerequisite: cache σ(strength × confidence) per market_type
       // and refresh every 6 h. See docs/plans/2026-04-29-concentration-gate-design.md.
       try {

--- a/packages/dashboard/src/services/SignalEngine.ts
+++ b/packages/dashboard/src/services/SignalEngine.ts
@@ -11,7 +11,11 @@
 
 import { EventEmitter } from 'events';
 import { isDatabaseConfigured, query } from '../database/index.js';
-import { signalWeightsRepo, tradingConfigRepo } from '../database/repositories.js';
+import {
+  signalWeightsRepo,
+  tradingConfigRepo,
+  generatorPredictionsRepo,
+} from '../database/repositories.js';
 import { getTradingAutomation } from './TradingAutomation.js';
 import { getDbEventListener } from './DbEventListener.js';
 import type { SignalResult } from './AutoSignalExecutor.js';
@@ -490,6 +494,26 @@ export class SignalEngine extends EventEmitter {
 
     if (signalOutputs.length === 0) {
       return null;
+    }
+
+    // Persist per-generator outputs (input to the combiner) so per-generator
+    // edge can be measured independently of weighting/dm. Fire-and-forget:
+    // a DB failure must not block the cycle.
+    if (isDatabaseConfigured()) {
+      const yesPrice = market.currentPrice;
+      const records = signalOutputs.map((o) => ({
+        market_id: market.id,
+        market_type: market.marketType ?? null,
+        signal_id: o.signalId,
+        direction: o.direction.toLowerCase() as 'long' | 'short' | 'neutral',
+        strength: Number(o.strength),
+        confidence: Number(o.confidence),
+        yes_price_at_signal: yesPrice,
+        metadata: o.metadata ?? {},
+      }));
+      generatorPredictionsRepo.bulkCreate(records).catch((err) => {
+        console.error('[SignalEngine] Failed to persist generator predictions:', err);
+      });
     }
 
     // Apply duration-based weight scaling, then price-range scaling (multiplicative composition)

--- a/packages/data-collector/src/database/init/030_generator_predictions.sql
+++ b/packages/data-collector/src/database/init/030_generator_predictions.sql
@@ -1,0 +1,47 @@
+-- Per-generator signal predictions
+--
+-- Stores the raw output of each individual signal generator (momentum,
+-- mean_reversion, OFI, MLOFI, Hawkes, volume_anomaly, spread_compression,
+-- cross_market_corr, price_divergence, attention_spike, news_sentiment,
+-- resolution_prior). The combined signal is already persisted in
+-- signal_predictions; this table captures the inputs to the combiner so we can
+-- measure per-generator predictive power independently of weighting and dm
+-- transforms.
+--
+-- yes_price_at_signal is always the YES token price at signal time (regardless
+-- of generator direction). This simplifies later drift analysis vs price_history
+-- (which also stores YES price).
+
+CREATE TABLE IF NOT EXISTS generator_predictions (
+    id BIGSERIAL,
+    time TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    market_id VARCHAR(128) NOT NULL,
+    market_type VARCHAR(32),
+
+    signal_id VARCHAR(50) NOT NULL,    -- 'momentum', 'mean_reversion', 'ofi', etc.
+    direction VARCHAR(8) NOT NULL,      -- 'long' | 'short' | 'neutral'
+    strength NUMERIC(7,4) NOT NULL,     -- raw output strength (-1..+1, may be signed)
+    confidence NUMERIC(5,4) NOT NULL,   -- 0..1
+    yes_price_at_signal NUMERIC(10,6) NOT NULL,
+    metadata JSONB DEFAULT '{}',
+
+    PRIMARY KEY (time, id)
+);
+
+SELECT create_hypertable('generator_predictions', 'time',
+    chunk_time_interval => INTERVAL '1 day',
+    if_not_exists => TRUE
+);
+
+CREATE INDEX IF NOT EXISTS idx_gen_predictions_signal_time
+    ON generator_predictions (signal_id, time DESC);
+CREATE INDEX IF NOT EXISTS idx_gen_predictions_market_time
+    ON generator_predictions (market_id, time DESC);
+
+-- ~110k rows/day at full universe (35 markets x 11 generators x 12 cycles/h x 24h).
+-- 30-day retention keeps the table around 3.3M rows / ~250 MB compressed.
+ALTER TABLE generator_predictions SET (
+    timescaledb.compress_after = '3 days'
+);
+
+SELECT add_retention_policy('generator_predictions', INTERVAL '30 days', if_not_exists => TRUE);


### PR DESCRIPTION
## Summary

Adds `generator_predictions` (TimescaleDB hypertable, 30-day retention) and persists each individual signal generator's raw output every cycle. The combined signal is already in `signal_predictions`; this captures its **inputs** so per-generator predictive power can be measured independently of weighting and direction-multiplier transforms.

## Why now

Empirical analysis on `signal_predictions` (combined-only) since 2026-04-08 shows weak edge across all directions and price buckets:

| Direction | YES bucket | n | edge / 4h | t-stat |
|---|---|---|---|---|
| LONG | 0.20-0.30 | 72 | +0.62% | 1.52 |
| LONG | 0.40-0.50 | 38 | +0.92% | 0.76 |
| SHORT | 0.40-0.50 | 35 | +0.50% | 1.58 |
| SHORT | 0.50-0.60 | 29 | 0.00% | 0.00 |

No bucket reaches t≥2. Edge magnitudes are at the noise level vs ~0.7-2.2% round-trip friction. Either every generator is at-best marginal or one or two strong generators are being diluted by the others — we can't tell from the combined output alone.

Per-generator persistence unlocks the diagnostic: 1-2 weeks of data + this query identifies which generators carry edge:

```sql
WITH preds AS (
  SELECT gp.signal_id, gp.direction, gp.yes_price_at_signal AS y0,
    (SELECT close FROM price_history ph
     WHERE ph.market_id = gp.market_id
       AND ph.time BETWEEN gp.time + INTERVAL '3.5h' AND gp.time + INTERVAL '4.5h'
     ORDER BY ABS(EXTRACT(EPOCH FROM (ph.time - gp.time - INTERVAL '4h'))) LIMIT 1) AS y4h
  FROM generator_predictions gp
  WHERE gp.time >= NOW() - INTERVAL '14 days' AND gp.direction != 'neutral'
)
SELECT signal_id, direction, COUNT(*) n,
  ROUND((AVG(CASE WHEN direction='long' THEN y4h-y0 ELSE y0-y4h END) /
         NULLIF(STDDEV(CASE WHEN direction='long' THEN y4h-y0 ELSE y0-y4h END), 0) *
         SQRT(COUNT(*)))::numeric, 2) tstat
FROM preds WHERE y4h IS NOT NULL
GROUP BY signal_id, direction HAVING COUNT(*) >= 30 ORDER BY tstat DESC;
```

## What changed

- **`030_generator_predictions.sql`** — migration: hypertable + indexes + 30-day retention + 3-day compression
- **`server.ts`** — startup `CREATE TABLE IF NOT EXISTS` + hypertable bootstrap (existing VMs keep their TimescaleDB volume across deploys, so init SQL doesn't re-run)
- **`repositories.ts`** — `generatorPredictionsRepo.bulkCreate(records[])` with single multi-row INSERT for low cycle latency
- **`SignalEngine.ts`** — fire-and-forget batched insert right after the per-generator `signal.compute()` loop. A DB failure logs but does not block the cycle.
- **`repositories.test.ts`** — 4 new unit tests (empty input, batched INSERT shape, metadata defaults, signed strength)

## Schema

```sql
generator_predictions (
  id BIGSERIAL,
  time TIMESTAMPTZ NOT NULL,
  market_id VARCHAR(128),
  market_type VARCHAR(32),
  signal_id VARCHAR(50),       -- 'momentum', 'mean_reversion', 'ofi', ...
  direction VARCHAR(8),         -- 'long' | 'short' | 'neutral'
  strength NUMERIC(7,4),        -- raw output, signed
  confidence NUMERIC(5,4),
  yes_price_at_signal NUMERIC(10,6),  -- always YES, regardless of direction
  metadata JSONB
)
```

`yes_price_at_signal` is normalized to YES price always so drift queries against `price_history` (also YES) need no conversion. Avoids the YES/NO mixup that produced spurious edge readings in earlier `signal_predictions` analyses.

## Volume / capacity

- ~110k rows/day at full universe (35 markets × 11 generators × ~12 cycles/h × 24h)
- 30-day retention: ~3.3M rows / ~250 MB compressed (3-day compress_after)
- e2-micro VM has headroom; price_history is comparable scale and runs fine

## Risk

Pure-additive, no trading logic touched. Failure modes:
- DB write fails: logged, cycle continues
- Schema migration fails on existing VM: logged, no further action (does not block boot)

## Test plan

- [x] 33/34 dashboard test files pass (1 pre-existing skip)
- [x] All 26 SignalEngine tests pass
- [x] 4 new repo unit tests pass
- [x] TypeScript clean
- [ ] Deploy to VM and verify: `SELECT COUNT(*) FROM generator_predictions;` returns rows after first signal cycle
- [ ] Verify retention policy registered: `SELECT * FROM timescaledb_information.jobs WHERE proc_name = 'policy_retention'` includes `generator_predictions`

## Follow-up (not in this PR)

After ≥7 days of data accumulated, run the per-generator t-stat query above and decide based on results:
- If 1-2 generators show t≥2: optimizer can downweight the noisy ones
- If all generators marginal: the system has no signal-layer edge; rethink at higher level (option D from analysis session 2026-05-08)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added generator prediction persistence layer to store individual prediction outputs during signal processing.

* **Infrastructure**
  * Created database table for generator predictions with TimescaleDB optimization, compression after 3 days, and 30-day retention policy.

* **Tests**
  * Expanded test coverage for bulk creation and retrieval of generator predictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->