### PR TITLE
fix(backtest): time-exit at maxHoldHours to mirror live's 4h MAX_HOLD_TIME_HOURS

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -113,9 +113,7 @@ services:
     restart: unless-stopped
     environment:
       NODE_ENV: production
-      # Temporarily info to debug 2026-05-11 trade stall (signal_predictions=0
-      # while generators emit ~600/10min). Revert to warn after diagnosis.
-      LOG_LEVEL: info
+      LOG_LEVEL: warn
       PORT: 3001
       HOST: 0.0.0.0
       CORS_ORIGIN: "*"

--- a/packages/backtest/src/engine/BacktestEngine.ts
+++ b/packages/backtest/src/engine/BacktestEngine.ts
@@ -54,6 +54,11 @@ export interface IPortfolioManager {
   getPosition(marketId: string, tokenId: string): { side: 'LONG' | 'SHORT'; size: number } | null;
   /** Close all open positions at current prices */
   closeAllPositions(currentTime: Date, getPriceFunc: (marketId: string, tokenId: string) => number | null): number;
+  closeAgedPositions(
+    currentTime: Date,
+    maxHoldMs: number,
+    getPriceFunc: (marketId: string, tokenId: string) => number | null
+  ): { closedCount: number; totalPnl: number };
 }
 
 export interface IOrderBookSimulator {
@@ -222,6 +227,28 @@ export class BacktestEngine {
           originalHandler(signal);
         }
         pendingSignals = [];
+
+        // Time-exit: close positions that have been open longer than
+        // maxHoldHours. Mirrors live MAX_HOLD_TIME_HOURS — without this the
+        // fitness function captures resolution-price PnL the live system
+        // never sees (event_long markets resolve over weeks, live time-exits
+        // at 4h). See RiskProfiles.useTimeExit jsdoc for the empirical case.
+        if (
+          this.portfolioManager &&
+          this.config.risk?.useTimeExit &&
+          this.config.risk.maxHoldHours > 0
+        ) {
+          const maxHoldMs = this.config.risk.maxHoldHours * 60 * 60 * 1000;
+          this.portfolioManager.closeAgedPositions(
+            tickTime,
+            maxHoldMs,
+            (marketId: string, tokenId: string) => {
+              const cacheKey = `${marketId}:${tokenId}`;
+              const cache = this.priceCache.get(cacheKey);
+              return cache?.currentBar?.close ?? null;
+            }
+          );
+        }
 
         // Generate signals for current state (will be executed next tick)
         await this.generateSignals();

--- a/packages/backtest/src/portfolio/PortfolioManager.timeExit.test.ts
+++ b/packages/backtest/src/portfolio/PortfolioManager.timeExit.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for PortfolioManager.closeAgedPositions — time-exit parity with live.
+ *
+ * Live (StopLossService) closes any position older than MAX_HOLD_TIME_HOURS
+ * (default 4h) at the current price. Backtest previously had no such gate,
+ * so positions stayed open until market resolution and captured full
+ * resolution-price PnL the live system cannot realise.
+ *
+ * Empirical evidence motivating the fix (2026-05-11):
+ * - shadow_trades event_long LONG: 100% WR @ avg +$96 (theoretical)
+ * - generator_predictions p2 t-stat event_long LONG @ 4h: -3.16 (anti-edge)
+ * - Optuna previously weighted mean_reversion event_long = 1.32 (HIGH)
+ *   while the actual 4h-horizon edge was negative.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { PortfolioManager } from './PortfolioManager.js';
+import type { OrderEvent } from '../types/index.js';
+
+function makePM(): PortfolioManager {
+  return new PortfolioManager({
+    initialCapital: 10_000,
+    feeRate: 0.001,
+    snapshotIntervalMinutes: 60,
+  });
+}
+
+function openLongOrder(
+  marketId: string,
+  tokenId: string,
+  price: number,
+  size: number,
+  filledAt: Date,
+): OrderEvent {
+  return {
+    type: 'ORDER_FILLED',
+    timestamp: filledAt,
+    data: {
+      id: `o_${marketId}_${tokenId}`,
+      marketId,
+      tokenId,
+      side: 'BUY',
+      requestedSize: size,
+      filledSize: size,
+      requestedPrice: price,
+      avgFillPrice: price,
+      status: 'FILLED',
+      type: 'MARKET',
+      createdAt: filledAt,
+      updatedAt: filledAt,
+      fills: [{ size, price, fee: 0, timestamp: filledAt }],
+    },
+  } as unknown as OrderEvent;
+}
+
+describe('PortfolioManager.closeAgedPositions — time-exit at maxHoldHours', () => {
+  it('closes a position older than maxHoldMs at the supplied current price', () => {
+    const pm = makePM();
+    const t0 = new Date('2026-05-08T00:00:00Z');
+    pm.handleOrderFilled(openLongOrder('m1', 'tok_yes', 0.30, 100, t0));
+
+    // 5h later — past the 4h horizon
+    const t1 = new Date('2026-05-08T05:00:00Z');
+    const maxHoldMs = 4 * 60 * 60 * 1000;
+    const getPrice = (mid: string, tid: string) =>
+      mid === 'm1' && tid === 'tok_yes' ? 0.31 : null;
+
+    const result = pm.closeAgedPositions(t1, maxHoldMs, getPrice);
+
+    expect(result.closedCount).toBe(1);
+    expect(result.totalPnl).toBeCloseTo((0.31 - 0.30) * 100, 6);
+
+    const state = pm.getState();
+    expect(state.positions.size).toBe(0);
+
+    const trades = pm.getTrades();
+    expect(trades).toHaveLength(1);
+    expect(trades[0].exitPrice).toBe(0.31);
+    expect(trades[0].exitTime).toEqual(t1);
+    expect(trades[0].holdingPeriodMs).toBe(5 * 60 * 60 * 1000);
+  });
+
+  it('does not close positions younger than maxHoldMs', () => {
+    const pm = makePM();
+    const t0 = new Date('2026-05-08T00:00:00Z');
+    pm.handleOrderFilled(openLongOrder('m1', 'tok_yes', 0.30, 100, t0));
+
+    // 2h later — within the 4h horizon
+    const t1 = new Date('2026-05-08T02:00:00Z');
+    const result = pm.closeAgedPositions(
+      t1,
+      4 * 60 * 60 * 1000,
+      () => 0.31,
+    );
+
+    expect(result.closedCount).toBe(0);
+    expect(result.totalPnl).toBe(0);
+    expect(pm.getState().positions.size).toBe(1);
+  });
+
+  it('skips aged positions when no price is available (no fabricated exits)', () => {
+    const pm = makePM();
+    const t0 = new Date('2026-05-08T00:00:00Z');
+    pm.handleOrderFilled(openLongOrder('m1', 'tok_yes', 0.30, 100, t0));
+
+    const t1 = new Date('2026-05-08T10:00:00Z'); // way past horizon
+    const result = pm.closeAgedPositions(
+      t1,
+      4 * 60 * 60 * 1000,
+      () => null, // no price available
+    );
+
+    expect(result.closedCount).toBe(0);
+    expect(pm.getState().positions.size).toBe(1);
+  });
+
+  it('closes multiple aged positions atomically', () => {
+    const pm = makePM();
+    pm.handleOrderFilled(openLongOrder('m1', 'tok1', 0.25, 100, new Date('2026-05-08T00:00:00Z')));
+    pm.handleOrderFilled(openLongOrder('m2', 'tok2', 0.40, 100, new Date('2026-05-08T01:00:00Z')));
+    pm.handleOrderFilled(openLongOrder('m3', 'tok3', 0.50, 100, new Date('2026-05-08T04:30:00Z')));
+
+    const t1 = new Date('2026-05-08T05:00:00Z');
+    const getPrice = (mid: string) => ({ m1: 0.26, m2: 0.42, m3: 0.51 }[mid] ?? null);
+
+    const result = pm.closeAgedPositions(t1, 4 * 60 * 60 * 1000, getPrice);
+
+    // m1 (5h old) and m2 (4h old) close; m3 (30min old) stays
+    expect(result.closedCount).toBe(2);
+    expect(pm.getState().positions.size).toBe(1);
+    expect(pm.getState().positions.has('m3:tok3')).toBe(true);
+  });
+
+  it('returns zero work when maxHoldMs <= 0 (feature disabled)', () => {
+    const pm = makePM();
+    pm.handleOrderFilled(openLongOrder('m1', 'tok_yes', 0.30, 100, new Date('2026-05-08T00:00:00Z')));
+
+    const result = pm.closeAgedPositions(
+      new Date('2026-05-15T00:00:00Z'),
+      0,
+      () => 0.31,
+    );
+
+    expect(result.closedCount).toBe(0);
+    expect(pm.getState().positions.size).toBe(1);
+  });
+});

--- a/packages/backtest/src/portfolio/PortfolioManager.ts
+++ b/packages/backtest/src/portfolio/PortfolioManager.ts
@@ -469,6 +469,67 @@ export class PortfolioManager implements IPortfolioManager {
   }
 
   /**
+   * Close positions that have been open longer than maxHoldMs at current price.
+   * Mirrors live's MAX_HOLD_TIME_HOURS exit (StopLossService) so backtest
+   * fitness reflects what live can actually realise — without this, event_long
+   * positions stay open until market resolution and capture full resolution-
+   * price PnL that live (4h time exit) cannot achieve.
+   *
+   * Returns the number of positions closed and total realised PnL.
+   */
+  closeAgedPositions(
+    currentTime: Date,
+    maxHoldMs: number,
+    getPriceFunc: (marketId: string, tokenId: string) => number | null
+  ): { closedCount: number; totalPnl: number } {
+    if (maxHoldMs <= 0) return { closedCount: 0, totalPnl: 0 };
+
+    let totalPnl = 0;
+    let closedCount = 0;
+    const cutoffTime = currentTime.getTime() - maxHoldMs;
+
+    // Snapshot keys because closePosition() mutates the underlying map
+    const aged = Array.from(this.positions.values()).filter(
+      (p) => p.openedAt.getTime() <= cutoffTime
+    );
+
+    for (const position of aged) {
+      const currentPrice = getPriceFunc(position.marketId, position.tokenId);
+      if (currentPrice === null) {
+        // No fresh price — leave the position. closeAllPositions at backtest
+        // end is the final cleanup; we don't want to fabricate an exit price.
+        continue;
+      }
+
+      const pnl =
+        position.side === 'LONG'
+          ? (currentPrice - position.entryPrice) * position.size
+          : (position.entryPrice - currentPrice) * position.size;
+      position.realizedPnl = pnl;
+
+      // Settle cash like a normal close
+      if (position.side === 'LONG') {
+        this.cash += position.size * currentPrice;
+      } else {
+        this.cash -= position.size * currentPrice;
+      }
+
+      totalPnl += pnl;
+      this.closePosition(position, currentPrice, currentTime);
+      closedCount += 1;
+    }
+
+    if (closedCount > 0) {
+      this.logger.debug(
+        { closedCount, totalPnl, maxHoldHours: maxHoldMs / 3_600_000 },
+        'Closed aged positions at time-exit horizon'
+      );
+    }
+
+    return { closedCount, totalPnl };
+  }
+
+  /**
    * Close all open positions at current prices
    * Returns total realized P&L from closing positions
    */

--- a/packages/backtest/src/types/RiskProfiles.ts
+++ b/packages/backtest/src/types/RiskProfiles.ts
@@ -59,6 +59,20 @@ export interface RiskConfig {
   /** Volatility multiplier for SL/TP adjustment */
   volatilityMultiplier: number;
 
+  // === Time-Based Exit (mirrors live StopLossService MAX_HOLD_TIME_HOURS) ===
+  /**
+   * Close any position that has been open longer than `maxHoldHours`. Defaults
+   * to true and 4h to match live behaviour. Critical for fitness function
+   * correctness: without it, backtests held event_long positions for weeks
+   * and captured full resolution-price PnL that live (with its 4h time exit)
+   * can never realise. That divergence drove Optuna to weight
+   * mean_reversion event_long high despite the actual 4h drift being
+   * anti-edge (t-stat -3.16 from generator_predictions, 2026-05-11).
+   */
+  useTimeExit: boolean;
+  /** Maximum hold time in hours before forced exit at current price */
+  maxHoldHours: number;
+
   // === Correlation & Diversification ===
   /** Maximum correlation between positions (0-1) */
   maxCorrelation: number;
@@ -140,6 +154,10 @@ export const AGGRESSIVE_PROFILE: RiskConfig = {
   useVolatilityAdjusted: true,   // Adjust for volatility
   volatilityMultiplier: 1.5,     // 1.5x volatility adjustment
 
+  // Time Exit (mirrors live MAX_HOLD_TIME_HOURS=4)
+  useTimeExit: true,
+  maxHoldHours: 4,
+
   // Correlation & Diversification
   maxCorrelation: 0.7,           // 70% max correlation (tighter)
   maxCategoryConcentrationPct: 40, // Max 40% in one category
@@ -201,6 +219,10 @@ export const MODERATE_PROFILE: RiskConfig = {
   useVolatilityAdjusted: true,
   volatilityMultiplier: 1.3,
 
+  // Time Exit (mirrors live MAX_HOLD_TIME_HOURS=4)
+  useTimeExit: true,
+  maxHoldHours: 4,
+
   // Correlation & Diversification
   maxCorrelation: 0.65,
   maxCategoryConcentrationPct: 35,
@@ -261,6 +283,10 @@ export const CONSERVATIVE_PROFILE: RiskConfig = {
   trailingStopPct: 4,
   useVolatilityAdjusted: false,
   volatilityMultiplier: 1.0,
+
+  // Time Exit (mirrors live MAX_HOLD_TIME_HOURS=4)
+  useTimeExit: true,
+  maxHoldHours: 4,
 
   // Correlation & Diversification
   maxCorrelation: 0.6,


### PR DESCRIPTION
## Root cause

Backtest's fitness function diverges from live in a way that systematically
mis-weights signals: it lets positions hold until market resolution, while
live closes everything after 4h via \`StopLossService.MAX_HOLD_TIME_HOURS\`.

## Empirical evidence

Per-(signal, market_type, direction) t-stat from \`generator_predictions\`
(3 days, ~150k predictions, 4h-forward drift):

| Generator x Type x Direction | n | edge @ 4h | t-stat |
|---|---|---|---|
| mean_reversion x event_long x LONG | 4261 | -0.10% | **-3.16** (anti) |
| mean_reversion x event_financial x LONG | 2619 | +0.28% | **+8.61** |
| mean_reversion x crypto_intraday x LONG | 1907 | +0.17% | **+8.00** |

Optuna's persisted per-type weights at the same moment:

| signal_type | market_type | weight |
|---|---|---|
| mean_reversion | event_long | **1.32** (high — wrong) |
| mean_reversion | event_financial | **0.78** (low — undervalued) |

Why backtest got it wrong: with no time-exit, a LONG opened at YES=0.10 on
event_long stays open for weeks until the market resolves YES (event_long
markets resolve YES ~100% in our shadow data — survivorship bias of
tracking pool). Backtest sees ~9x return per trade. Live cannot ever
realise this; its 4h exit captures only the intermediate drift, which is
mean-reverting against the LONG bet.

## Changes

- \`RiskConfig.useTimeExit\` + \`maxHoldHours\` (default true, 4h to match live)
- All three risk profiles (AGGRESSIVE/MODERATE/CONSERVATIVE) updated
- \`PortfolioManager.closeAgedPositions(currentTime, maxHoldMs, getPrice)\` —
  mirrors live behaviour, settles at current price, skips when no price
- \`BacktestEngine\` main loop calls it once per tick before \`generateSignals\`
- 5 unit tests in \`PortfolioManager.timeExit.test.ts\`:
  - closes aged at supplied price (PnL math correct)
  - leaves fresh positions alone
  - skips when no price (no fabricated exits)
  - multi-close in one call
  - disabled when maxHoldMs <= 0

Also reverts \`docker-compose.gcp.yml\` LOG_LEVEL info → warn (no longer
needed after diagnosis: the rejection path is the existing
\`ALLOWED_MARKET_TYPES\` gating event_long, not a hidden bug).

## Test plan

- [x] 82/82 backtest tests pass (5 new + 77 existing)
- [x] 63/63 OptimizationScheduler tests pass (no contract changes)
- [x] TS clean across packages
- [ ] **Empirical validation post-deploy**: next Optuna cycle runs with
      time-exit fitness. Expected change to per-type weights:
  - mean_reversion event_long: 1.32 → much lower (was rewarded by
    resolution capture that no longer exists)
  - mean_reversion event_financial: 0.78 → higher or stable (the small
    consistent 4h edge now matters more relative to resolution-driven trades)
  - mlofi/ofi: stay near zero (we manually muted; expect Optuna to agree
    now that fitness reflects live)
- [ ] Monitor \`signal_weights_history\` after the first post-merge Optuna
      apply cycle (~6h after deploy) to confirm convergence.

## Classification

\`root-cause\`. This fixes the upstream divergence between backtest and live,
which produces correct downstream weight optimization. Reverting weights
via SQL was the patch; this is the real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
