### PR TITLE
feat(combiner): SIGNAL_TYPES_DISABLED env var to hard-disable generators

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -218,6 +218,14 @@ services:
       #   with 0% WR. Structural mismatch, not a signal quality issue.
       # Closes of existing positions are never blocked (unwind path).
       EXECUTOR_BLOCKED_TYPE_DIRECTIONS: "event_financial:short,crypto_intraday:long"
+      # Hard-disable signal_types at the combiner layer. Bypasses any signal_weights
+      # row (even ones the Render Optimizer writes). Same list as the boot cleanup
+      # in dashboard/src/server.ts:467 — these 6 generators are not wired into
+      # BacktestService so Optuna can't trial-fit them meaningfully. Until the
+      # Optimizer is patched to skip them server-side, this gate makes the system
+      # immune to the oscillation discovered 2026-05-12 (boot cleanup deletes
+      # per-type rows; Optimizer re-writes them every 6h).
+      SIGNAL_TYPES_DISABLED: "mlofi,spread_compression,cross_market_corr,price_divergence,attention_spike,news_sentiment"
       # Market type gate: only trade these types live, shadow-trade the rest
       # event_financial: WTI, Fed, indices (continuous underlying)
       # event_short: event markets with short resolution windows (better win rate than event_long)

--- a/packages/dashboard/src/services/SignalEngine.test.ts
+++ b/packages/dashboard/src/services/SignalEngine.test.ts
@@ -1,4 +1,32 @@
 import { describe, it, expect } from 'vitest';
+import { parseDisabledSignalIds } from './SignalEngine.js';
+
+describe('parseDisabledSignalIds', () => {
+  it('returns empty set for undefined or empty string', () => {
+    expect(parseDisabledSignalIds(undefined).size).toBe(0);
+    expect(parseDisabledSignalIds('').size).toBe(0);
+    expect(parseDisabledSignalIds('   ').size).toBe(0);
+  });
+
+  it('parses comma-separated ids with whitespace tolerance', () => {
+    const s = parseDisabledSignalIds(' mlofi , spread_compression ,cross_market_corr');
+    expect(s.size).toBe(3);
+    expect(s.has('mlofi')).toBe(true);
+    expect(s.has('spread_compression')).toBe(true);
+    expect(s.has('cross_market_corr')).toBe(true);
+  });
+
+  it('drops empty entries (trailing commas)', () => {
+    const s = parseDisabledSignalIds('mlofi,,spread_compression,');
+    expect(s.size).toBe(2);
+  });
+
+  it('preserves the standard not-wired-in-backtest list', () => {
+    const list = 'mlofi,spread_compression,cross_market_corr,price_divergence,attention_spike,news_sentiment';
+    const s = parseDisabledSignalIds(list);
+    expect(s.size).toBe(6);
+  });
+});
 
 /**
  * Extract the pure Bayesian confidence cap computation for testing.

--- a/packages/dashboard/src/services/SignalEngine.ts
+++ b/packages/dashboard/src/services/SignalEngine.ts
@@ -114,6 +114,18 @@ const DEFAULT_CONFIG: Omit<SignalEngineConfig, 'directionResolver'> = {
   exitThreshold: 0.25,           // Exit threshold (lower — only exits on real reversals)
 };
 
+/** Parse comma-separated SIGNAL_TYPES_DISABLED env var into a Set.
+ *  Whitespace-tolerant. Empty / unset → empty set. */
+export function parseDisabledSignalIds(raw: string | undefined): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+  );
+}
+
 interface ActiveMarket {
   id: string;
   question: string;
@@ -179,6 +191,11 @@ export class SignalEngine extends EventEmitter {
         minCombinedStrength: this.config.minCombinedStrength ?? 0.27,
         // Loaded from signal_weights table at startup (matches direction_multiplier precedent)
         consensusDiscountFloor: this.config.consensusDiscountFloor ?? 0.5,
+        // Hard-disabled signals (env: SIGNAL_TYPES_DISABLED, comma-separated).
+        // Bypasses any signal_weights row. Use for generators not wired into
+        // BacktestService (where Optuna can't fit them meaningfully) or
+        // empirically anti-edge ones.
+        disabledSignalIds: parseDisabledSignalIds(process.env.SIGNAL_TYPES_DISABLED),
       }
     );
   }

