### PR TITLE
feat(executor): per-(market_type, direction) blocklist gate (0f)

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -204,6 +204,16 @@ services:
       EXECUTOR_EVENT_OTM_TTR_HOURS: "240"
       EXECUTOR_EVENT_OTM_PRICE_LO: "0.20"
       EXECUTOR_EVENT_OTM_PRICE_HI: "0.80"
+      # Gate 0f: per-(market_type, direction) blocklist. Cells with empirical
+      # anti-edge in generator_predictions per-type t-stat analysis. The
+      # signal_weights schema can't separately downweight SHORT vs LONG inside
+      # a (signal, type), so the only place to act on direction asymmetry is
+      # this executor filter. Format: comma-separated type:direction pairs
+      # (both lowercase). Configured 2026-05-11 from 3 days of P2 data:
+      #   mean_reversion event_financial LONG  t=+8.61  (strong edge — allow)
+      #   mean_reversion event_financial SHORT t=-9.97  (strong anti — block)
+      # Closes of existing positions are never blocked (unwind path).
+      EXECUTOR_BLOCKED_TYPE_DIRECTIONS: "event_financial:short"
       # Market type gate: only trade these types live, shadow-trade the rest
       # event_financial: WTI, Fed, indices (continuous underlying)
       # event_short: event markets with short resolution windows (better win rate than event_long)

