### PR TITLE
feat(p2): cost-aware t-stat tool (gross + net) and skill update

### DIFF
--- a/.claude/skills/daily-autoreview-analysis/SKILL.md
+++ b/.claude/skills/daily-autoreview-analysis/SKILL.md
@@ -105,6 +105,26 @@ Report: live PnL/WR vs shadow PnL/WR side-by-side, per (type, side). Flag when:
 
 The empirical haircut for shadow → live (project_shadow_execution_realism.md) is currently 0.33 for `event_long` (n=16, small sample). Do NOT use shadow Sharpe directly to argue for promotion — apply the haircut and note it.
 
+**Per-generator P2 cost-aware t-stat** (whenever proposing to enable, disable, or rebalance a (signal, market_type, direction) cell):
+
+Gross t-stat from raw `generator_predictions` joined to 4h-forward `price_history` drift over-states edge because it ignores execution costs. For low-volatility cohorts (year-horizon binary markets, mid-priced event_financial) the drift is comparable to round-trip cost (~0.5%), so a +8 gross t-stat can be a near-zero or negative net t-stat. Empirically falsified 2026-05-12 (`mean_reversion crypto_intraday LONG`: gross t=+8 → live 0/7 WR).
+
+Always run **both** versions side-by-side via `scripts/p2-tstat.js`:
+
+```bash
+# From VM (preferred — pg + DATABASE_URL are present in dashboard container):
+docker cp /home/Usuario/polymarket-trader/scripts/p2-tstat.js polymarket-dashboard-api:/app/p2-tstat.js
+docker exec polymarket-dashboard-api node /app/p2-tstat.js --window 7d --rtcost 0.005
+
+# Flags:
+#   --window {7d|3d|24h}   lookback (default 7d)
+#   --rtcost 0.005         round-trip cost as fraction (default 0.005 = 0.5%)
+#   --horizon 4h           forward price horizon (default 4h)
+#   --minn 100             skip cohorts smaller than N (default 100)
+```
+
+The script outputs per-(signal, type, direction) gross_pct, net_pct, t_gross, t_net. **Decisions must use t_net, not t_gross.** Flag any cell with t_gross ≥ 2 but t_net ≤ 0 — that's a cohort where edge exists in theory but is consumed by friction. Captured as a principle in `feedback_realistic_costs.md`.
+
 **Loss-streak forensic** (MANDATORY when consecutive losses ≥ 5 OR daily PnL < −$30 OR day-N win rate < 50% of historical baseline):
 
 Do NOT accept the auto-review's narrative ("warm-up artifact", "post-deploy noise", "low signal confidence on first exposure") at face value. The auto-review is biased toward not creating reactive PRs, which can read as complacency when losses actually fit known dysfunctional patterns. Examine the streak yourself:

