### PR TITLE
fix(daily-review): cleanup stale SSH keys + retry + gather_failed fallback

### DIFF
--- a/.github/workflows/daily-trade-review-claude.yml
+++ b/.github/workflows/daily-trade-review-claude.yml
@@ -69,6 +69,27 @@ jobs:
           git config user.name "Claude (Daily Review)"
           git config user.email "noreply@anthropic.com"
 
+      - name: Cleanup stale SSH keys in project metadata
+        # Each `gcloud compute ssh` regenerates and uploads a key. Without
+        # cleanup, project metadata grows unbounded and delays key propagation
+        # past the ConnectTimeout, causing `Permission denied (publickey)`.
+        # deploy-gcp.yml has this step since 2026-04-15; the daily-review was
+        # missing it, causing the 5-day notification outage (2026-05-05 to 09).
+        # Keep the latest key per user only.
+        run: |
+          set -euo pipefail
+          tmp=$(mktemp)
+          gcloud compute project-info describe \
+            --format=json \
+            | jq -r '.commonInstanceMetadata.items[]? | select(.key == "ssh-keys") | .value' \
+            | awk -F: '{ lines[$1]=$0 } END { for (k in lines) if (k != "") print lines[k] }' \
+            > "$tmp"
+          if [ -s "$tmp" ]; then
+            gcloud compute project-info add-metadata \
+              --metadata-from-file=ssh-keys="$tmp"
+          fi
+          rm -f "$tmp"
+
       - name: Run pre-review tests
         id: pre_tests
         run: |
@@ -97,20 +118,44 @@ jobs:
       - name: Gather data from VM
         id: gather
         run: |
-          SSH="gcloud compute ssh Usuario@polymarket-vm --zone=us-east1-b --ssh-flag=-o --ssh-flag=ServerAliveInterval=30 --ssh-flag=-o --ssh-flag=StrictHostKeyChecking=no --ssh-flag=-o --ssh-flag=ConnectTimeout=30"
+          SSH="gcloud compute ssh Usuario@polymarket-vm --zone=us-east1-b --ssh-flag=-o --ssh-flag=ServerAliveInterval=30 --ssh-flag=-o --ssh-flag=StrictHostKeyChecking=no --ssh-flag=-o --ssh-flag=ConnectTimeout=60"
 
-          # Run script on VM, save to temp file
-          $SSH --command="cd /home/Usuario/polymarket-trader && git pull --quiet origin main >/dev/null 2>&1; bash scripts/daily-review.sh > /tmp/daily-review-output.json 2>/tmp/daily-review-stderr.log" \
-            2>ssh-stderr.log || true
+          # Retry loop: VM SSH key propagation can take up to 60s after the
+          # project-metadata update in the cleanup step above. Three attempts
+          # with 20s waits gives ~3 minutes total before falling back.
+          SSH_OK=false
+          for attempt in 1 2 3; do
+            if $SSH --command="echo ssh_ok" > /dev/null 2>>ssh-stderr.log; then
+              SSH_OK=true
+              break
+            fi
+            echo "::warning::SSH attempt $attempt/3 failed — waiting 20s for key propagation"
+            sleep 20
+          done
 
-          # Retrieve JSON
-          $SSH --command="cat /tmp/daily-review-output.json" \
-            > review-data.json 2>>ssh-stderr.log || true
+          if [ "$SSH_OK" = "true" ]; then
+            # Run script on VM, save to temp file
+            $SSH --command="cd /home/Usuario/polymarket-trader && git pull --quiet origin main >/dev/null 2>&1; bash scripts/daily-review.sh > /tmp/daily-review-output.json 2>/tmp/daily-review-stderr.log" \
+              2>>ssh-stderr.log || true
 