--- a/packages/dashboard/src/services/AutoSignalExecutor.directionBlocklist.test.ts
+++ b/packages/dashboard/src/services/AutoSignalExecutor.directionBlocklist.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for AutoSignalExecutor Gate 0f — per-(market_type, direction) blocklist.
+ *
+ * Generator-predictions per-type t-stat analysis (2026-05-11) revealed
+ * asymmetric edge inside the same market_type:
+ *
+ *   mean_reversion x event_financial x LONG  → t = +8.61 (strong edge)
+ *   mean_reversion x event_financial x SHORT → t = -9.97 (strong anti-edge)
+ *
+ * The signal_weights schema is keyed on (signal_type, market_type) — no
+ * direction — so per-type weights amplify BOTH directions equally. The only
+ * way to act on direction-specific edge today is to filter at the executor
+ * level via this blocklist.
+ *
+ * The env var is parsed at module-load, so each test uses isolateModules to
+ * re-import AutoSignalExecutor with the desired env state.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../database/index.js', () => ({
+  query: vi.fn(),
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+vi.mock('../database/repositories.js', () => ({
+  paperTradesRepo: { create: vi.fn() },
+  paperPositionsRepo: {
+    getAll: vi.fn().mockResolvedValue([]),
+    insert: vi.fn(),
+    upsert: vi.fn(),
+    openPositionAtomically: vi.fn().mockResolvedValue({ opened: true }),
+  },
+  signalPredictionsRepo: { create: vi.fn() },
+  signalWeightsRepo: { get: vi.fn() },
+}));
+
+vi.mock('./PositionClosingService.js', () => {
+  const { EventEmitter } = require('events');
+  const mockService = new EventEmitter();
+  mockService.close = vi.fn().mockResolvedValue({ executed: true, pnl: 0 });
+  return { getPositionClosingService: vi.fn(() => mockService) };
+});
+
+vi.mock('./CircuitBreakerService.js', () => ({
+  getCircuitBreakerService: vi.fn(() => ({ isTradingHalted: vi.fn(() => false) })),
+}));
+
+vi.mock('./ExecutionRouter.js', () => ({ getExecutionRouter: vi.fn(() => null) }));
+
+vi.mock('./OrderBookExecutionSimulator.js', () => ({
+  OrderBookExecutionSimulator: class {
+    simulateBuy = vi.fn().mockResolvedValue({
+      executed: true, executedPrice: 0.50, executedSize: 10,
+      slippagePct: 0.1, fee: 0.005, fillSource: 'estimated',
+      snapshotAgeMs: null, availableDepth: 0,
+      bestBid: null, bestAsk: null,
+    });
+    simulateSell = vi.fn().mockResolvedValue({
+      executed: true, executedPrice: 0.50, executedSize: 10,
+      slippagePct: 0.1, fee: 0.005, fillSource: 'estimated',
+      snapshotAgeMs: null, availableDepth: 0,
+      bestBid: null, bestAsk: null,
+    });
+  },
+}));
+
+import { query } from '../database/index.js';
+import { paperPositionsRepo } from '../database/repositories.js';
+
+interface MakeSignalOverrides {
+  direction?: 'long' | 'short';
+  marketType?: string;
+  marketId?: string;
+}
+
+function makeSignal(overrides: MakeSignalOverrides = {}) {
+  return {
+    signalId: 'mean_reversion',
+    marketId: overrides.marketId ?? 'mkt1',
+    tokenId: 'tok1',
+    direction: overrides.direction ?? 'long',
+    strength: 0.7,
+    confidence: 0.7,
+    price: 0.5,
+    marketType: overrides.marketType ?? 'event_financial',
+  };
+}
+
+// Common mock chain: market is active, capital is healthy, no positions
+function setupMockChain() {
+  (paperPositionsRepo.getAll as any).mockResolvedValue([]);
+  (query as any).mockImplementation((sql: string) => {
+    if (sql.includes('FROM markets WHERE id')) {
+      return Promise.resolve({
+        rows: [{ is_active: true, is_resolved: false, end_date: null, market_type: 'event_financial' }],
+      });
+    }
+    if (sql.includes('FROM paper_account')) {
+      return Promise.resolve({
+        rows: [{ available_capital: '9500', current_capital: '10000', peak_equity: '10000' }],
+      });
+    }
+    if (sql.includes('FROM paper_positions WHERE closed_at IS NULL')) {
+      return Promise.resolve({ rows: [{ total_exposure: '0' }] });
+    }
+    return Promise.resolve({ rows: [] });
+  });
+}
+
+describe('AutoSignalExecutor Gate 0f — direction blocklist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    delete process.env.EXECUTOR_BLOCKED_TYPE_DIRECTIONS;
+  });
+
+  it('allows all directions when the env var is empty (default)', async () => {
+    const { AutoSignalExecutor } = await import('./AutoSignalExecutor.js');
+    setupMockChain();
+    const exec = new AutoSignalExecutor({ enabled: true, cooldownMs: 0 });
+
+    const result = await exec.processSignal(makeSignal({ direction: 'short' }) as any);
+    expect(result.reason ?? '').not.toMatch(/direction_blocked_for_type/);
+  });
+
+  it('blocks short on event_financial when configured, allows long', async () => {
+    process.env.EXECUTOR_BLOCKED_TYPE_DIRECTIONS = 'event_financial:short';
+    const { AutoSignalExecutor } = await import('./AutoSignalExecutor.js');
+    setupMockChain();
+    const exec = new AutoSignalExecutor({ enabled: true, cooldownMs: 0 });
+
+    const shortResult = await exec.processSignal(makeSignal({ direction: 'short' }) as any);
+    expect(shortResult.executed).toBe(false);
+    expect(shortResult.reason).toMatch(/direction_blocked_for_type: event_financial:short/);
+
+    const longResult = await exec.processSignal(makeSignal({ direction: 'long' }) as any);
+    expect(longResult.reason ?? '').not.toMatch(/direction_blocked_for_type/);
+  });
+
+  it('allows direction-blocked signals to close existing positions (unwind path)', async () => {
+    process.env.EXECUTOR_BLOCKED_TYPE_DIRECTIONS = 'event_financial:short';
+    const { AutoSignalExecutor } = await import('./AutoSignalExecutor.js');
+    setupMockChain();
+    // Existing LONG position in the same market
+    (paperPositionsRepo.getAll as any).mockResolvedValue([
+      { market_id: 'mkt1', token_id: 'tok_yes', side: 'long', size: 10, current_price: 0.5, avg_entry_price: 0.45 },
+    ]);
+
+    const exec = new AutoSignalExecutor({ enabled: true, cooldownMs: 0 });
+    const result = await exec.processSignal(makeSignal({ direction: 'short' }) as any);
+
+    // Signal does not get rejected by the direction blocklist (close is allowed)
+    expect(result.reason ?? '').not.toMatch(/direction_blocked_for_type/);
+  });
+
+  it('supports multiple (type:direction) pairs', async () => {
+    process.env.EXECUTOR_BLOCKED_TYPE_DIRECTIONS = 'event_financial:short,event_long:long';
+    const { AutoSignalExecutor } = await import('./AutoSignalExecutor.js');
+    setupMockChain();
+    const exec = new AutoSignalExecutor({ enabled: true, cooldownMs: 0 });
+
+    const r1 = await exec.processSignal(makeSignal({ direction: 'short', marketType: 'event_financial' }) as any);
+    expect(r1.reason).toMatch(/event_financial:short/);
+
+    // event_long would be blocked by ALLOWED_MARKET_TYPES upstream of 0f in the
+    // current default config, so we configure ALLOWED_MARKET_TYPES to include
+    // it via a separate import that does NOT set that env. For this test we
+    // rely on the absence of ALLOWED_MARKET_TYPES (set to null), so the
+    // direction blocklist is the only gate that fires.
+    delete process.env.ALLOWED_MARKET_TYPES;
+    vi.resetModules();
+    const { AutoSignalExecutor: ExecWithoutTypeGate } = await import('./AutoSignalExecutor.js');
+    const exec2 = new ExecWithoutTypeGate({ enabled: true, cooldownMs: 0 });
+    const r2 = await exec2.processSignal(makeSignal({ direction: 'long', marketType: 'event_long' }) as any);
+    expect(r2.reason).toMatch(/event_long:long/);
+  });
+
+  it('rejects malformed entries silently (only valid type:direction pairs are honoured)', async () => {
+    process.env.EXECUTOR_BLOCKED_TYPE_DIRECTIONS = 'event_financial:short,invalid_entry,event_long:wrongside';
+    const { AutoSignalExecutor } = await import('./AutoSignalExecutor.js');
+    setupMockChain();
+    const exec = new AutoSignalExecutor({ enabled: true, cooldownMs: 0 });
+
+    // valid entry blocks
+    const r1 = await exec.processSignal(makeSignal({ direction: 'short', marketType: 'event_financial' }) as any);
+    expect(r1.reason).toMatch(/event_financial:short/);
+
+    // invalid entries don't accidentally block legitimate signals
+    const r2 = await exec.processSignal(makeSignal({ direction: 'long', marketType: 'event_long' }) as any);
+    expect(r2.reason ?? '').not.toMatch(/direction_blocked_for_type/);
+  });
+});

