### PR TITLE
fix(scheduler): zombie prune now catches expired markets

### DIFF
--- a/packages/data-collector/src/services/Scheduler.ts
+++ b/packages/data-collector/src/services/Scheduler.ts
@@ -527,17 +527,30 @@ export class Scheduler {
    */
   private async pruneZombieMarkets(): Promise<void> {
     const pool = getPool();
+    // Two zombie criteria:
+    //  1. End date passed by >1 day — market is no longer tradeable regardless
+    //     of update recency. (The previous `updated_at < NOW() - 7d` gate never
+    //     fired because sync-markets refreshes updated_at every 5 min, so
+    //     43k+ expired markets were left is_active=true. Discovered 2026-05-12
+    //     investigating event_short supply: 43,138 expired event_short alone.)
+    //  2. No volume + no recent update >7d — legacy criterion for null-end_date
+    //     markets that drifted out of activity.
     const result = await pool.query(`
       UPDATE markets
       SET is_active = false, updated_at = NOW()
       WHERE is_active = true
-        AND is_resolved = false
-        AND (volume_24h IS NULL OR volume_24h = 0)
-        AND updated_at < NOW() - INTERVAL '7 days'
+        AND COALESCE(is_resolved, false) = false
+        AND (
+          (end_date IS NOT NULL AND end_date < NOW() - INTERVAL '1 day')
+          OR (
+            (volume_24h IS NULL OR volume_24h = 0)
+            AND updated_at < NOW() - INTERVAL '7 days'
+          )
+        )
     `);
     const pruned = result.rowCount ?? 0;
     if (pruned > 0) {
-      logger.info({ pruned }, 'Pruned zombie markets (no volume, stale >7d)');
+      logger.info({ pruned }, 'Pruned zombie markets (expired or stale)');
     }
   }
 

--- a/scripts/event_short_investigation.sql
+++ b/scripts/event_short_investigation.sql
@@ -1,0 +1,80 @@
+-- 1. Markets event_short ACTIVE+COLD por horizon end_date
+SELECT
+  CASE
+    WHEN end_date IS NULL THEN '(null end_date)'
+    WHEN end_date < NOW() THEN 'past (expired)'
+    WHEN end_date < NOW() + INTERVAL '24 hours' THEN '< 24h'
+    WHEN end_date < NOW() + INTERVAL '7 days' THEN '1-7 days'
+    WHEN end_date < NOW() + INTERVAL '30 days' THEN '7-30 days'
+    WHEN end_date < NOW() + INTERVAL '90 days' THEN '30-90 days'
+    ELSE '> 90 days'
+  END AS horizon,
+  COUNT(*) AS n
+FROM markets
+WHERE market_type='event_short' AND is_active=true AND COALESCE(is_resolved,false)=false
+GROUP BY 1 ORDER BY 1;
+
+-- 2. Sub-cohorts via question prefix (all currently event_short active markets)
+SELECT
+  CASE
+    WHEN question ~* '^will [a-z ]+ win on [0-9]' THEN 'sports_match_dated'
+    WHEN question ~* 'world cup|fifa|nba|nfl|nhl|mlb|ufc|formula|olympics|tennis' THEN 'sports_tournament_other'
+    WHEN question ~* 'election|senate|president|governor|congress|democrat|republican' THEN 'politics_us'
+    WHEN question ~* 'fed|cpi|ppi|gdp|unemployment|inflation|rate cut|rate hike' THEN 'macro_data'
+    WHEN question ~* 'bitcoin|btc|ethereum|eth|crypto|sol|altcoin' THEN 'crypto_misc'
+    ELSE 'other'
+  END AS bucket,
+  COUNT(*) AS n,
+  COUNT(*) FILTER (WHERE end_date < NOW() + INTERVAL '7 days') AS within_7d,
+  COUNT(*) FILTER (WHERE volume_24h > 0) AS with_volume_24h
+FROM markets
+WHERE market_type='event_short' AND is_active=true AND COALESCE(is_resolved,false)=false
+GROUP BY 1 ORDER BY 2 DESC;
+
+-- 3. Shadow event_short LONG sub-cohorts (resolved last 30d)
+SELECT
+  CASE
+    WHEN m.question ~* '^will [a-z ]+ win on [0-9]' THEN 'sports_match_dated'
+    WHEN m.question ~* 'world cup|fifa|nba|nfl|nhl|mlb|ufc|formula|olympics|tennis' THEN 'sports_tournament_other'
+    WHEN m.question ~* 'election|senate|president|governor|congress' THEN 'politics_us'
+    WHEN m.question ~* 'fed|cpi|ppi|gdp|unemployment|inflation' THEN 'macro_data'
+    ELSE 'other'
+  END AS bucket,
+  COUNT(*) AS n,
+  ROUND(AVG(s.theoretical_pnl)::numeric, 2) AS avg_pnl,
+  COUNT(*) FILTER (WHERE s.theoretical_pnl > 0) AS wins,
+  ROUND(100.0 * COUNT(*) FILTER (WHERE s.theoretical_pnl > 0) / NULLIF(COUNT(*), 0), 1) AS wr_pct
+FROM shadow_trades s
+JOIN markets m ON m.id = s.market_id
+WHERE s.market_type='event_short' AND s.direction='long' AND s.resolved_at IS NOT NULL
+  AND s.time >= NOW() - INTERVAL '30 days'
+GROUP BY 1 ORDER BY 2 DESC;
+
+-- 4. Hold horizon (time → resolved_at) en shadow event_short LONG
+SELECT
+  CASE
+    WHEN EXTRACT(EPOCH FROM (s.resolved_at - s.time))/86400 < 1 THEN '< 1 day'
+    WHEN EXTRACT(EPOCH FROM (s.resolved_at - s.time))/86400 < 7 THEN '1-7 days'
+    WHEN EXTRACT(EPOCH FROM (s.resolved_at - s.time))/86400 < 30 THEN '7-30 days'
+    ELSE '> 30 days'
+  END AS held_horizon,
+  COUNT(*) AS n,
+  ROUND(AVG(s.theoretical_pnl)::numeric, 2) AS avg_pnl,
+  ROUND(100.0 * COUNT(*) FILTER (WHERE s.theoretical_pnl > 0) / NULLIF(COUNT(*), 0), 1) AS wr_pct
+FROM shadow_trades s
+WHERE s.market_type='event_short' AND s.direction='long' AND s.resolved_at IS NOT NULL
+  AND s.time >= NOW() - INTERVAL '30 days'
+GROUP BY 1 ORDER BY 1;
+
+-- 5. Sample of resolved event_short LONG shadow trades (top wins + losses) for context
+SELECT
+  LEFT(m.question, 80) AS q,
+  m.market_type,
+  ROUND(s.theoretical_pnl::numeric, 2) AS pnl,
+  ROUND(EXTRACT(EPOCH FROM (s.resolved_at - s.time))/86400, 1) AS days_held
+FROM shadow_trades s
+JOIN markets m ON m.id = s.market_id
+WHERE s.market_type='event_short' AND s.direction='long' AND s.resolved_at IS NOT NULL
+  AND s.time >= NOW() - INTERVAL '30 days'
+ORDER BY s.theoretical_pnl DESC
+LIMIT 10;

--- a/scripts/event_short_investigation_2.sql
+++ b/scripts/event_short_investigation_2.sql
@@ -1,0 +1,52 @@
+-- A. Cuantos markets event_short tienen end_date pasado vs is_active=true (zombie zombies)
+SELECT
+  COUNT(*) FILTER (WHERE end_date IS NOT NULL AND end_date < NOW()) AS expired_but_active,
+  COUNT(*) FILTER (WHERE end_date IS NOT NULL AND end_date >= NOW()) AS future,
+  COUNT(*) FILTER (WHERE end_date IS NULL) AS no_end_date,
+  COUNT(*) AS total
+FROM markets WHERE market_type='event_short' AND is_active=true AND COALESCE(is_resolved,false)=false;
+
+-- B. Sample de shadow event_short LONG wins — qué markets son realmente (puede ser misclassification antigua)
+SELECT
+  LEFT(m.question, 100) AS q,
+  m.market_type AS current_type,
+  s.market_type AS shadow_recorded_type,
+  ROUND(s.theoretical_pnl::numeric, 2) AS pnl,
+  ROUND(EXTRACT(EPOCH FROM (s.resolved_at - s.time))/86400, 1) AS days_held
+FROM shadow_trades s
+JOIN markets m ON m.id = s.market_id
+WHERE s.market_type='event_short' AND s.direction='long' AND s.resolved_at IS NOT NULL
+  AND s.theoretical_pnl > 0
+  AND s.time >= NOW() - INTERVAL '30 days'
+GROUP BY m.question, m.market_type, s.market_type, s.theoretical_pnl, s.time, s.resolved_at
+ORDER BY s.theoretical_pnl DESC
+LIMIT 5;
+
+-- C. Misma vista para LOSSES
+SELECT
+  LEFT(m.question, 100) AS q,
+  m.market_type AS current_type,
+  s.market_type AS shadow_recorded_type,
+  ROUND(s.theoretical_pnl::numeric, 2) AS pnl,
+  ROUND(EXTRACT(EPOCH FROM (s.resolved_at - s.time))/86400, 1) AS days_held
+FROM shadow_trades s
+JOIN markets m ON m.id = s.market_id
+WHERE s.market_type='event_short' AND s.direction='long' AND s.resolved_at IS NOT NULL
+  AND s.theoretical_pnl < 0
+  AND s.time >= NOW() - INTERVAL '30 days'
+GROUP BY m.question, m.market_type, s.market_type, s.theoretical_pnl, s.time, s.resolved_at
+ORDER BY s.theoretical_pnl ASC
+LIMIT 5;
+
+-- D. Cuantos shadow event_short LONG son ahora event_financial (misclassification drift)?
+SELECT
+  m.market_type AS current_type,
+  COUNT(*) AS shadow_n,
+  ROUND(AVG(s.theoretical_pnl)::numeric, 2) AS avg_pnl,
+  ROUND(100.0 * COUNT(*) FILTER (WHERE s.theoretical_pnl > 0) / NULLIF(COUNT(*), 0), 1) AS wr_pct
+FROM shadow_trades s
+JOIN markets m ON m.id = s.market_id
+WHERE s.market_type='event_short' AND s.direction='long' AND s.resolved_at IS NOT NULL
+  AND s.time >= NOW() - INTERVAL '30 days'
+GROUP BY m.market_type
+ORDER BY shadow_n DESC;


### PR DESCRIPTION
## Root cause

The existing zombie prune required \`updated_at < NOW() - 7d\` but \`sync-markets\` refreshes \`updated_at\` every 5 minutes. The gate never fired, so markets with end_date in the past stayed \`is_active=true\` indefinitely.

## Evidence (2026-05-12 investigation)

While investigating event_short supply, the catalog showed 70,468 markets with end_date in the past but \`is_active=true\`:

| market_type | expired_but_active |
|---|---|
| event_short | 43,138 |
| crypto_intraday | 12,991 |
| event_long | 12,542 |
| crypto_daily | 1,185 |
| event_financial | 612 |

This pollutes MarketRotator's candidate pool, MarketClassifier's pending queue, and any analytics that filter by \`is_active=true\`.

## Fix

\`pruneZombieMarkets\` now uses two OR-ed criteria:

1. \`end_date IS NOT NULL AND end_date < NOW() - INTERVAL '1 day'\` — new, catches the missed cohort.
2. \`(volume_24h IS NULL OR volume_24h = 0) AND updated_at < NOW() - INTERVAL '7 days'\` — kept for null-end_date markets.

Bulk cleanup applied manually on the VM (\`UPDATE 70468\`). This PR ensures the scheduler keeps the catalog clean every 6h.

Investigation SQL committed to \`scripts/event_short_investigation*.sql\` for reproducibility.

## Side benefit: invalidates the shadow event_short "edge" claim

The investigation also revealed that the 59.5% WR shown for shadow event_short LONG is misattribution: 407/660 of those trades are on markets that have since been reclassified to event_financial (e.g. "WTI Crude Oil hit LOW \$80 in April"). The 253 trades that remain genuinely event_short have a 0% WR and -\$124 avg. Documented separately.

## Classification

\`root-cause\`. The legacy criterion was strictly inactive (sync-markets keeps updated_at fresh), and the missing end_date check let zombies accumulate for months.

## Test plan

- [x] 250/250 data-collector tests pass
- [x] Scheduler.test.ts unchanged (pruneZombieMarkets isn't directly tested; behavior is observable via VM)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the market inactivity detection logic to identify zombie markets using additional criteria
  * Added diagnostic investigation utilities for analyzing event-based market performance and patterns

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/214)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->