### PR TITLE
feat(combiner): per-direction weight lookup + SIGNAL_DIRECTIONS_DISABLED (PR-B)

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -226,6 +226,13 @@ services:
       # immune to the oscillation discovered 2026-05-12 (boot cleanup deletes
       # per-type rows; Optimizer re-writes them every 6h).
       SIGNAL_TYPES_DISABLED: "mlofi,spread_compression,cross_market_corr,price_divergence,attention_spike,news_sentiment"
+      # PR-B 2026-05-13: per-(signal_id, direction) hard-disable. Tokens are
+      # lowercase `signalId:direction` (direction ∈ {long, short}), e.g.
+      # "momentum:short,ofi:long". Empty by default — same operational
+      # kill-switch as SIGNAL_TYPES_DISABLED but at PR-A's per-direction granularity.
+      # Will start being populated once cost-aware seeds (PR-D) reveal specific
+      # cells that warrant muting. See feedback_realistic_costs.md.
+      SIGNAL_DIRECTIONS_DISABLED: ""
       # Market type gate: only trade these types live, shadow-trade the rest
       # event_financial: WTI, Fed, indices (continuous underlying)
       # event_short: event markets with short resolution windows (better win rate than event_long)

--- a/packages/dashboard/src/database/repositories.ts
+++ b/packages/dashboard/src/database/repositories.ts
@@ -296,6 +296,38 @@ export const signalWeightsRepo = {
   },
 
   /**
+   * Get all per-direction weights (rows where direction IN ('long','short')),
+   * grouped as { marketType → { signalType → { direction → weight } } }.
+   * Used by SignalEngine to populate the combiner's per-direction lookup map.
+   * Returns an empty object until PR-C/PR-D start writing per-direction rows
+   * (currently all rows are direction='__all__' and read via getAllPerType).
+   * PR-B 2026-05-13.
+   */
+  async getAllPerDirection(): Promise<Record<string, Record<string, Record<string, number>>>> {
+    const result = await query<{
+      signal_type: string;
+      market_type: string;
+      direction: string;
+      weight: number;
+    }>(
+      `SELECT signal_type, market_type, direction, weight
+       FROM signal_weights
+       WHERE market_type != '__global__'
+         AND direction IN ('long','short')
+         AND is_enabled = true`
+    );
+    const map: Record<string, Record<string, Record<string, number>>> = {};
+    for (const row of result.rows) {
+      if (!map[row.market_type]) map[row.market_type] = {};
+      if (!map[row.market_type][row.signal_type]) {
+        map[row.market_type][row.signal_type] = {};
+      }
+      map[row.market_type][row.signal_type][row.direction] = Number(row.weight);
+    }
+    return map;
+  },
+
+  /**
    * Read a single per-type weight. Returns null if no row exists or row is disabled.
    * Used by the OptimizationScheduler min-lift gate to compare against the
    * currently-persisted dm before flipping it.

--- a/packages/dashboard/src/database/signalWeightsRepo.getAllPerDirection.test.ts
+++ b/packages/dashboard/src/database/signalWeightsRepo.getAllPerDirection.test.ts
@@ -1,0 +1,48 @@
+/**
+ * PR-B 2026-05-13: signalWeightsRepo.getAllPerDirection.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./index.js', () => ({
+  query: vi.fn(),
+  transaction: vi.fn(),
+}));
+
+import { query } from './index.js';
+import { signalWeightsRepo } from './repositories.js';
+
+describe('signalWeightsRepo.getAllPerDirection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("queries only direction IN ('long','short') and excludes __global__", async () => {
+    (query as any).mockResolvedValueOnce({ rows: [] });
+    await signalWeightsRepo.getAllPerDirection();
+    const [sql] = (query as any).mock.calls[0];
+    expect(sql).toMatch(/market_type != '__global__'/);
+    expect(sql).toMatch(/direction IN \('long','short'\)/);
+    expect(sql).toMatch(/is_enabled = true/);
+  });
+
+  it('groups rows into { marketType: { signalType: { direction: weight } } }', async () => {
+    (query as any).mockResolvedValueOnce({
+      rows: [
+        { signal_type: 'mean_reversion', market_type: 'crypto_intraday', direction: 'short', weight: 1.5 },
+        { signal_type: 'mean_reversion', market_type: 'crypto_intraday', direction: 'long', weight: 0.2 },
+        { signal_type: 'momentum', market_type: 'event_financial', direction: 'long', weight: 0.0 },
+      ],
+    });
+    const out = await signalWeightsRepo.getAllPerDirection();
+    expect(out.crypto_intraday.mean_reversion.long).toBe(0.2);
+    expect(out.crypto_intraday.mean_reversion.short).toBe(1.5);
+    expect(out.event_financial.momentum.long).toBe(0.0);
+    expect(out.event_financial.momentum.short).toBeUndefined();
+  });
+
+  it('returns an empty object when there are no per-direction rows', async () => {
+    (query as any).mockResolvedValueOnce({ rows: [] });
+    const out = await signalWeightsRepo.getAllPerDirection();
+    expect(out).toEqual({});
+  });
+});

--- a/packages/dashboard/src/services/SignalEngine.directionsDisabledParser.test.ts
+++ b/packages/dashboard/src/services/SignalEngine.directionsDisabledParser.test.ts
@@ -1,0 +1,47 @@
+/**
+ * PR-B 2026-05-13: SIGNAL_DIRECTIONS_DISABLED parser.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseDisabledSignalDirections } from './SignalEngine.js';
+
+describe('parseDisabledSignalDirections', () => {
+  it('returns empty Set when env unset/empty', () => {
+    expect(parseDisabledSignalDirections(undefined).size).toBe(0);
+    expect(parseDisabledSignalDirections('').size).toBe(0);
+  });
+
+  it('parses single valid token', () => {
+    const out = parseDisabledSignalDirections('momentum:short');
+    expect(out.has('momentum:short')).toBe(true);
+    expect(out.size).toBe(1);
+  });
+
+  it('parses multiple tokens, trims whitespace, lowercases', () => {
+    const out = parseDisabledSignalDirections(' MOMENTUM:Short , Ofi:LONG ,mean_reversion:short');
+    expect(out.has('momentum:short')).toBe(true);
+    expect(out.has('ofi:long')).toBe(true);
+    expect(out.has('mean_reversion:short')).toBe(true);
+    expect(out.size).toBe(3);
+  });
+
+  it('drops invalid tokens silently (typo-tolerant)', () => {
+    const out = parseDisabledSignalDirections('momentum,ofi:both,bad:long:extra,:short,mean_reversion:short');
+    // Only the well-formed `mean_reversion:short` survives.
+    expect(out.has('mean_reversion:short')).toBe(true);
+    expect(out.size).toBe(1);
+  });
+
+  it('does not accept upper-case direction (must be lowercase after normalize)', () => {
+    // After lowercase: "momentum:long" → valid.
+    const out = parseDisabledSignalDirections('Momentum:LONG');
+    expect(out.has('momentum:long')).toBe(true);
+  });
+
+  it('does not allow non-long/short directions', () => {
+    const out = parseDisabledSignalDirections('momentum:neutral,momentum:up,momentum:long');
+    expect(out.has('momentum:long')).toBe(true);
+    expect(out.has('momentum:neutral')).toBe(false);
+    expect(out.has('momentum:up')).toBe(false);
+    expect(out.size).toBe(1);
+  });
+});

--- a/packages/dashboard/src/services/SignalEngine.ts
+++ b/packages/dashboard/src/services/SignalEngine.ts
@@ -126,6 +126,21 @@ export function parseDisabledSignalIds(raw: string | undefined): Set<string> {
   );
 }
 
+/** Parse comma-separated SIGNAL_DIRECTIONS_DISABLED env var into a Set.
+ *  Tokens must be lowercase `signalId:direction` with direction ∈ {long, short}.
+ *  Invalid tokens are silently dropped (typo-tolerant; bad input never bypasses
+ *  the gate via implicit acceptance). Empty / unset → empty set.
+ *  PR-B 2026-05-13. */
+export function parseDisabledSignalDirections(raw: string | undefined): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter((s) => /^[a-z_]+:(long|short)$/.test(s))
+  );
+}
+
 interface ActiveMarket {
   id: string;
   question: string;
@@ -196,6 +211,12 @@ export class SignalEngine extends EventEmitter {
         // BacktestService (where Optuna can't fit them meaningfully) or
         // empirically anti-edge ones.
         disabledSignalIds: parseDisabledSignalIds(process.env.SIGNAL_TYPES_DISABLED),
+        // Hard-disabled per-direction (env: SIGNAL_DIRECTIONS_DISABLED).
+        // Tokens are lowercase `signalId:direction`. Same operational kill-switch
+        // semantics as disabledSignalIds but with PR-A's per-direction granularity.
+        // Empty by default; deferred operational use until cost-aware data
+        // justifies muting a specific (signal, direction) cell.
+        disabledSignalDirections: parseDisabledSignalDirections(process.env.SIGNAL_DIRECTIONS_DISABLED),
       }
     );
   }
