### PR TITLE
fix(backtest): realistic spread + drop OHLC-as-bid/ask hack

### DIFF
--- a/packages/backtest/src/engine/BacktestEngine.ts
+++ b/packages/backtest/src/engine/BacktestEngine.ts
@@ -390,7 +390,13 @@ export class BacktestEngine {
         bar => bar.time >= this.config.startDate && bar.time <= this.config.endDate
       );
 
-      // Generate price update events from bars
+      // Generate price update events from bars.
+      // bid/ask are intentionally omitted: bars carry OHLC, not order-book quotes.
+      // Using bar.low/bar.high as bid/ask produced an artificially zero spread on
+      // snapshot bars (low == high == close) and an unrealistically wide spread
+      // on volatile bars (e.g. 8% on a 1-min bar that wicked). The synthetic
+      // spread inside OrderBookSimulator (baseSpreadPct) is a better proxy for
+      // Polymarket's actual round-trip cost.
       for (const bar of validBars) {
         const priceEvent: PriceUpdateEvent = {
           type: 'PRICE_UPDATE',
@@ -400,8 +406,6 @@ export class BacktestEngine {
             tokenId: bar.tokenId,
             price: bar.close,
             volume: bar.volume,
-            bid: bar.low,
-            ask: bar.high,
           },
         };
         events.push(priceEvent);

--- a/packages/backtest/src/simulation/OrderBookSimulator.ts
+++ b/packages/backtest/src/simulation/OrderBookSimulator.ts
@@ -63,9 +63,17 @@ export class OrderBookSimulator implements IOrderBookSimulator {
     slippageModel: SlippageModel,
     config?: Partial<OrderBookSimulatorConfig>
   ) {
+    // baseSpreadPct: percent of mid (e.g. 1.5 = 1.5% mid-relative spread).
+    // Default 1.5% matches empirical Polymarket round-trip cost — earlier 0.5%
+    // under-priced friction on snapshot-driven backtests and caused Optuna to
+    // over-reward signals whose drift < real spread. Override via env var
+    // BACKTEST_BASE_SPREAD_PCT for explicit calibration.
+    const envSpread = process.env.BACKTEST_BASE_SPREAD_PCT
+      ? parseFloat(process.env.BACKTEST_BASE_SPREAD_PCT)
+      : null;
     this.config = {
       depthLevels: 10,
-      baseSpreadPct: 0.5,
+      baseSpreadPct: envSpread != null && Number.isFinite(envSpread) && envSpread > 0 ? envSpread : 1.5,
       sizeDecay: 0.8,
       minLevelSize: 100,
       volumeSpreadImpact: 0.1,


### PR DESCRIPTION
## Why

The backtest under-prices execution friction in two related ways:

1. `BacktestEngine` passed `bar.low` as bid and `bar.high` as ask in `PRICE_UPDATE` events. Bars carry OHLC, not order-book quotes. For a snapshot bar (no trades, low==high==close) this produced **zero spread**. For a volatile 1-min bar that wicked from 0.48 to 0.52 it produced **8% spread**. Neither is realistic.

2. `OrderBookSimulator.baseSpreadPct` defaulted to 0.5%. Polymarket empirical round-trip cost is closer to 1.5-2.0%.

Combined effect: Optuna's per-type fitness over-rewarded signals whose actual 4h price drift is smaller than the real spread + fee, recommending high weights for generators whose live edge is consumed by friction. Same class of error empirically falsified on 2026-05-12 (mean_reversion crypto_intraday LONG, gross t=+8 → live 0/7 WR). Principle in `feedback_realistic_costs.md`.

## Changes

- `BacktestEngine.ts`: drop `bid: bar.low, ask: bar.high` from `PRICE_UPDATE` events. Let `OrderBookSimulator` build synthetic quotes from the configured spread.
- `OrderBookSimulator.ts`: default `baseSpreadPct` 0.5 → 1.5. New env override `BACKTEST_BASE_SPREAD_PCT` for explicit calibration.

## Expected impact

The next Optuna cycle will produce different per-type weights — generators whose net edge (drift minus ~1.7% round-trip cost) is negative should get lower weights. Generators with genuine sub-second-level edge above friction should retain or gain weight. Validation: post-deploy, compare cycle-N weights to cycle-N-1.

## Classification

`root-cause`. Closes the backtest-vs-live realism gap that produced the recurring "Optuna recommends X, live loses on X" pattern.

## Test plan

- [x] 82/82 backtest tests pass
- [x] 371/385 dashboard tests pass (14 pre-existing skips unchanged)
- [ ] Live validation: next Optuna cycle should rebalance away from low-drift cohorts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined price update event structure for more consistent quote handling in backtesting simulations.

* **Configuration**
  * Default market spread adjusted from 0.5% to 1.5%.
  * Market spread percentage now configurable via environment variables for greater flexibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/213)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->