--- a/scripts/p2-tstat.js
+++ b/scripts/p2-tstat.js
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+/**
+ * P2 per-generator t-stat — gross AND net of execution costs.
+ *
+ * Why net: gross t-stat measures the average 4h price drift after each
+ * prediction, ignoring fees + spread. For low-volatility cohorts the drift
+ * is comparable to round-trip cost (~0.5%), so a gross t-stat of +8 can be
+ * a net t-stat near zero or negative.  This was empirically falsified on
+ * 2026-05-12 (mean_reversion crypto_intraday LONG: gross t=+8 → live 0/7 WR).
+ *
+ * Reports both side-by-side so allow/block decisions can use the net version.
+ *
+ * Usage (run from monorepo root or anywhere with DATABASE_URL set):
+ *   DATABASE_URL=postgres://... node scripts/p2-tstat.js
+ *   DATABASE_URL=postgres://... node scripts/p2-tstat.js --window 3d --rtcost 0.005
+ *
+ * Flags:
+ *   --window N{d|h}  Lookback window for predictions. Default 7d.
+ *   --rtcost X       Round-trip cost as fraction (fee+spread). Default 0.005 (0.5%).
+ *                     Overrides env P2_ROUND_TRIP_COST.
+ *   --horizon Nh     Forward horizon in hours. Default 4h (= MAX_HOLD_TIME_HOURS).
+ *   --minn N         Drop cohorts with fewer than N observations. Default 100.
+ *
+ * Example output:
+ *   signal_id          | market_type     | dir   | n     | gross_pct | net_pct | t_gross | t_net
+ *   mean_reversion     | event_financial | long  | 2619  | +0.28     | -0.22   | +8.61   | -6.83
+ *   ...
+ */
+const { Pool } = require('pg');
+
+function parseArgs(argv) {
+  const args = { window: '7d', rtcost: null, horizon: '4h', minn: 100 };
+  for (let i = 2; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === '--window') args.window = argv[++i];
+    else if (k === '--rtcost') args.rtcost = parseFloat(argv[++i]);
+    else if (k === '--horizon') args.horizon = argv[++i];
+    else if (k === '--minn') args.minn = parseInt(argv[++i], 10);
+  }
+  if (args.rtcost == null) {
+    args.rtcost = parseFloat(process.env.P2_ROUND_TRIP_COST || '0.005');
+  }
+  return args;
+}
+
+function intervalLiteral(s) {
+  // Accept "7d", "24h", "30d" → "INTERVAL '7 days'" etc.
+  const m = s.match(/^(\d+)([dh])$/);
+  if (!m) throw new Error(`Invalid window/horizon: ${s}`);
+  const unit = m[2] === 'd' ? 'days' : 'hours';
+  return `INTERVAL '${m[1]} ${unit}'`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const windowSql = intervalLiteral(args.window);
+  const horizonSql = intervalLiteral(args.horizon);
+  const horizonHi = intervalLiteral(args.horizon.replace(/(\d+)([dh])/, (_, n, u) => `${parseInt(n, 10) + 1}${u}`));
+
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  try {
+    const q = `
+      WITH outcomes AS (
+        SELECT
+          g.signal_id,
+          g.market_type,
+          g.direction,
+          g.yes_price_at_signal::numeric AS y0,
+          (
+            SELECT p.close::numeric
+            FROM price_history p
+            WHERE p.market_id = g.market_id
+              AND p.time >= g.time + ${horizonSql}
+              AND p.time <  g.time + ${horizonHi}
+            ORDER BY p.time ASC
+            LIMIT 1
+          ) AS y1
+        FROM generator_predictions g
+        WHERE g.time >= NOW() - ${windowSql}
+          AND g.direction IN ('long','short')
+      ),
+      edges AS (
+        SELECT
+          signal_id, market_type, direction, y0, y1,
+          CASE WHEN direction='long' THEN y1 - y0 ELSE y0 - y1 END AS gross_edge
+        FROM outcomes
+        WHERE y1 IS NOT NULL
+      ),
+      stats AS (
+        SELECT
+          signal_id, market_type, direction,
+          COUNT(*) AS n,
+          AVG(gross_edge) AS mean_gross,
+          STDDEV(gross_edge) AS sd_gross
+        FROM edges
+        GROUP BY 1,2,3
+        HAVING COUNT(*) >= $1
+      )
+      SELECT
+        signal_id, market_type, direction, n,
+        ROUND((mean_gross * 100)::numeric, 4)            AS gross_pct,
+        ROUND(((mean_gross - $2) * 100)::numeric, 4)     AS net_pct,
+        CASE WHEN sd_gross > 0 THEN
+          ROUND((mean_gross * SQRT(n) / sd_gross)::numeric, 2)
+        END AS t_gross,
+        CASE WHEN sd_gross > 0 THEN
+          ROUND(((mean_gross - $2) * SQRT(n) / sd_gross)::numeric, 2)
+        END AS t_net
+      FROM stats
+      ORDER BY t_net DESC NULLS LAST;
+    `;
+    const result = await pool.query(q, [args.minn, args.rtcost]);
+
+    const header = ['signal_id', 'market_type', 'direction', 'n', 'gross_pct', 'net_pct', 't_gross', 't_net'];
+    const widths = [22, 18, 8, 8, 10, 10, 10, 10];
+    console.log(`\nP2 t-stat (window=${args.window}, horizon=${args.horizon}, round-trip cost=${(args.rtcost * 100).toFixed(2)}%, min n=${args.minn})\n`);
+    console.log(header.map((h, i) => h.padEnd(widths[i])).join(' | '));
+    console.log(widths.map((w) => '-'.repeat(w)).join('-+-'));
+    for (const row of result.rows) {
+      const tNet = row.t_net != null ? Number(row.t_net) : null;
+      const verdict = tNet == null ? '' : tNet >= 2 ? '  ← edge net' : tNet <= -2 ? '  ← anti net' : '';
+      const cells = [
+        String(row.signal_id),
+        String(row.market_type),
+        String(row.direction),
+        String(row.n),
+        row.gross_pct != null ? Number(row.gross_pct).toFixed(4) : '—',
+        row.net_pct != null ? Number(row.net_pct).toFixed(4) : '—',
+        row.t_gross != null ? Number(row.t_gross).toFixed(2) : '—',
+        row.t_net != null ? Number(row.t_net).toFixed(2) : '—',
+      ];
+      console.log(cells.map((c, i) => c.padEnd(widths[i])).join(' | ') + verdict);
+    }
+    console.log(`\nNote: t_gross ignores fees + spread. t_net subtracts the round-trip cost from mean edge.`);
+    console.log(`Use t_net (not t_gross) for allow/block decisions. See feedback_realistic_costs.md.\n`);
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('Error:', err.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Why

P2 per-generator t-stat measures gross 4h-forward price drift after each prediction, ignoring fees + spread. For low-volatility cohorts (year-horizon binaries, mid-priced event_financial) drift is comparable to round-trip cost (~0.5%), so a +8 gross t-stat can be a net t-stat near zero or negative.

Empirically falsified 2026-05-12: \`mean_reversion crypto_intraday LONG\` had gross t=+8.00 over 3 days; live result was 7/7 time exits and 0% WR. We allowed the cohort based on gross; net would have flagged it as friction-consumed.

Captured as a recurring principle in \`feedback_realistic_costs.md\` and now operationalized as a tool.

## What

\`scripts/p2-tstat.js\`:
- Per-(signal_id, market_type, direction) report over \`generator_predictions\` joined to 4h-forward \`price_history\`.
- Reports both \`gross_pct\` / \`t_gross\` (drift only) and \`net_pct\` / \`t_net\` (drift minus round-trip cost).
- Flags \`<- edge net\` for cells with \`t_net >= 2\`, \`<- anti net\` for \`t_net <= -2\`.
- Configurable: \`--window\`, \`--rtcost\`, \`--horizon\`, \`--minn\`.

Daily-autoreview-analysis skill updated to:
- Include a "Per-generator P2 cost-aware t-stat" mandatory step whenever proposing to enable/disable/rebalance a cell.
- Explicit instruction: decisions use \`t_net\`, not \`t_gross\`.
- Documents how to run on the VM (docker cp + docker exec, since dashboard-api container already has \`pg\`).

## Classification

\`root-cause\` for the analysis pipeline. The runtime allow/block decisions in \`EXECUTOR_BLOCKED_TYPE_DIRECTIONS\` and \`SIGNAL_TYPES_DISABLED\` remain unchanged; this PR ensures future decisions do not repeat the gross-only mistake.

## Test plan

- [x] Parser smoke test (no DB) passes — no syntax errors
- [ ] First live run lands at the next daily review (DB connection requires \`pg\` from dashboard-api container)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cost-aware signal evaluation capability with configurable lookback windows and round-trip cost parameters.
  * New analysis script for computing net profit t-statistics on trading signals.

* **Documentation**
  * Added guidance for interpreting cost-aware metrics and flagging cases where signals appear profitable before costs but unprofitable after costs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/212)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->