-          if ! jq . review-data.json > /dev/null 2>&1; then
-            echo "::error::Invalid JSON from daily-review.sh"
-            cat ssh-stderr.log 2>/dev/null || true
-            exit 1
+            # Retrieve JSON
+            $SSH --command="cat /tmp/daily-review-output.json" \
+              > review-data.json 2>>ssh-stderr.log || true
+          else
+            echo "::warning::SSH failed after 3 attempts — VM unreachable"
+            : > review-data.json
+          fi
+
+          # Empty-file / invalid-JSON fallback: write a gather_failed stub so
+          # format-review.js triggers its degraded-notification path (Slack +
+          # email "FAILED" alert) instead of crashing on JSON.parse(''). Empty
+          # JSON before this fix silently passed `jq .` on some runners but
+          # broke notifications downstream.
+          if [ ! -s review-data.json ] || ! jq . review-data.json > /dev/null 2>&1; then
+            echo "::warning::review-data.json empty or invalid — emitting gather_failed stub"
+            cat ssh-stderr.log 2>/dev/null | head -20 || true
+            printf '{"gather_failed":true,"ssh_error":true,"generated_at":"%s"}\n' \
+              "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > review-data.json
           fi
           echo "data_collected=true" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Why

Five consecutive days of empty Slack/email notifications (2026-05-05 to 09 + ongoing). Two compounding bugs:

### Bug 1 — Missing SSH key cleanup (root cause)

`deploy-gcp.yml` has had this step since 2026-04-15 after the 165KB/284-key metadata bloat incident. `daily-trade-review-claude.yml` never got the same fix. Each daily-review run adds a key without removing the old one — eventually metadata propagation exceeds the 30s ConnectTimeout and gcloud SSH fails with \`Permission denied (publickey)\`.

Claude diagnosed this in issue #199 (2026-05-09) and prepared the fix locally, but couldn't push because the workflow's GITHUB_TOKEN lacks \`workflows\` scope. This PR is the human-pushed version of Claude's fix.

### Bug 2 — Silent empty-data path

When SSH fails, gather wrote an empty review-data.json which silently passed \`jq .\` on the runner's jq version. The Claude analysis then ran with no data and \`format-review.js\` crashed on \`JSON.parse('')\` (\"Unexpected end of JSON input\"). Result: zero Slack/email notifications even though the workflow appeared to make progress.

## What changed

1. **\"Cleanup stale SSH keys in project metadata\" step** — identical to deploy-gcp.yml. Runs before any gcloud SSH attempt. Keeps the latest key per user only.

2. **ConnectTimeout 30s → 60s + 3-attempt retry loop with 20s waits** — belt-and-suspenders for transient propagation delays.

3. **Empty-file / invalid-JSON fallback** — writes \`{\"gather_failed\":true,\"ssh_error\":true,\"generated_at\":\"...\"}\` stub when SSH fails. \`format-review.js\` already has a \`gather_failed === true\` early-exit path that produces the Slack + email FAILED alert. **Notifications now ALWAYS go out — no more silent outages.**

## Classification

\`root-cause\` for bug 1 (the key cleanup is the actual upstream problem).
\`containment\` for bugs 2/3 (retry + fallback are belt-and-suspenders; root-cause fix above should mean they never trigger, but they ensure the user always gets a notification if anything else breaks).

## Test plan

- [x] Workflow YAML is syntactically valid (no shellcheck errors in shell blocks)
- [ ] Manual trigger of \`workflow_dispatch\` after merge to verify:
  - Cleanup step runs cleanly
  - SSH succeeds on first attempt (clean metadata)
  - Notifications arrive on Slack and Gmail
- [ ] Next daily 08:00 UTC run delivers notifications normally

## Related context

- Daily review issue #199 (root cause investigation): https://github.com/JaviMaligno/polymarket-trader/issues/199
- Original cleanup step in deploy-gcp.yml: lines 156-173
- format-review.js \`gather_failed\` early-exit: scripts/format-review.js lines 37-80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of daily trade review data collection with retry logic to handle delayed connection propagation
  * Enhanced error handling to gracefully degrade when data collection fails, ensuring workflow continues with fallback status
  * Optimized SSH connection stability with extended timeouts and cleanup of stale connection metadata

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/200)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->