### PR TITLE
fix(trading-config): parse TEXT value in get() — prevents {...string} corruption

### DIFF
--- a/packages/dashboard/src/database/repositories.test.ts
+++ b/packages/dashboard/src/database/repositories.test.ts
@@ -7,7 +7,7 @@ vi.mock('./index.js', () => ({
 }));
 
 import { query, transaction } from './index.js';
-import { paperPositionsRepo, generatorPredictionsRepo } from './repositories.js';
+import { paperPositionsRepo, generatorPredictionsRepo, tradingConfigRepo } from './repositories.js';
 
 describe('paperPositionsRepo.insert', () => {
   beforeEach(() => {
@@ -312,5 +312,71 @@ describe('generatorPredictionsRepo.bulkCreate', () => {
     const params = vi.mocked(query).mock.calls[0][1] as unknown[];
     expect(params[4]).toBe(-0.85); // strength preserved with negative sign
     expect(params[3]).toBe('short'); // direction lowercase
+  });
+});
+
+describe('tradingConfigRepo.get — JSON parse from TEXT column', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('parses a JSON-encoded object value', async () => {
+    vi.mocked(query).mockResolvedValueOnce({
+      rows: [{ value: '{"global":1,"perMarketType":{"event_short":1}}' }],
+    } as any);
+
+    const result = await tradingConfigRepo.get<{ global: number; perMarketType: Record<string, number> }>(
+      'direction_multiplier_policy',
+    );
+
+    expect(result).toEqual({ global: 1, perMarketType: { event_short: 1 } });
+  });
+
+  it('parses JSON-encoded number / boolean / array', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ value: '42' }] } as any);
+    expect(await tradingConfigRepo.get<number>('k')).toBe(42);
+
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ value: 'true' }] } as any);
+    expect(await tradingConfigRepo.get<boolean>('k')).toBe(true);
+
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ value: '[1,2,3]' }] } as any);
+    expect(await tradingConfigRepo.get<number[]>('k')).toEqual([1, 2, 3]);
+  });
+
+  it('returns null for missing key', async () => {
+    vi.mocked(query).mockResolvedValueOnce({ rows: [] } as any);
+    expect(await tradingConfigRepo.get('k')).toBeNull();
+  });
+
+  it('returns raw string for legacy non-JSON values', async () => {
+    // Pre-JSON.stringify era values exist as plain strings in the column.
+    vi.mocked(query).mockResolvedValueOnce({ rows: [{ value: 'plain-text-legacy' }] } as any);
+    expect(await tradingConfigRepo.get<string>('k')).toBe('plain-text-legacy');
+  });
+
+  it('returned object is safe to spread (no character-by-character corruption)', async () => {
+    // Regression for the {...stringValue} bug: when get() returned the raw TEXT
+    // string, `{...current}` in callers like syncDirectionMultiplierPolicy
+    // expanded characters as numeric keys, silently corrupting the stored value.
+    vi.mocked(query).mockResolvedValueOnce({
+      rows: [{ value: '{"global":1,"perMarketType":{"event_short":1}}' }],
+    } as any);
+
+    const current = await tradingConfigRepo.get<{
+      global?: number;
+      perMarketType?: Record<string, number>;
+    }>('direction_multiplier_policy');
+
+    const merged = {
+      ...(current ?? {}),
+      perMarketType: { ...(current?.perMarketType ?? {}), event_financial: 1 },
+    };
+
+    // No numeric-string keys (the corruption signature)
+    expect(Object.keys(merged).filter((k) => /^\d+$/.test(k))).toEqual([]);
+    expect(merged).toEqual({
+      global: 1,
+      perMarketType: { event_short: 1, event_financial: 1 },
+    });
   });
 });

--- a/packages/dashboard/src/database/repositories.ts
+++ b/packages/dashboard/src/database/repositories.ts
@@ -732,12 +732,26 @@ export const portfolioSnapshotsRepo = {
 // ============================================
 
 export const tradingConfigRepo = {
+  // trading_config.value is TEXT, populated by `set()` with JSON.stringify().
+  // Without parsing here every caller has to remember that get() returns a
+  // string, not the typed object it claims. Some don't, and then patterns
+  // like `{ ...current, foo: bar }` silently expand the string character-by-
+  // character into numeric-keyed object properties — the corruption pattern
+  // that hit direction_multiplier_policy in May 2026.
   async get<T = unknown>(key: string): Promise<T | null> {
-    const result = await query<{ value: T }>(
+    const result = await query<{ value: string }>(
       'SELECT value FROM trading_config WHERE key = $1',
       [key]
     );
-    return result.rows[0]?.value ?? null;
+    const raw = result.rows[0]?.value;
+    if (raw == null) return null;
+    try {
+      return JSON.parse(raw) as T;
+    } catch {
+      // Legacy unencoded string values predate JSON.stringify() in set().
+      // Return raw so callers that opted into a `string` type still work.
+      return raw as unknown as T;
+    }
   },
 
   async set(key: string, value: unknown, description?: string): Promise<void> {
@@ -753,12 +767,16 @@ export const tradingConfigRepo = {
   },
 
   async getAll(): Promise<Record<string, unknown>> {
-    const result = await query<{ key: string; value: unknown }>(
+    const result = await query<{ key: string; value: string }>(
       'SELECT key, value FROM trading_config'
     );
     const config: Record<string, unknown> = {};
     for (const row of result.rows) {
-      config[row.key] = row.value;
+      try {
+        config[row.key] = JSON.parse(row.value);
+      } catch {
+        config[row.key] = row.value;
+      }
     }
     return config;
   },


### PR DESCRIPTION
## Why

\`trading_config.value\` is a TEXT column populated by \`set()\` via \`JSON.stringify(value)\`. \`get<T>()\` declared a typed return but did not parse — every caller received the raw string typed as T.

### Bug pattern (VM 2026-05-11)

\`OptimizationScheduler.syncDirectionMultiplierPolicy\`:

\`\`\`typescript
const current = await tradingConfigRepo.get<{...}>('direction_multiplier_policy');
const base = current ?? { global: 1.0, perMarketType: {}, segments: [] };
const updated = { ...base, perMarketType: { ...(base.perMarketType ?? {}), ... } };
\`\`\`

When \`base\` was a string (the JSON-encoded TEXT), \`{...base}\` spread it character by character into numeric-keyed properties. The DB row became \`{"0":"{","1":"\\""," 2":"g",...,"perMarketType":{"event_short":1}}\`. global / minMultiplier / segments / other perMarketType entries were lost.

This is a regression of PR #178, which fixed the same class of bug in \`wipeDirectionMultiplierSegments\` but only inside that function. \`syncDirectionMultiplierPolicy\` (PR #194) repeated the mistake.

## Fix

\`tradingConfigRepo.get()\` and \`getAll()\` now \`JSON.parse\` the TEXT value, with a string-fallback for legacy unencoded values. Bug class eliminated at the storage boundary; callers can spread safely.

## Classification

\`root-cause\`. All callers benefit; previous string-handling code in \`wipeDirectionMultiplierSegments\` becomes defensive-only.

## Out-of-band repair already applied

\`\`\`sql
UPDATE trading_config 
SET value = '{"global":1,"minMultiplier":-1,"maxMultiplier":1,"segments":[],"perMarketType":{"event_short":1,"event_financial":1,"crypto_intraday":1,"crypto_daily":1,"event_long":1}}'
WHERE key = 'direction_multiplier_policy';
\`\`\`

## Tests

- 4 new unit tests for the parse behaviour
- Regression test: \`{...result}\` produces no numeric-keyed properties
- All 357 dashboard tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
