### PR TITLE
feat(signal-weights): per-direction column + PK swap (PR-A schema)

### DIFF
--- a/docs/plans/2026-05-13-per-direction-weights-design.md
+++ b/docs/plans/2026-05-13-per-direction-weights-design.md
@@ -1,0 +1,152 @@
+# Per-Direction Signal Weights — Design
+
+**Date**: 2026-05-13
+**Trigger**: Cost-aware P2 t-stat (2026-05-13) revealed directional asymmetry the current schema cannot express. Example: `mean_reversion crypto_intraday` has t_net=+6.44 SHORT vs t_net=−23.96 LONG. The combiner averages both into a single weight per (signal_type, market_type), washing out edge.
+
+## Problem
+
+`signal_weights` is keyed on `(signal_type, market_type)` — a single weight applies to BOTH the LONG and the SHORT output of a generator on a given market type. Real edge is direction-specific (asymmetric on most cells, sometimes opposite-signed). Without per-direction granularity:
+
+1. Optuna cannot capture asymmetric edge in the weight space.
+2. The combiner cannot favour the profitable direction of a generator without amplifying its anti-edge direction too.
+3. Patches at the executor (`EXECUTOR_BLOCKED_TYPE_DIRECTIONS`) are coarse — they zero out the entire direction for a market_type rather than per-(signal, direction).
+4. The only operationally-correct cells get diluted into noise (see e.g. `mean_reversion crypto_intraday SHORT` n=126 t_net=+6.44 — drowned by 4 other anti-edge SHORT generators in the combined signal).
+
+## Goals
+
+- Add per-direction granularity to `signal_weights` so Optuna optimises per (signal_type, market_type, direction).
+- Migration: zero-downtime, backwards-compatible. Existing 55+ rows continue to work.
+- Combiner: looks up exact (sig, type, dir) row, falls back to '__all__' direction.
+- Optuna: trial space gains a third axis. Initial seed derived from the cost-aware t-stat (already measured).
+- Operational kill-switch: `SIGNAL_DIRECTIONS_DISABLED` env gate (mirrors `SIGNAL_TYPES_DISABLED` from PR #210), default empty.
+
+## Non-goals
+
+- Per-direction `direction_multiplier` pseudo-row — `direction_multiplier` is itself a multiplier on the combined direction; adding a direction to it makes no semantic sense. Keep its rows at direction='__all__'.
+- Per-direction `consensus_discount_floor` / `resolution_prior` config rows — they are global parameters, not generator outputs. Keep at '__all__'.
+- Removing the executor blocklist (`EXECUTOR_BLOCKED_TYPE_DIRECTIONS`) — keep as belt-and-suspenders. Per-direction weights are the cleaner lever for fine control; the blocklist remains a hard structural override.
+
+## Schema change
+
+```sql
+-- packages/data-collector/src/database/init/029_signal_weights_per_direction.sql
+-- Idempotent ALTER (re-runs are no-ops). New rows default to direction='__all__' so
+-- existing INSERTs without an explicit direction keep working.
+ALTER TABLE signal_weights
+  ADD COLUMN IF NOT EXISTS direction VARCHAR(8) NOT NULL DEFAULT '__all__'
+  CHECK (direction IN ('__all__','long','short'));
+
+ALTER TABLE signal_weights DROP CONSTRAINT IF EXISTS signal_weights_pkey_per_type;
+ALTER TABLE signal_weights
+  ADD CONSTRAINT signal_weights_pkey_per_direction
+  PRIMARY KEY (signal_type, market_type, direction);
+
+CREATE INDEX IF NOT EXISTS idx_signal_weights_lookup
+  ON signal_weights (signal_type, market_type, direction)
+  WHERE is_enabled = true;
+```
+
+**Boot path**: the init SQL runs only on fresh volume. Existing VM needs an idempotent ALTER at dashboard boot (same pattern as the existing `bootstrapDirectionMultiplier`). Add to `server.ts` init sequence right before the per-type bootstrap.
+
+## Lookup semantics (combiner)
+
+For a signal `s` on market_type `t` with output direction `d ∈ {long, short}`:
+
+```typescript
+weight = (
+  SELECT weight FROM signal_weights
+  WHERE signal_type = s AND market_type = t AND direction = d AND is_enabled = true
+) ?? (
+  SELECT weight FROM signal_weights
+  WHERE signal_type = s AND market_type = t AND direction = '__all__' AND is_enabled = true
+) ?? 0;
+```
+
+Fallback to '__all__' = backwards-compatible. New rows initially populated by the cost-aware seed (PR-D); until Optuna runs, every cell has a sensible initial value.
+
+## `SIGNAL_DIRECTIONS_DISABLED` env gate
+
+Identical mechanism to PR #210 (`SIGNAL_TYPES_DISABLED`). Comma-separated `signal_id:direction` tokens. Combiner skips any signal whose `signalId:direction` (uppercase) is in the set. Cost: ~30 LOC + 1 test. Default: empty (no-op).
+
+Use case: emergency operational override when the schema-driven weights drift or when we want to canary-disable a specific cell pre-optimization.
+
+## Migration strategy (zero-downtime)
+
+1. **PR-A (schema, additive only)**: ALTER TABLE adds the column with default '__all__'. PK swap is atomic in Postgres. All existing rows valid. All existing INSERT/UPSERT statements keep working (omitted column defaults to '__all__').
+
+2. **PR-B (combiner + env gate)**: combiner reads per-direction with fallback. New env var. No new rows yet — fallback handles everything.
+
+3. **PR-C (optimizer)**: Optuna trial space gains direction axis. Writes per-direction rows (LONG and SHORT separately) instead of '__all__'. Existing '__all__' rows untouched but progressively shadowed by per-direction rows.
+
+4. **PR-D (seed)**: SQL script seeds per-direction rows from current `__all__` rows × the cost-aware t-stat measured today. Scaling: `weight_dir = base_weight × max(0, 0.5 + 0.05 × t_net_dir)` clamped to [0, 2]. So strongly negative t_net rows seed near 0; strong positive seed near base. After Optuna runs, the seed gets refined.
+
+5. **PR-E (deprecation)**: once per-direction rows fully cover the active universe, change combiner default behaviour to ignore '__all__' rows (or keep them only for config/pseudo signals). Optional, can defer.
+
+## Affected files (from inventory)
+
+### Schema (1)
+- `packages/data-collector/src/database/init/029_signal_weights_per_direction.sql` (new)
+
+### Boot ALTER for existing VM (1)
+- `packages/dashboard/src/server.ts` — add ALTER block before line 356
+
+### Repo layer (1)
+- `packages/dashboard/src/database/repositories.ts:240-330` — `signalWeightsRepo.{get,getAll,getAllPerType,getPerType,update,updatePerType}` gain `direction` parameter, default '__all__'. Lookup falls back to '__all__'.
+
+### Combiner (2)
+- `packages/signals/src/combiners/WeightedAverageCombiner.ts` — `getSignalWeight()` per-direction lookup; new `disabledSignalDirections: Set<string>` param.
+- `packages/dashboard/src/services/SignalEngine.ts:200-260` — sync per-direction weights to combiner. Parse `SIGNAL_DIRECTIONS_DISABLED` env.
+
+### Optimizer (2)
+- `packages/dashboard/src/services/OptimizationScheduler.ts:1240-1280` — per-direction loop in `updateStrategy()`.
+- `packages/optimizer/*` (Render service) — Optuna study param space gains direction. Schema in Neon DB unaffected (trial storage).
+
+### API routes (1)
+- `packages/dashboard/src/api/routes.ts:1822-1829` (POST `/api/signals/weights`) — accept optional `direction` field, default '__all__'.
+
+### Seed script (1)
+- `scripts/seed-per-direction-weights.sql` (new) — backfills per-direction rows from t-stat.
+
+### Tests (estimated +6 files)
+- `WeightedAverageCombiner.perDirection.test.ts` (new)
+- `bootstrapDirectionMultiplier.test.ts` — verify dm stays at direction='__all__'
+- `repositories.test.ts` — verify per-direction lookup with fallback
+- `SignalEngine.test.ts` — verify per-direction sync
+- `OptimizationScheduler.test.ts` — verify per-direction updates respect min-lift per direction
+- `signal_weights_per_direction.migration.test.ts` (new)
+
+### Untouched
+- `direction_multiplier` rows: stay direction='__all__'.
+- `consensus_discount_floor` / `resolution_prior` config rows: stay '__all__'.
+- `SignalLearningService` updates global rows only — no change needed.
+- Daily-review / monitoring scripts: still read by signal_type; add direction column to output later.
+
+## Risks
+
+- **PK swap**: atomic in Postgres but locks the table briefly (~1s on 50 rows). Acceptable.
+- **Combiner regression**: fallback semantics must be correct; if buggy, weight becomes 0 → no trades. PR-B includes integration test that verifies fallback behaviour with a row at '__all__'.
+- **Optuna convergence time**: doubles param space (LONG, SHORT separately). One full cycle (~6h) before per-direction edges crystallize. The seed in PR-D mitigates by starting from a cost-aware prior.
+- **Stale '__all__' rows**: after PR-C starts writing per-direction, '__all__' rows from before become outdated. The lookup priority (direction-first, fallback) handles this correctly — but PR-E is the eventual cleanup.
+
+## Pre-requisite to PR-D: measure round-trip cost per market_type
+
+A single 0.5% prior is arbitrary. Before seeding per-direction weights, measure actual round-trip cost from `paper_trades` per `market_type` (fee + observed slippage). Use the measured value as the `rtcost` input to the seed formula, per market_type. This becomes part of PR-D's commit (data + measurement script).
+
+## Out-of-scope (deferred)
+
+- `event_financial:long` blocklist re-evaluation. Held until per-direction weights land + 2 Optuna cycles. The Optimizer should downweight the anti-edge LONG generators (momentum, ofi, etc.) on event_financial first, then we re-measure live WR.
+- PR-E (deprecation of '__all__' code path) runs at the end of the series, after C and D land and stabilize.
+
+## Validation checklist (post-deploy)
+
+- [ ] Migration applies idempotently on existing DB.
+- [ ] All 55+ existing rows survive ALTER with direction='__all__'.
+- [ ] Combiner fallback verified by integration test (row exists for '__all__' but not for direction='long' → reads '__all__').
+- [ ] Optuna writes per-direction rows after one cycle.
+- [ ] `mean_reversion crypto_intraday SHORT` weight diverges from `LONG` weight after 1-2 cycles.
+- [ ] Live SHORT trades emerge (target: ≥1 in 72h post-deploy).
+- [ ] Live event_financial LONG WR improves (current 26.3% → target ≥40% over n≥30).
+
+## Acceptance
+
+Plan signed off by the project owner. PRs land one at a time with checkpoints; CI must be green and the next PR doesn't open until the previous is on the VM.

--- a/packages/dashboard/src/api/routes.ts
+++ b/packages/dashboard/src/api/routes.ts
@@ -1817,11 +1817,12 @@ export async function registerRoutes(
       // Also update in database if configured
       if (isDatabaseConfigured()) {
         for (const [signalType, weight] of Object.entries(weights)) {
-          // Use raw query for upsert since repo doesn't have it
+          // Use raw query for upsert since repo doesn't have it.
+          // direction='__all__' = legacy/global semantics (PR-A 2026-05-13).
           await query(
-            `INSERT INTO signal_weights (signal_type, market_type, weight, is_enabled, min_confidence, updated_at)
-             VALUES ($1, $2, $3, true, 0.6, NOW())
-             ON CONFLICT (signal_type, market_type) DO UPDATE SET
+            `INSERT INTO signal_weights (signal_type, market_type, direction, weight, is_enabled, min_confidence, updated_at)
+             VALUES ($1, $2, '__all__', $3, true, 0.6, NOW())
+             ON CONFLICT (signal_type, market_type, direction) DO UPDATE SET
                weight = EXCLUDED.weight,
                is_enabled = EXCLUDED.is_enabled,
                min_confidence = EXCLUDED.min_confidence,

--- a/packages/dashboard/src/database/repositories.ts
+++ b/packages/dashboard/src/database/repositories.ts
@@ -213,20 +213,31 @@ export interface SignalWeight {
   is_enabled: boolean;
   min_confidence: number;
   updated_at: Date;
+  direction?: SignalWeightDirection;
 }
 
+/** PR-A added: '__all__' = legacy/global semantics (any direction). */
+export type SignalWeightDirection = '__all__' | 'long' | 'short';
+
 export const signalWeightsRepo = {
-  async getAll(): Promise<SignalWeight[]> {
+  async getAll(direction: SignalWeightDirection = '__all__'): Promise<SignalWeight[]> {
     const result = await query<SignalWeight>(
-      `SELECT * FROM signal_weights WHERE market_type = '__global__' ORDER BY signal_type`
+      `SELECT * FROM signal_weights
+       WHERE market_type = '__global__' AND direction = $1
+       ORDER BY signal_type`,
+      [direction]
     );
     return result.rows;
   },
 
-  async get(signalType: string): Promise<SignalWeight | null> {
+  async get(
+    signalType: string,
+    direction: SignalWeightDirection = '__all__'
+  ): Promise<SignalWeight | null> {
     const result = await query<SignalWeight>(
-      `SELECT * FROM signal_weights WHERE signal_type = $1 AND market_type = '__global__'`,
-      [signalType]
+      `SELECT * FROM signal_weights
+       WHERE signal_type = $1 AND market_type = '__global__' AND direction = $2`,
+      [signalType, direction]
     );
     return result.rows[0] ?? null;
   },
@@ -234,13 +245,15 @@ export const signalWeightsRepo = {
   async update(
     signalType: string,
     weight: number,
-    reason: string
+    reason: string,
+    direction: SignalWeightDirection = '__all__'
   ): Promise<void> {
     await transaction(async (client: PoolClient) => {
       // Get current weight
       const current = await client.query<SignalWeight>(
-        'SELECT weight FROM signal_weights WHERE signal_type = $1 AND market_type = $2',
-        [signalType, '__global__']
+        `SELECT weight FROM signal_weights
+         WHERE signal_type = $1 AND market_type = $2 AND direction = $3`,
+        [signalType, '__global__', direction]
       );
       const previousWeight = current.rows[0]?.weight;
 
@@ -248,8 +261,8 @@ export const signalWeightsRepo = {
       await client.query(
         `UPDATE signal_weights
          SET weight = $1, updated_at = NOW()
-         WHERE signal_type = $2 AND market_type = $3`,
-        [weight, signalType, '__global__']
+         WHERE signal_type = $2 AND market_type = $3 AND direction = $4`,
+        [weight, signalType, '__global__', direction]
       );
 
       // Record history
@@ -265,12 +278,14 @@ export const signalWeightsRepo = {
   /**
    * Get all per-type weights, grouped by market_type. Excludes '__global__' rows
    * and disabled rows (is_enabled = false). Returns { market_type → { signal_type → weight } }.
+   * Filters to direction='__all__' so existing callers keep legacy semantics until
+   * PR-B migrates them to per-direction lookup via `getAllPerDirection`.
    */
   async getAllPerType(): Promise<Record<string, Record<string, number>>> {
     const result = await query<{ signal_type: string; market_type: string; weight: number }>(
       `SELECT signal_type, market_type, weight
        FROM signal_weights
-       WHERE market_type != '__global__' AND is_enabled = true`
+       WHERE market_type != '__global__' AND direction = '__all__' AND is_enabled = true`
     );
     const map: Record<string, Record<string, number>> = {};
     for (const row of result.rows) {
@@ -285,11 +300,15 @@ export const signalWeightsRepo = {
    * Used by the OptimizationScheduler min-lift gate to compare against the
    * currently-persisted dm before flipping it.
    */
-  async getPerType(signalType: string, marketType: string): Promise<number | null> {
+  async getPerType(
+    signalType: string,
+    marketType: string,
+    direction: SignalWeightDirection = '__all__'
+  ): Promise<number | null> {
     const result = await query<{ weight: number }>(
       `SELECT weight FROM signal_weights
-       WHERE signal_type = $1 AND market_type = $2 AND is_enabled = true`,
-      [signalType, marketType]
+       WHERE signal_type = $1 AND market_type = $2 AND direction = $3 AND is_enabled = true`,
+      [signalType, marketType, direction]
     );
     return result.rows[0] ? Number(result.rows[0].weight) : null;
   },
@@ -298,21 +317,25 @@ export const signalWeightsRepo = {
    * UPSERT a per-type weight row. Used by OptimizationScheduler.updateStrategy.
    * History insert is intentionally skipped in this PR (signal_weights_history
    * lacks a market_type column; tracked as separate follow-up).
+   *
+   * `direction` defaults to '__all__' (legacy). Optuna (PR-C) will start writing
+   * per-direction rows ('long'/'short') against the new 3-column PK.
    */
   async updatePerType(
     signalType: string,
     marketType: string,
     weight: number,
-    reason: string
+    reason: string,
+    direction: SignalWeightDirection = '__all__'
   ): Promise<void> {
     await query(
-      `INSERT INTO signal_weights (signal_type, market_type, weight, updated_at)
-       VALUES ($1, $2, $3, NOW())
-       ON CONFLICT (signal_type, market_type)
+      `INSERT INTO signal_weights (signal_type, market_type, direction, weight, updated_at)
+       VALUES ($1, $2, $3, $4, NOW())
+       ON CONFLICT (signal_type, market_type, direction)
        DO UPDATE SET weight = EXCLUDED.weight, updated_at = EXCLUDED.updated_at`,
-      [signalType, marketType, weight]
+      [signalType, marketType, direction, weight]
     );
-    console.log(`[signalWeightsRepo] updatePerType ${signalType}@${marketType} = ${weight} (${reason})`);
+    console.log(`[signalWeightsRepo] updatePerType ${signalType}@${marketType}:${direction} = ${weight} (${reason})`);
   },
 
   async getHistory(

--- a/packages/dashboard/src/database/signalWeightsRepo.perDirection.test.ts
+++ b/packages/dashboard/src/database/signalWeightsRepo.perDirection.test.ts
@@ -1,0 +1,99 @@
+/**
+ * PR-A 2026-05-13: per-direction signal_weights schema.
+ *
+ * Tests verify that the repository layer accepts the new optional `direction`
+ * argument with a backwards-compatible default of '__all__'. Each method's SQL
+ * carries the direction parameter so the upsert/lookup targets the 3-column PK
+ * introduced by init/029_signal_weights_per_direction.sql.
+ *
+ * We don't test combiner fallback semantics here — that's PR-B's scope. PR-A's
+ * goal is "no existing caller breaks; new direction parameter routes correctly".
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./index.js', () => ({
+  query: vi.fn(),
+  transaction: vi.fn(async (fn) => {
+    const fakeClient = { query: vi.fn().mockResolvedValue({ rows: [] }) };
+    return fn(fakeClient);
+  }),
+}));
+
+import { query } from './index.js';
+import { signalWeightsRepo } from './repositories.js';
+
+describe('signalWeightsRepo per-direction parameter (PR-A)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (query as any).mockResolvedValue({ rows: [] });
+  });
+
+  describe('getAll', () => {
+    it('defaults direction to "__all__"', async () => {
+      await signalWeightsRepo.getAll();
+      const [sql, params] = (query as any).mock.calls[0];
+      expect(sql).toMatch(/direction = \$1/);
+      expect(params).toEqual(['__all__']);
+    });
+
+    it('passes explicit direction through', async () => {
+      await signalWeightsRepo.getAll('long');
+      const [, params] = (query as any).mock.calls[0];
+      expect(params).toEqual(['long']);
+    });
+  });
+
+  describe('get', () => {
+    it('defaults direction to "__all__"', async () => {
+      await signalWeightsRepo.get('momentum');
+      const [sql, params] = (query as any).mock.calls[0];
+      expect(sql).toMatch(/AND direction = \$2/);
+      expect(params).toEqual(['momentum', '__all__']);
+    });
+
+    it('passes explicit direction through', async () => {
+      await signalWeightsRepo.get('momentum', 'short');
+      const [, params] = (query as any).mock.calls[0];
+      expect(params).toEqual(['momentum', 'short']);
+    });
+  });
+
+  describe('getPerType', () => {
+    it('defaults direction to "__all__"', async () => {
+      await signalWeightsRepo.getPerType('mean_reversion', 'crypto_intraday');
+      const [sql, params] = (query as any).mock.calls[0];
+      expect(sql).toMatch(/AND direction = \$3/);
+      expect(params).toEqual(['mean_reversion', 'crypto_intraday', '__all__']);
+    });
+
+    it('passes explicit direction through', async () => {
+      await signalWeightsRepo.getPerType('mean_reversion', 'crypto_intraday', 'long');
+      const [, params] = (query as any).mock.calls[0];
+      expect(params).toEqual(['mean_reversion', 'crypto_intraday', 'long']);
+    });
+  });
+
+  describe('getAllPerType', () => {
+    it("filters on direction='__all__' so legacy callers see only the global-direction rows", async () => {
+      await signalWeightsRepo.getAllPerType();
+      const [sql] = (query as any).mock.calls[0];
+      expect(sql).toMatch(/direction = '__all__'/);
+    });
+  });
+
+  describe('updatePerType', () => {
+    it('writes direction column with default "__all__" and 3-col ON CONFLICT', async () => {
+      await signalWeightsRepo.updatePerType('momentum', 'event_financial', 0.5, 'test');
+      const [sql, params] = (query as any).mock.calls[0];
+      expect(sql).toMatch(/INSERT INTO signal_weights \(signal_type, market_type, direction, weight, updated_at\)/);
+      expect(sql).toMatch(/ON CONFLICT \(signal_type, market_type, direction\)/);
+      expect(params).toEqual(['momentum', 'event_financial', '__all__', 0.5]);
+    });
+
+    it('writes a per-direction row when direction is explicitly long', async () => {
+      await signalWeightsRepo.updatePerType('mean_reversion', 'crypto_intraday', 0.8, 'optuna', 'long');
+      const [, params] = (query as any).mock.calls[0];
+      expect(params).toEqual(['mean_reversion', 'crypto_intraday', 'long', 0.8]);
+    });
+  });
+});

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -329,12 +329,19 @@ async function main(): Promise<void> {
             ADD COLUMN IF NOT EXISTS market_type VARCHAR(32) NOT NULL DEFAULT '__global__';
         `);
 
-        // Defensive PK swap: discover existing PK name dynamically
+        // Defensive PK swap: discover existing PK name dynamically.
+        // Skip if EITHER the per-type OR the per-direction (PR-A 2026-05-13) PK is
+        // already installed — otherwise we'd PK-flap on every boot, and once
+        // per-direction rows exist, a 2-col PK can't be created without
+        // unique-constraint violations.
         await query(`
           DO $$
           DECLARE pkey_name TEXT;
           BEGIN
-            IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'signal_weights_pkey_per_type') THEN
+            IF EXISTS (
+              SELECT 1 FROM pg_constraint
+              WHERE conname IN ('signal_weights_pkey_per_type', 'signal_weights_pkey_per_direction')
+            ) THEN
               RETURN;
             END IF;
 
@@ -351,7 +358,60 @@ async function main(): Promise<void> {
           END $$;
         `);
 
-        // Bootstrap 55 per-type rows from current DEFAULT_TYPE_WEIGHTS hardcoded values
+        // PR-A (2026-05-13): per-direction schema migration. Must run BEFORE
+        // the bootstrap INSERT below so its ON CONFLICT (sig, type, direction)
+        // target has a matching unique constraint.
+        // See docs/plans/2026-05-13-per-direction-weights-design.md.
+        await query(`
+          ALTER TABLE signal_weights
+            ADD COLUMN IF NOT EXISTS direction VARCHAR(8) NOT NULL DEFAULT '__all__';
+        `);
+        await query(`
+          DO $$
+          BEGIN
+            IF NOT EXISTS (
+              SELECT 1 FROM pg_constraint
+              WHERE conname = 'signal_weights_direction_check'
+                AND conrelid = 'signal_weights'::regclass
+            ) THEN
+              ALTER TABLE signal_weights
+                ADD CONSTRAINT signal_weights_direction_check
+                CHECK (direction IN ('__all__','long','short'));
+            END IF;
+          END $$;
+        `);
+        await query(`
+          DO $$
+          DECLARE pkey_name TEXT;
+          BEGIN
+            IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'signal_weights_pkey_per_direction') THEN
+              RETURN;
+            END IF;
+
+            SELECT conname INTO pkey_name
+            FROM pg_constraint
+            WHERE conrelid = 'signal_weights'::regclass AND contype = 'p';
+
+            IF pkey_name IS NOT NULL THEN
+              EXECUTE format('ALTER TABLE signal_weights DROP CONSTRAINT %I', pkey_name);
+            END IF;
+
+            ALTER TABLE signal_weights
+              ADD CONSTRAINT signal_weights_pkey_per_direction
+              PRIMARY KEY (signal_type, market_type, direction);
+          END $$;
+        `);
+        await query(`
+          CREATE INDEX IF NOT EXISTS idx_signal_weights_lookup
+            ON signal_weights (signal_type, market_type, direction)
+            WHERE is_enabled = true;
+        `);
+
+        // Bootstrap 55 per-type rows from current DEFAULT_TYPE_WEIGHTS hardcoded values.
+        // PR-A (2026-05-13): rows are direction='__all__' (legacy/global semantics).
+        // Per-direction rows ('long','short') are seeded later by PR-D's backfill
+        // SQL using cost-aware t-stat priors. Until then, the combiner's fallback
+        // to '__all__' makes these the active weights.
         await query(`
           INSERT INTO signal_weights (signal_type, weight, market_type, updated_at) VALUES
             -- crypto_intraday
@@ -414,7 +474,7 @@ async function main(): Promise<void> {
             ('price_divergence',    0.0, 'event_long', NOW()),
             ('attention_spike',     0.0, 'event_long', NOW()),
             ('news_sentiment',      0.0, 'event_long', NOW())
-          ON CONFLICT (signal_type, market_type) DO NOTHING;
+          ON CONFLICT (signal_type, market_type, direction) DO NOTHING;
         `);
 
         console.log('[server] signal_weights per-type schema migration applied');
@@ -426,10 +486,11 @@ async function main(): Promise<void> {
       // Sub-project B.2: seed consensus_discount_floor config row.
       // signal_weights uses the row-per-config pattern (same as
       // direction_multiplier). See docs/plans/2026-04-25-signal-consensus-design.md.
+      // direction='__all__' — config rows are not directional.
       await query(`
-        INSERT INTO signal_weights (signal_type, weight, market_type, is_enabled, min_confidence, updated_at)
-        VALUES ('consensus_discount_floor', 0.5, '__global__', true, 0.0, NOW())
-        ON CONFLICT (signal_type, market_type) DO NOTHING;
+        INSERT INTO signal_weights (signal_type, weight, market_type, direction, is_enabled, min_confidence, updated_at)
+        VALUES ('consensus_discount_floor', 0.5, '__global__', '__all__', true, 0.0, NOW())
+        ON CONFLICT (signal_type, market_type, direction) DO NOTHING;
       `);
       console.log('signal_weights.consensus_discount_floor row ensured');
 
@@ -438,9 +499,9 @@ async function main(): Promise<void> {
       // so the generator is wired but inactive until Optuna provides
       // empirical evidence of value.
       await query(`
-        INSERT INTO signal_weights (signal_type, weight, market_type, is_enabled, min_confidence, updated_at)
-        VALUES ('resolution_prior', 0.0, '__global__', true, 0.0, NOW())
-        ON CONFLICT (signal_type, market_type) DO NOTHING;
+        INSERT INTO signal_weights (signal_type, weight, market_type, direction, is_enabled, min_confidence, updated_at)
+        VALUES ('resolution_prior', 0.0, '__global__', '__all__', true, 0.0, NOW())
+        ON CONFLICT (signal_type, market_type, direction) DO NOTHING;
       `);
       console.log('[server] signal_weights.resolution_prior row ensured');
 

--- a/packages/dashboard/src/services/bootstrapDirectionMultiplier.test.ts
+++ b/packages/dashboard/src/services/bootstrapDirectionMultiplier.test.ts
@@ -20,9 +20,11 @@ describe('bootstrapDirectionMultiplierRows', () => {
     expect(sql).toMatch(/INSERT INTO signal_weights/);
     expect(sql).toMatch(/'direction_multiplier'/);
     // 2026-05-04: all five seeds flipped to +1.0 (see DirectionMultiplierPolicy.ts header).
-    expect(sql).toMatch(/'event_financial',\s*1\.0/);
-    expect(sql).toMatch(/'crypto_intraday',\s*1\.0/);
-    expect(sql).toMatch(/'event_short',\s*1\.0/);
-    expect(sql).toMatch(/ON CONFLICT \(signal_type, market_type\) DO NOTHING/);
+    // 2026-05-13 PR-A: direction='__all__' between market_type and weight — dm is
+    // not a directional signal, so its row is the legacy/global one.
+    expect(sql).toMatch(/'event_financial',\s*'__all__',\s*1\.0/);
+    expect(sql).toMatch(/'crypto_intraday',\s*'__all__',\s*1\.0/);
+    expect(sql).toMatch(/'event_short',\s*'__all__',\s*1\.0/);
+    expect(sql).toMatch(/ON CONFLICT \(signal_type, market_type, direction\) DO NOTHING/);
   });
 });

--- a/packages/dashboard/src/services/bootstrapDirectionMultiplier.ts
+++ b/packages/dashboard/src/services/bootstrapDirectionMultiplier.ts
@@ -1,16 +1,19 @@
 import { query } from '../database/index.js';
 
 export async function bootstrapDirectionMultiplierRows(): Promise<void> {
+  // direction='__all__' because direction_multiplier is itself a multiplier on
+  // the combined signal's direction — splitting it per-direction is not meaningful.
+  // See docs/plans/2026-05-13-per-direction-weights-design.md.
   await query(
-    `INSERT INTO signal_weights (signal_type, market_type, weight, updated_at, is_enabled)
+    `INSERT INTO signal_weights (signal_type, market_type, direction, weight, updated_at, is_enabled)
      VALUES
        -- 2026-05-04: flipped seeds -1 → +1 after empirical reverse-direction
        -- analysis (n=386, 84.7% counter-WR). See DirectionMultiplierPolicy.ts header.
-       ('direction_multiplier', 'crypto_intraday', 1.0, NOW(), true),
-       ('direction_multiplier', 'crypto_daily',    1.0, NOW(), true),
-       ('direction_multiplier', 'event_short',     1.0, NOW(), true),
-       ('direction_multiplier', 'event_long',      1.0, NOW(), true),
-       ('direction_multiplier', 'event_financial', 1.0, NOW(), true)
-     ON CONFLICT (signal_type, market_type) DO NOTHING`
+       ('direction_multiplier', 'crypto_intraday', '__all__', 1.0, NOW(), true),
+       ('direction_multiplier', 'crypto_daily',    '__all__', 1.0, NOW(), true),
+       ('direction_multiplier', 'event_short',     '__all__', 1.0, NOW(), true),
+       ('direction_multiplier', 'event_long',      '__all__', 1.0, NOW(), true),
+       ('direction_multiplier', 'event_financial', '__all__', 1.0, NOW(), true)
+     ON CONFLICT (signal_type, market_type, direction) DO NOTHING`
   );
 }

--- a/packages/data-collector/src/database/init/029_signal_weights_per_direction.sql
+++ b/packages/data-collector/src/database/init/029_signal_weights_per_direction.sql
@@ -1,0 +1,54 @@
+-- 029_signal_weights_per_direction.sql
+-- Extends signal_weights to support per-direction rows. Existing rows become
+-- direction='__all__' (legacy/global semantics). Per-direction rows seeded
+-- later by scripts/seed-per-direction-weights.sql (PR-D).
+--
+-- Design: docs/plans/2026-05-13-per-direction-weights-design.md
+-- Trigger: P2 cost-aware t-stat (2026-05-13) showed directional asymmetry
+-- the (signal_type, market_type) key cannot express. E.g. mean_reversion
+-- crypto_intraday: SHORT t_net=+6.44, LONG t_net=-23.96.
+
+ALTER TABLE signal_weights
+  ADD COLUMN IF NOT EXISTS direction VARCHAR(8) NOT NULL DEFAULT '__all__';
+
+-- Add CHECK constraint defensively (NOT VALID then VALIDATE would lock briefly
+-- on huge tables; here ~50 rows so just ADD).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'signal_weights_direction_check'
+      AND conrelid = 'signal_weights'::regclass
+  ) THEN
+    ALTER TABLE signal_weights
+      ADD CONSTRAINT signal_weights_direction_check
+      CHECK (direction IN ('__all__','long','short'));
+  END IF;
+END $$;
+
+-- PK swap to include direction. Idempotent — discovers existing PK by name
+-- so it survives multiple boots and the previous per-type swap (025).
+DO $$
+DECLARE pkey_name TEXT;
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'signal_weights_pkey_per_direction') THEN
+    RETURN;
+  END IF;
+
+  SELECT conname INTO pkey_name
+  FROM pg_constraint
+  WHERE conrelid = 'signal_weights'::regclass AND contype = 'p';
+
+  IF pkey_name IS NOT NULL THEN
+    EXECUTE format('ALTER TABLE signal_weights DROP CONSTRAINT %I', pkey_name);
+  END IF;
+
+  ALTER TABLE signal_weights
+    ADD CONSTRAINT signal_weights_pkey_per_direction
+    PRIMARY KEY (signal_type, market_type, direction);
+END $$;
+
+-- Hot path index for combiner lookups (PR-B uses this).
+CREATE INDEX IF NOT EXISTS idx_signal_weights_lookup
+  ON signal_weights (signal_type, market_type, direction)
+  WHERE is_enabled = true;


### PR DESCRIPTION
## Summary

PR-A of the per-direction-weights series. **Schema-only change**, backwards-compatible defaults. Combiner, optimizer, and seed land in PR-B / PR-C / PR-D.

### Why

Cost-aware P2 t-stat measured 2026-05-13 (3-day window, 0.5% round-trip cost) shows the `(signal_type, market_type)` key cannot express the directional asymmetry that actually exists in the data. Examples:

| signal | market_type | LONG t_net | SHORT t_net |
|---|---|---|---|
| mean_reversion | crypto_intraday | -23.96 | **+6.44** |
| mean_reversion | event_financial | **+1.60** | -15.93 |
| momentum | event_financial | -16.47 | -19.02 |

A single weight per (signal, type) averages both directions into one number. The lone profitable SHORT cell (mean_reversion crypto_intraday SHORT) gets washed out by anti-edge contributions from the same generator on the LONG side and from other generators. **Result so far: zero live SHORTs in 7 days** — all combined SHORTs were blocked at the executor because the only types producing them (event_financial, event_long) are gated.

This PR is the schema foundation for fixing that. PR-B will let the combiner look up weights per-direction; PR-C will let Optuna optimise per-direction; PR-D will seed initial per-direction weights from cost-aware data.

### Schema

```sql
ALTER TABLE signal_weights
  ADD COLUMN direction VARCHAR(8) NOT NULL DEFAULT '__all__'
  CHECK (direction IN ('__all__','long','short'));

ALTER TABLE signal_weights DROP CONSTRAINT signal_weights_pkey_per_type;
ALTER TABLE signal_weights ADD CONSTRAINT signal_weights_pkey_per_direction
  PRIMARY KEY (signal_type, market_type, direction);

CREATE INDEX idx_signal_weights_lookup
  ON signal_weights (signal_type, market_type, direction)
  WHERE is_enabled = true;
```

All existing rows migrate to `direction='__all__'` via the column default. PK swap is atomic. The boot block in `server.ts` mirrors this for existing volumes whose init/029 won't re-run.

### Compatibility

- Existing INSERTs without a `direction` value get `'__all__'` via column default.
- `signalWeightsRepo.getAllPerType()` filters to `direction='__all__'` so legacy callers see exactly today's rows — no semantic change.
- New optional `direction` parameter on all repo methods (`get`, `getAll`, `getPerType`, `update`, `updatePerType`) defaults to `'__all__'`.
- `direction_multiplier`, `consensus_discount_floor`, `resolution_prior` pseudo/config rows stay at `'__all__'` — none are directional signals.
- `EXECUTOR_BLOCKED_TYPE_DIRECTIONS` remains as a hard structural override (belt-and-suspenders).

### Tests

- New: `signalWeightsRepo.perDirection.test.ts` — verifies default '__all__', passthrough of explicit direction, 3-col ON CONFLICT.
- Updated: `bootstrapDirectionMultiplier.test.ts` — expects direction in SQL.
- **987 tests pass** + 14 skipped, tsc clean.

### Validation post-deploy

- [ ] Migration applies idempotently on existing DB
- [ ] All 55+ existing rows survive with `direction='__all__'`
- [ ] `SELECT COUNT(*) FROM signal_weights GROUP BY direction` returns one row: `__all__` → 55+
- [ ] Combiner/Optuna runtime behaviour unchanged (no per-direction rows exist yet)
- [ ] Container boots cleanly (no PK swap loop in logs)

## Test plan
- [x] tsc clean (signals + dashboard)
- [x] vitest 987 passed locally
- [ ] CI green
- [ ] VM deploy + verify schema with `\d signal_weights`
- [ ] Restart dashboard, confirm logs show "per-direction schema migration applied" once

Design: `docs/plans/2026-05-13-per-direction-weights-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Signal weights can now be configured per trading direction (long, short, or all directions) for more granular control.

* **Chores**
  * Database schema updated to support per-direction signal weight configuration.
  * Added schema migration with new lookup index for enabled weights.

* **Tests**
  * Added comprehensive test coverage for direction-specific weight operations and backward-compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/218)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->