--- a/packages/dashboard/src/services/AutoSignalExecutor.ts
+++ b/packages/dashboard/src/services/AutoSignalExecutor.ts
@@ -233,6 +233,28 @@ const ALLOWED_MARKET_TYPES: Set<string> | null = process.env.ALLOWED_MARKET_TYPE
   ? new Set(process.env.ALLOWED_MARKET_TYPES.split(',').map(t => t.trim()))
   : null;
 
+/**
+ * Per-(market_type, direction) blocklist. Surgically blocks (type, side)
+ * combinations that empirical generator_predictions analysis identifies as
+ * anti-edge. Format: comma-separated `type:direction` pairs, both lowercase
+ * (e.g. "event_financial:short,event_long:short").
+ *
+ * Why this is per-direction and not per-signal: per-type weights apply to
+ * both LONG and SHORT outputs of a generator. mean_reversion event_financial
+ * has LONG t=+8.61 (strong edge) AND SHORT t=-9.97 (strong anti-edge) over
+ * 3 days of generator_predictions; the schema cannot capture that
+ * asymmetry, so the cleanest filter is at the executor level.
+ *
+ * Closes of existing positions are NEVER blocked (legacy unwind path),
+ * matching the ALLOWED_MARKET_TYPES gate behaviour.
+ */
+const BLOCKED_TYPE_DIRECTIONS: Set<string> = new Set(
+  (process.env.EXECUTOR_BLOCKED_TYPE_DIRECTIONS || '')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => /^[a-z_]+:(long|short)$/.test(s)),
+);
+
 interface TradeRecord {
   marketId: string;
   timestamp: number;
@@ -553,6 +575,38 @@ export class AutoSignalExecutor extends EventEmitter {
               `event_otm_near_expiry (position check failed)`
           );
           return { executed: false, reason: 'event_otm_near_expiry: position check failed' };
+        }
+      }
+    }
+
+    // 0f. Per-(market_type, direction) blocklist. Surgically blocks the
+    // anti-edge (type, side) cells that emerge in generator_predictions per-
+    // type t-stats. Closes of existing positions are always allowed (matches
+    // 0d behaviour). Shadow trade is recorded on block so we can re-evaluate
+    // promotion if the per-type edge shifts.
+    if (BLOCKED_TYPE_DIRECTIONS.size > 0) {
+      const key = `${effectiveMarketType}:${signal.direction}`.toLowerCase();
+      if (BLOCKED_TYPE_DIRECTIONS.has(key)) {
+        try {
+          const openPositions = await paperPositionsRepo.getAll();
+          const hasOpenPosition = openPositions.some((p) => p.market_id === signal.marketId);
+          if (!hasOpenPosition) {
+            console.log(
+              `[AutoExecutor] REJECTED ${signal.marketId.substring(0, 12)}... : ` +
+                `direction_blocked_for_type (${key})`
+            );
+            this.insertShadowTrade(signal, 'direction_blocked_for_type').catch(() => {});
+            return {
+              executed: false,
+              reason: `direction_blocked_for_type: ${key}`,
+            };
+          }
+        } catch {
+          console.log(
+            `[AutoExecutor] REJECTED ${signal.marketId.substring(0, 12)}... : ` +
+              `direction_blocked_for_type (${key}, position check failed)`
+          );
+          return { executed: false, reason: `direction_blocked_for_type: ${key} (position check failed)` };
         }
       }
     }


### PR DESCRIPTION
Direction-aware anti-edge filter. See commit message for full empirical justification. event_financial SHORT t=-9.97 (anti-edge) vs LONG t=+8.61 (edge) over 3 days of generator_predictions. Adds EXECUTOR_BLOCKED_TYPE_DIRECTIONS env var (default pre-configured to event_financial:short). 5 new tests, 364/378 dashboard suite pass. See PR #198/#204 for the diagnostic chain that led here.