### PR TITLE
fix(classifier): route year-horizon binary crypto markets to event_long

### DIFF
--- a/packages/dashboard/src/services/MarketClassifier.test.ts
+++ b/packages/dashboard/src/services/MarketClassifier.test.ts
@@ -59,5 +59,29 @@ describe('MarketClassifier', () => {
       // Question with no keywords at all, no end date → still returns a type
       expect(classifier.classifyWithRegex('Opaque question with no hints', null)).toBe('event_short');
     });
+
+    it('routes year-horizon binary crypto markets to event_long, not crypto_intraday', () => {
+      // Real example from 2026-05-12: end_date 2027-01-01, "dip to" phrasing.
+      // Pre-fix would have matched isUpDown and returned crypto_intraday despite
+      // the year-horizon end_date.
+      const yearOut = new Date(Date.now() + 230 * 24 * 60 * 60 * 1000); // ~2027-01
+      expect(
+        classifier.classifyWithRegex('Will Bitcoin dip to $55,000 by Dec 31, 2026?', yearOut)
+      ).toBe('event_long');
+    });
+
+    it('routes "hit $X by <far date>" crypto markets to event_long', () => {
+      const yearOut = new Date(Date.now() + 230 * 24 * 60 * 60 * 1000);
+      expect(
+        classifier.classifyWithRegex('Will Bitcoin hit $150k by June 30, 2026?', yearOut)
+      ).toBe('event_long');
+    });
+
+    it('keeps crypto markets at <= 4h horizon as crypto_intraday', () => {
+      const threeHours = new Date(Date.now() + 3 * 60 * 60 * 1000);
+      expect(
+        classifier.classifyWithRegex('Will Bitcoin reach $100k in the next 3 hours?', threeHours)
+      ).toBe('crypto_intraday');
+    });
   });
 });

--- a/packages/dashboard/src/services/MarketClassifier.ts
+++ b/packages/dashboard/src/services/MarketClassifier.ts
@@ -163,6 +163,14 @@ export class MarketClassifier {
         console.warn(`[MarketClassifier] Haiku said "${text}" but question does not look like a crypto price market, overriding to ${fallback}: "${question.slice(0, 60)}"`);
         return fallback;
       }
+      // Horizon sanity: crypto markets resolving > 7 days are not intraday/daily.
+      // E.g., "Will Bitcoin dip to $55,000 by Dec 31, 2026?" with end_date in 2027
+      // — the 4h MAX_HOLD_TIME_HOURS makes signal-based trading structurally
+      // unprofitable on these. Route to event_long so the live gate shadows them.
+      if ((text === 'crypto_intraday' || text === 'crypto_daily') && this.endsAfterCryptoHorizon(endDate)) {
+        console.warn(`[MarketClassifier] Haiku said "${text}" but end_date is > 7 days out, overriding to event_long: "${question.slice(0, 60)}"`);
+        return 'event_long';
+      }
       // Same sanity check for event_financial — ensure it has a financial keyword.
       if (text === 'event_financial' && !this.questionLooksFinancial(question)) {
         const fallback = this.classifyWithRegex(question, endDate);
@@ -229,6 +237,15 @@ export class MarketClassifier {
     return commodities.test(question) || equitiesIndices.test(question) || rates.test(question) || forex.test(question);
   }
 
+  /** True when end_date is more than 7 days from now (the upper bound of
+   *  the crypto_daily horizon). Returns false for null end_date because we
+   *  can't tell, so callers stick with the legacy "treat as daily" default. */
+  private endsAfterCryptoHorizon(endDate: Date | null): boolean {
+    if (!endDate) return false;
+    const hoursUntilEnd = (endDate.getTime() - Date.now()) / (1000 * 60 * 60);
+    return hoursUntilEnd > 7 * 24;
+  }
+
   /**
    * Simple regex-based classification as fallback.
    * Priority: crypto > financial > event_{long,short}.
@@ -241,9 +258,17 @@ export class MarketClassifier {
     if (isCrypto) {
       if (endDate) {
         const hoursUntilEnd = (endDate.getTime() - Date.now()) / (1000 * 60 * 60);
-        if (hoursUntilEnd <= 4 || isUpDown) return 'crypto_intraday';
+        if (hoursUntilEnd <= 4) return 'crypto_intraday';
         if (hoursUntilEnd <= 7 * 24) return 'crypto_daily';
+        // Year-horizon binary crypto markets (e.g., "Will Bitcoin dip to $55,000
+        // by Dec 31, 2026?" with end_date in 2027). The 4h MAX_HOLD_TIME_HOURS
+        // makes signal-based trading structurally unprofitable on these — 7/7
+        // time exits, 0% WR observed 2026-05-12. Route to event_long so the
+        // live gate shadows them but does not live-trade.
+        return 'event_long';
       }
+      // No end_date: legacy behaviour — treat as intraday for up/down phrasing,
+      // else daily. Reached only when classifying a market with NULL end_date.
       return isUpDown ? 'crypto_intraday' : 'crypto_daily';
     }
 


### PR DESCRIPTION
## Root cause

PR #209 (block crypto_intraday:long) was containment. The real bug:

`MarketClassifier.classifyWithRegex` matched `isUpDown` ("dip to"/"hit \$") before checking the actual horizon. Result: "Will Bitcoin dip to \$55,000 by Dec 31, 2026?" with end_date 2027-01-01 was tagged `crypto_intraday` despite year-long resolution. The 4h `MAX_HOLD_TIME_HOURS` killed every trade: 7/7 time exits, 0% WR, -\$11.23 in one day (2026-05-12).

`MarketClassifier.classifyWithHaiku` similarly lacked a horizon sanity check — when Haiku correctly returned `crypto_intraday` for a year-horizon market, we would accept it.

## Fix

- `classifyWithRegex`: short-circuit only on actual 4h horizon. Crypto markets with end_date > 7 days route to `event_long`.
- `classifyWithHaiku`: new `endsAfterCryptoHorizon` sanity check overrides `crypto_*` to `event_long` when end_date > 7 days.

`event_long` is shadow-only in `ALLOWED_MARKET_TYPES`, so misclassified markets will accumulate shadow data but will not live-trade.

## Backfill (manual, post-merge)

```sql
UPDATE markets SET market_type = 'event_long'
WHERE market_type = 'crypto_intraday'
  AND end_date > NOW() + INTERVAL '7 days';
```

Once run, the `crypto_intraday:long` entry in `EXECUTOR_BLOCKED_TYPE_DIRECTIONS` (PR #209) becomes redundant for those markets, though it stays as defence-in-depth.

## Classification

`root-cause`. This closes the misclassification path that produced PR #209.

## Test plan

- [x] 12/12 MarketClassifier tests pass (3 new — year-horizon "dip to", "hit \$X by", and intraday horizon still classifies as crypto_intraday)
- [x] No existing test changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crypto market classification to correctly distinguish between short-term and long-term markets. Markets with end dates beyond 7 days are now properly classified as longer-term events instead of intraday/daily trades.

* **Tests**
  * Added test coverage for horizon-based crypto market classification behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/211)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->