@@ -361,6 +382,33 @@ export class SignalEngine extends EventEmitter {
       } catch (err) {
         console.error('[SignalEngine] Failed to sync per-type weights:', err);
         // Continue with empty typeWeights; combiner falls back to this.weights.
+      }
+
+      // PR-B 2026-05-13: per-direction overrides. Fed into the combiner's
+      // perDirectionTypeWeights map. Empty until PR-C/PR-D start writing
+      // per-direction rows — at which point the combiner's lookup chain
+      // (per-direction → '__all__' → 0) starts picking these up.
+      try {
+        const perDirWeights = await signalWeightsRepo.getAllPerDirection();
+        const filteredPerDir: Record<string, Record<string, Record<string, number>>> = {};
+        for (const [marketType, generators] of Object.entries(perDirWeights)) {
+          for (const [signalType, dirMap] of Object.entries(generators)) {
+            // Mirror getAllPerType filter: drop signals without an active generator.
+            if (!this.signals.has(signalType)) continue;
+            if (!filteredPerDir[marketType]) filteredPerDir[marketType] = {};
+            filteredPerDir[marketType][signalType] = { ...dirMap };
+          }
+        }
+        this.combiner.setPerDirectionTypeWeights(filteredPerDir);
+        const cellCount = Object.values(filteredPerDir)
+          .flatMap((m) => Object.values(m))
+          .flatMap((d) => Object.keys(d)).length;
+        console.log(
+          `[SignalEngine] Synced perDirectionWeights from database: ${cellCount} cells across ${Object.keys(filteredPerDir).length} types`
+        );
+      } catch (err) {
+        console.error('[SignalEngine] Failed to sync per-direction weights:', err);
+        // Non-fatal: combiner falls back to typeWeights ('__all__' direction).
       }
     } catch (error) {
       console.error('[SignalEngine] Failed to sync weights:', error);

--- a/packages/signals/src/combiners/WeightedAverageCombiner.perDirection.test.ts
+++ b/packages/signals/src/combiners/WeightedAverageCombiner.perDirection.test.ts
@@ -1,0 +1,125 @@
+/**
+ * PR-B 2026-05-13: per-direction weight lookup + SIGNAL_DIRECTIONS_DISABLED.
+ *
+ * These tests exercise the combiner's per-direction lookup path in isolation
+ * from the SignalEngine / DB. The goal is to prove:
+ *   1. When perDirectionTypeWeights is empty, behaviour is identical to PR-A
+ *      (lookup goes via typeWeights / legacy '__all__').
+ *   2. When a per-direction weight exists, it overrides the legacy '__all__'
+ *      value for that (signalId, direction).
+ *   3. When a per-direction weight is MISSING for one direction but exists for
+ *      the other, the missing direction falls back to '__all__'.
+ *   4. disabledSignalDirections (signalId:direction) zeroes the weight for
+ *      ONLY the specified direction; the other direction is unaffected.
+ *   5. parameter set/get round-trip works.
+ */
+import { describe, expect, it } from 'vitest';
+import { WeightedAverageCombiner } from './WeightedAverageCombiner.js';
+import type { SignalOutput } from '../core/types/signal.types.js';
+
+function sig(
+  signalId: string,
+  direction: 'LONG' | 'SHORT',
+  strength: number,
+  marketType = 'event_financial'
+): SignalOutput {
+  return {
+    signalId,
+    marketId: 'm-1',
+    tokenId: 't-1',
+    direction,
+    strength,
+    confidence: 1,
+    timestamp: new Date(),
+    ttlMs: 60_000,
+    metadata: { marketType },
+  };
+}
+
+describe('WeightedAverageCombiner per-direction (PR-B)', () => {
+  const baseParams = { minCombinedStrength: 0.01, minCombinedConfidence: 0.01 };
+
+  it("falls back to typeWeights ('__all__') when no per-direction row exists", () => {
+    const c = new WeightedAverageCombiner({ momentum: 1 }, baseParams);
+    c.setDirectionMultiplier(1);
+    c.setTypeWeights({ event_financial: { momentum: 1, mean_reversion: 1 } });
+    // No setPerDirectionTypeWeights — should behave exactly like PR-A.
+
+    const out = c.combine([sig('momentum', 'LONG', 0.5), sig('mean_reversion', 'LONG', 0.5)], undefined, 'event_financial');
+    expect(out).not.toBeNull();
+    expect(out!.direction).toBe('LONG');
+  });
+
+  it('uses per-direction weight when present, ignoring the legacy value for that direction only', () => {
+    const c = new WeightedAverageCombiner({ momentum: 1 }, baseParams);
+    c.setDirectionMultiplier(1);
+    c.setTypeWeights({ event_financial: { mean_reversion: 1 } });
+    // Override: mean_reversion LONG weighs 2, SHORT weighs 0.
+    c.setPerDirectionTypeWeights({
+      event_financial: { mean_reversion: { long: 2, short: 0 } },
+    });
+
+    // LONG signal → per-direction lookup hits 2 → LONG output.
+    const longOut = c.combine([sig('mean_reversion', 'LONG', 0.5)], undefined, 'event_financial');
+    expect(longOut?.direction).toBe('LONG');
+
+    // SHORT signal of equal magnitude → per-direction lookup hits 0 → NEUTRAL.
+    const shortOut = c.combine([sig('mean_reversion', 'SHORT', -0.5)], undefined, 'event_financial');
+    expect(shortOut?.direction === 'NEUTRAL' || shortOut === null).toBe(true);
+  });
+
+  it('falls back to legacy weight when only one direction is per-direction-overridden', () => {
+    const c = new WeightedAverageCombiner({ momentum: 1 }, baseParams);
+    c.setDirectionMultiplier(1);
+    c.setTypeWeights({ event_financial: { mean_reversion: 0.5 } });
+    // Per-direction override only for LONG. SHORT falls back to '__all__' = 0.5.
+    c.setPerDirectionTypeWeights({
+      event_financial: { mean_reversion: { long: 3 } },
+    });
+
+    const longOut = c.combine([sig('mean_reversion', 'LONG', 0.5)], undefined, 'event_financial');
+    const shortOut = c.combine([sig('mean_reversion', 'SHORT', -0.5)], undefined, 'event_financial');
+    expect(longOut?.direction).toBe('LONG');
+    // Fallback to 0.5 means SHORT still produces a SHORT (just weighted less than LONG).
+    expect(shortOut?.direction).toBe('SHORT');
+  });
+
+  it('disabledSignalDirections zeros out only the specified direction', () => {
+    const c = new WeightedAverageCombiner({ momentum: 1 }, baseParams);
+    c.setDirectionMultiplier(1);
+    c.setTypeWeights({ event_financial: { momentum: 1 } });
+    c.setDisabledSignalDirections(['momentum:short']);
+
+    // LONG: not in disabled set → goes through.
+    const longOut = c.combine([sig('momentum', 'LONG', 0.5)], undefined, 'event_financial');
+    expect(longOut?.direction).toBe('LONG');
+
+    // SHORT: matches `momentum:short` → weight 0 → no signal.
+    const shortOut = c.combine([sig('momentum', 'SHORT', -0.5)], undefined, 'event_financial');
+    expect(shortOut === null || shortOut!.direction === 'NEUTRAL').toBe(true);
+  });
+
+  it('setDisabledSignalDirections round-trips through getDisabledSignalDirections', () => {
+    const c = new WeightedAverageCombiner({}, baseParams);
+    c.setDisabledSignalDirections(['momentum:short', 'ofi:long']);
+    const got = c.getDisabledSignalDirections();
+    expect(got.has('momentum:short')).toBe(true);
+    expect(got.has('ofi:long')).toBe(true);
+    expect(got.size).toBe(2);
+  });
+
+  it('does not interfere with disabledSignalIds (whole-signal disable still works)', () => {
+    const c = new WeightedAverageCombiner({ momentum: 1 }, baseParams);
+    c.setDirectionMultiplier(1);
+    c.setTypeWeights({ event_financial: { momentum: 1, mean_reversion: 1 } });
+    c.setDisabledSignalIds(['mean_reversion']);
+    // Per-direction set is independent (empty here).
+
+    const out = c.combine(
+      [sig('momentum', 'LONG', 0.5), sig('mean_reversion', 'LONG', 0.5)],
+      undefined,
+      'event_financial'
+    );
+    expect(out?.componentSignals?.some((s) => s.signalId === 'mean_reversion')).toBe(false);
+  });
+});

--- a/packages/signals/src/combiners/WeightedAverageCombiner.ts
+++ b/packages/signals/src/combiners/WeightedAverageCombiner.ts
@@ -30,6 +30,13 @@ interface WeightedAverageParams {
    *  control. The Optimizer can still write rows for these signals — they're
    *  ignored here, immune to oscillation. */
   disabledSignalIds: Set<string>;
+  /** Per-(signalId, direction) hard-disable set. Tokens are lowercase
+   *  `signalId:direction` (direction ∈ {long, short}). Used to selectively
+   *  silence one direction of a generator without nuking the whole signal.
+   *  Same operational-gate semantics as `disabledSignalIds` but with the
+   *  granularity that PR-A's per-direction `signal_weights` schema unlocks.
+   *  Source: SIGNAL_DIRECTIONS_DISABLED env var (parsed by SignalEngine). */
+  disabledSignalDirections: Set<string>;
 }
 
 /**
@@ -113,6 +120,11 @@ export class WeightedAverageCombiner implements ISignalCombiner {
   private logger: Logger;
   private weights: Record<string, number> = {};
   private typeWeights: Record<string, Record<string, number>>;
+  /** Per-direction overrides — populated by setPerDirectionTypeWeights.
+   *  Shape: { marketType → { signalId → { 'long'|'short' → weight } } }.
+   *  Lookup falls back to typeWeights (=== direction '__all__') when an entry
+   *  is missing. Empty initially; PR-C's Optuna writes rows that load here. */
+  private perDirectionTypeWeights: Record<string, Record<string, Record<string, number>>> = {};
   private parameters: WeightedAverageParams;
   /** Multiplier applied to combined strength before direction determination.
    *  -1 = flip all signals (contrarian). Context overrides are stored separately
@@ -142,6 +154,7 @@ export class WeightedAverageCombiner implements ISignalCombiner {
       maxSignalAgeMs: 5 * 60 * 1000, // 5 minutes
       consensusDiscountFloor: 0.5,
       disabledSignalIds: new Set<string>(),
+      disabledSignalDirections: new Set<string>(),
       ...params,
     };
   }
@@ -150,6 +163,37 @@ export class WeightedAverageCombiner implements ISignalCombiner {
   setDisabledSignalIds(ids: Iterable<string>): void {
     this.parameters.disabledSignalIds = new Set(ids);
     this.logger.info({ disabled: Array.from(this.parameters.disabledSignalIds) }, 'Disabled signal IDs updated');
+  }
+
+  /** Replace the disabled (signalId, direction) set. Tokens must be lowercase
+   *  `signalId:direction` with direction ∈ {long, short}. Pass an empty Set
+   *  to clear. SignalEngine parses SIGNAL_DIRECTIONS_DISABLED into this. */
+  setDisabledSignalDirections(tokens: Iterable<string>): void {
+    this.parameters.disabledSignalDirections = new Set(tokens);
+    this.logger.info(
+      { disabled: Array.from(this.parameters.disabledSignalDirections) },
+      'Disabled signal directions updated'
+    );
+  }
+
+  getDisabledSignalDirections(): Set<string> {
+    return new Set(this.parameters.disabledSignalDirections);
+  }
+
+  /** Set per-direction weights for combiner lookup (PR-B 2026-05-13).
+   *  Shape: { marketType: { signalId: { 'long' | 'short': weight } } }.
+   *  Missing entries fall back to typeWeights (the legacy '__all__' direction). */
+  setPerDirectionTypeWeights(
+    weights: Record<string, Record<string, Record<string, number>>>
+  ): void {
+    this.perDirectionTypeWeights = { ...this.perDirectionTypeWeights, ...weights };
+    const totalCells = Object.values(weights)
+      .flatMap((m) => Object.values(m))
+      .flatMap((d) => Object.keys(d)).length;
+    this.logger.info(
+      { markets: Object.keys(weights), cells: totalCells },
+      'Per-direction type weights updated'
+    );
   }
 
   getDisabledSignalIds(): Set<string> {
@@ -462,26 +506,60 @@ export class WeightedAverageCombiner implements ISignalCombiner {
   }
 
   /**
-   * Get weight for a specific signal, using market-type-specific weights if available
+   * Get weight for a specific signal, using market-type-specific weights if available.
+   *
+   * PR-B 2026-05-13: lookup is now per-direction. For a signal with direction
+   * LONG or SHORT, we look up `perDirectionTypeWeights[marketType][signalId][direction]`
+   * first; if absent, fall back to `typeWeights[marketType][signalId]` (legacy
+   * '__all__' direction). NEUTRAL signals always use the legacy path.
+   *
+   * Normalization base is built consistently with the fallback chain: for each
+   * other signal configured on this market_type, take its per-direction weight
+   * for THIS direction if present, else its '__all__' weight. This keeps the
+   * normalize semantics correct during the transition period where some cells
+   * are per-direction and others are still '__all__'.
    */
   private getSignalWeight(signal: SignalOutput, now: Date, marketType?: string): number {
-    // Hard disable: configured via SIGNAL_TYPES_DISABLED env var. Immune to
+    // Hard disable (whole signal): SIGNAL_TYPES_DISABLED env var. Immune to
     // signal_weights rows (the Optimizer can write whatever it wants — this
     // gate ignores them). Resolves the oscillation discovered 2026-05-12 where
     // dashboard boot cleanup deleted rows but Optuna re-wrote them every 6h.
     if (this.parameters.disabledSignalIds.has(signal.signalId)) {
       return 0;
     }
-    // Per-type weights are explicit allowlists — generators not listed for this
-    // market_type intentionally do not contribute. Default 0 honors that intent
-    // (a previous default of 1 caused unlisted generators to dominate via the
-    // normalize pass). The legacy this.weights branch keeps default 1 for
-    // backward compatibility with markets that have no type-specific entry.
+    // Hard disable (specific direction): SIGNAL_DIRECTIONS_DISABLED env var.
+    // Lets us silence one direction of a generator (e.g., "momentum:short")
+    // without nuking its other direction. PR-B 2026-05-13.
+    const dirKey =
+      signal.direction === 'LONG' ? 'long' : signal.direction === 'SHORT' ? 'short' : null;
+    if (dirKey && this.parameters.disabledSignalDirections.has(`${signal.signalId}:${dirKey}`)) {
+      return 0;
+    }
+
     let weight: number;
     let weightSource: Record<string, number>;
+
     if (marketType && this.typeWeights[marketType]) {
-      weightSource = this.typeWeights[marketType];
-      weight = weightSource[signal.signalId] ?? 0;
+      // Per-direction override (PR-B). Falls back to typeWeights when no
+      // explicit per-direction row exists for this (signal, direction).
+      const perDir = dirKey ? this.perDirectionTypeWeights[marketType] : undefined;
+      const perDirWeight = perDir?.[signal.signalId]?.[dirKey!];
+
+      if (perDirWeight !== undefined) {
+        weight = perDirWeight;
+        // Build normalize base: each configured signal contributes its
+        // per-direction weight for THIS direction if present, else its
+        // legacy '__all__' weight. Captures the effective weight vector
+        // that's active for this signal's direction.
+        weightSource = {};
+        for (const sigId of Object.keys(this.typeWeights[marketType])) {
+          weightSource[sigId] =
+            perDir?.[sigId]?.[dirKey!] ?? this.typeWeights[marketType][sigId];
+        }
+      } else {
+        weightSource = this.typeWeights[marketType];
+        weight = weightSource[signal.signalId] ?? 0;
+      }
     } else {
       weightSource = this.weights;
       weight = weightSource[signal.signalId] ?? 1;


### PR DESCRIPTION
## Summary

PR-B of the per-direction-weights series. Built on PR-A (#218)'s schema. Combiner gains per-direction weight lookup with fallback to `'__all__'`; SignalEngine loads per-direction rows from DB at boot; new env-gate `SIGNAL_DIRECTIONS_DISABLED` parallels `SIGNAL_TYPES_DISABLED` at `(signalId, direction)` granularity.

**No behaviour change yet** — the per-direction lookup map is empty until PR-C/PR-D start writing 'long'/'short' rows. The combiner always falls back to `typeWeights` ('__all__' direction) for now, matching today's production semantics exactly.

### Changes

**WeightedAverageCombiner**
- New param `disabledSignalDirections: Set<string>`. Tokens: `signalId:direction` (lowercase). Zeroes weight for ONLY that direction.
- New setter/getter: `setDisabledSignalDirections` / `getDisabledSignalDirections`.
- New storage `perDirectionTypeWeights` + setter `setPerDirectionTypeWeights`.
- `getSignalWeight` lookup chain: disabled-id → disabled-direction → per-direction → '__all__' → 0.
- Normalization base built consistently: each configured signal contributes its per-direction value for THIS direction if present, else its '__all__' value. Keeps normalize semantics correct during the transition.

**SignalEngine**
- New `parseDisabledSignalDirections(raw)` regex-validates tokens (drops malformed silently).
- Constructor reads `process.env.SIGNAL_DIRECTIONS_DISABLED` into combiner params.
- `syncWeightsFromDB` now also pulls `getAllPerDirection()` and calls `setPerDirectionTypeWeights`.

**Repositories**
- New `signalWeightsRepo.getAllPerDirection()` — returns `{ marketType: { signalType: { 'long'|'short': weight } } }`. Empty today.

**Compose**
- `SIGNAL_DIRECTIONS_DISABLED: \"\"` — empty default. Available as operational kill-switch.

### Tests
- `WeightedAverageCombiner.perDirection.test.ts` (6 cases)
- `SignalEngine.directionsDisabledParser.test.ts` (6 cases)
- `signalWeightsRepo.getAllPerDirection.test.ts` (3 cases)
- **1002 tests pass** / 14 skipped, tsc clean.

### Validation post-deploy
- [ ] Combiner.setPerDirectionTypeWeights logs \"cells: 0\" at boot (no per-direction rows yet).
- [ ] Live signal generation identical — fallback through typeWeights.
- [ ] SIGNAL_DIRECTIONS_DISABLED visible in container env, empty.

### Future
PR-C: Optuna writes per-direction rows. PR-D: cost-aware seed. PR-E: deprecate '__all__'.

## Test plan
- [x] tsc clean (signals + dashboard)
- [x] vitest 1002 passed locally
- [ ] CI green
- [ ] VM deploy + verify boot logs show \"Synced perDirectionWeights from database: 0 cells\"

Design: \`docs/plans/2026-05-13-per-direction-weights-design.md\`
Builds on: #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-direction signal disabling capability—selectively disable specific signal directions (long/short) independently via new `SIGNAL_DIRECTIONS_DISABLED` configuration.
  * Added support for direction-specific signal weights, allowing granular weight control per signal direction with fallback to existing default weights.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/219)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->