--- a/packages/signals/src/combiners/WeightedAverageCombiner.test.ts
+++ b/packages/signals/src/combiners/WeightedAverageCombiner.test.ts
@@ -109,6 +109,70 @@ describe('WeightedAverageCombiner — applied direction multiplier', () => {
   });
 });
 
+describe('WeightedAverageCombiner — disabledSignalIds', () => {
+  it('drops a disabled signal even when it has a non-zero weight', () => {
+    const combiner = new WeightedAverageCombiner(
+      { momentum: 1, mlofi: 1 },
+      { ...params(), disabledSignalIds: new Set(['mlofi']) }
+    );
+    combiner.setDirectionMultiplier(1); // disable contrarian default for assertion clarity
+    const signals = [
+      buildSignal({ signalId: 'momentum',   direction: 'long',  strength: 0.6, confidence: 0.9 }),
+      buildSignal({ signalId: 'mlofi',      direction: 'short', strength: 0.8, confidence: 0.9 }),
+    ];
+    const result = combiner.combine(signals);
+    expect(result).not.toBeNull();
+    // mlofi (short, 0.8) is filtered out; only momentum (long, 0.6) contributes.
+    expect(result!.direction).toBe('LONG');
+    expect(result!.componentSignals.map((s) => s.signalId)).toEqual(['momentum']);
+  });
+
+  it('drops a disabled signal even when typeWeights would assign it', () => {
+    const combiner = new WeightedAverageCombiner({}, {
+      ...params(),
+      disabledSignalIds: new Set(['spread_compression']),
+    });
+    combiner.setDirectionMultiplier(1);
+    combiner.setTypeWeights({
+      event_financial: { mean_reversion: 0.5, spread_compression: 1.99 },
+    });
+    const signals = [
+      buildSignal({ signalId: 'mean_reversion',     direction: 'long',  strength: 0.6, confidence: 0.9 }),
+      buildSignal({ signalId: 'spread_compression', direction: 'short', strength: 0.9, confidence: 0.9 }),
+    ];
+    const result = combiner.combine(signals, undefined, 'event_financial');
+    expect(result).not.toBeNull();
+    expect(result!.componentSignals.map((s) => s.signalId)).toEqual(['mean_reversion']);
+  });
+
+  it('setDisabledSignalIds replaces the previous set', () => {
+    const combiner = new WeightedAverageCombiner(
+      { momentum: 1, mlofi: 1 },
+      { ...params(), disabledSignalIds: new Set(['mlofi']) }
+    );
+    combiner.setDirectionMultiplier(1);
+    combiner.setDisabledSignalIds([]); // re-enable everything
+    expect(combiner.getDisabledSignalIds().size).toBe(0);
+
+    const result = combiner.combine([
+      buildSignal({ signalId: 'momentum', direction: 'long', strength: 0.6, confidence: 0.9 }),
+      buildSignal({ signalId: 'mlofi',    direction: 'long', strength: 0.6, confidence: 0.9 }),
+    ]);
+    expect(result!.componentSignals.length).toBe(2);
+  });
+
+  it('empty set is the default and does not filter anything', () => {
+    const combiner = new WeightedAverageCombiner({ momentum: 1, mlofi: 1 }, params());
+    combiner.setDirectionMultiplier(1);
+    expect(combiner.getDisabledSignalIds().size).toBe(0);
+    const result = combiner.combine([
+      buildSignal({ signalId: 'momentum', direction: 'long', strength: 0.6, confidence: 0.9 }),
+      buildSignal({ signalId: 'mlofi',    direction: 'long', strength: 0.6, confidence: 0.9 }),
+    ]);
+    expect(result!.componentSignals.length).toBe(2);
+  });
+});
+
 function mkSignalForConsensusTest(direction: 'LONG' | 'SHORT' | 'NEUTRAL'): SignalOutput {
   return {
     signalId: 'x',

--- a/packages/signals/src/combiners/WeightedAverageCombiner.ts
+++ b/packages/signals/src/combiners/WeightedAverageCombiner.ts
@@ -24,6 +24,12 @@ interface WeightedAverageParams {
   /** Consensus discount floor ∈ [0, 1]. 1.0 = no effect. 0.0 = aggressive
    *  filter. Optuna tunes this value weekly via signal_weights table. */
   consensusDiscountFloor: number;
+  /** Signal IDs disabled entirely. Filtered before weight lookup so they
+   *  contribute zero regardless of signal_weights rows or per-type weights.
+   *  Mirrors EXECUTOR_BLOCKED_TYPE_DIRECTIONS semantics for signal_type-level
+   *  control. The Optimizer can still write rows for these signals — they're
+   *  ignored here, immune to oscillation. */
+  disabledSignalIds: Set<string>;
 }
 
 /**
@@ -135,8 +141,19 @@ export class WeightedAverageCombiner implements ISignalCombiner {
       timeDecayFactor: 0.9,
       maxSignalAgeMs: 5 * 60 * 1000, // 5 minutes
       consensusDiscountFloor: 0.5,
+      disabledSignalIds: new Set<string>(),
       ...params,
     };
+  }
+
+  /** Replace the disabled signal-id set. Pass empty Set to re-enable everything. */
+  setDisabledSignalIds(ids: Iterable<string>): void {
+    this.parameters.disabledSignalIds = new Set(ids);
+    this.logger.info({ disabled: Array.from(this.parameters.disabledSignalIds) }, 'Disabled signal IDs updated');
+  }
+
+  getDisabledSignalIds(): Set<string> {
+    return new Set(this.parameters.disabledSignalIds);
   }
 
   /**
@@ -448,6 +465,13 @@ export class WeightedAverageCombiner implements ISignalCombiner {
    * Get weight for a specific signal, using market-type-specific weights if available
    */
   private getSignalWeight(signal: SignalOutput, now: Date, marketType?: string): number {
+    // Hard disable: configured via SIGNAL_TYPES_DISABLED env var. Immune to
+    // signal_weights rows (the Optimizer can write whatever it wants — this
+    // gate ignores them). Resolves the oscillation discovered 2026-05-12 where
+    // dashboard boot cleanup deleted rows but Optuna re-wrote them every 6h.
+    if (this.parameters.disabledSignalIds.has(signal.signalId)) {
+      return 0;
+    }
     // Per-type weights are explicit allowlists — generators not listed for this
     // market_type intentionally do not contribute. Default 0 honors that intent
     // (a previous default of 1 caused unlisted generators to dominate via the


### PR DESCRIPTION
## Why

On 2026-05-12 we discovered an oscillation: the dashboard boot cleanup (`packages/dashboard/src/server.ts:467-483`) deletes per-(signal_type, market_type) rows for 6 generators that are not wired into `BacktestService.createSignals` (`mlofi`, `spread_compression`, `cross_market_corr`, `price_divergence`, `attention_spike`, `news_sentiment`). The Render Optimizer trial-fits and re-writes those exact rows on every ~6h cycle. Between dashboard restarts and Optuna applies, these "not wired" generators are alive at high per-type weights, contributing to live combined signals despite empirical anti-edge (P2 t-stat 2026-05-11: mlofi t=-13 to -19, spread_compression t=-4, etc.).

A SQL `UPDATE … is_enabled=false` on `__global__` rows does NOT block them because `WeightedAverageCombiner` consults per-type rows first when they exist. See `project_generator_gating_bug.md`.

## What

Defensive combiner-layer gate:
- New `disabledSignalIds: Set<string>` in `WeightedAverageParams` (default empty).
- `getSignalWeight` returns 0 immediately for disabled signal ids — the existing `.filter(s => s.weight !== 0)` drops them before any consensus / weighted-average math.
- `setDisabledSignalIds(iter)` and `getDisabledSignalIds()` accessors.
- SignalEngine reads `SIGNAL_TYPES_DISABLED` (comma-separated env var) at construction via new exported `parseDisabledSignalIds` helper.
- `docker-compose.gcp.yml` sets the canonical not-wired list to match `server.ts:467`.

## Classification

`containment`. The principled fix is at the Optimizer (Render service) — stop trial-fitting and persisting per-type rows for not-wired signals. This PR is the executor-side guard so any oscillation in the meantime is harmless. Tracked as deferred item in `project_deferred_followups_2026-05-12.md`.

## Test plan

- [x] 4 new combiner tests (filter by signalId, override typeWeights, mutate via setDisabledSignalIds, default empty)
- [x] 4 new SignalEngine.parseDisabledSignalIds tests (undefined/empty, whitespace, trailing commas, canonical 6-signal list)
- [x] All 25 combiner tests pass
- [x] All 23 SignalEngine tests pass
- [x] No existing test changes (behavior preserved for default empty set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to disable specific signal types via environment configuration, allowing control over which signals are processed in the signal combination engine.

* **Tests**
  * Added test coverage for signal disabling functionality, verifying configuration parsing, proper filtering, and excluded signal behavior in weighted calculations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/210)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->