### PR TITLE
feat(seed): per-direction signal_weights from cost-aware t-stat (PR-D)

### DIFF
--- a/data/cost-aware-tstat-2026-05-13.json
+++ b/data/cost-aware-tstat-2026-05-13.json
@@ -1,0 +1,43 @@
+{
+  "_meta": {
+    "generated_at": "2026-05-13",
+    "window_days": 3,
+    "horizon_hours": 4,
+    "rt_cost_assumption_pct": 1.08,
+    "rt_cost_source": "scripts/measure-rt-cost.js — measured from paper_trades post-2026-05-11-reset, fees + observed buy-side slippage",
+    "sql_source": "tmp-tstat-focused.sql (event_financial + crypto_intraday) + tmp-tstat-event-short-only.sql — see git history",
+    "note": "event_short: all 6 measurable cells show gross=0.0 (static midpoints on World Cup markets, no 4h drift). event_long: deferred — 122k predictions × per-row price seeks too slow on e2-micro (>60min) without query rewrite. For market_types without cells in this file the seed preserves the existing __all__ weight (no per-direction row written, combiner falls back via PR-B's lookup chain)."
+  },
+  "cells": [
+    { "signal_id": "cross_market_corr", "market_type": "crypto_intraday", "direction": "long",  "n":  834, "gross_pct": -0.3179, "t_gross": -10.17 },
+    { "signal_id": "mean_reversion",    "market_type": "crypto_intraday", "direction": "long",  "n": 2784, "gross_pct":  0.0735, "t_gross":   4.13 },
+    { "signal_id": "mlofi",             "market_type": "crypto_intraday", "direction": "long",  "n": 2009, "gross_pct": -0.3485, "t_gross": -17.41 },
+    { "signal_id": "momentum",          "market_type": "crypto_intraday", "direction": "long",  "n": 3179, "gross_pct": -0.0612, "t_gross":  -3.25 },
+    { "signal_id": "ofi",               "market_type": "crypto_intraday", "direction": "long",  "n": 3349, "gross_pct": -0.0778, "t_gross":  -4.54 },
+    { "signal_id": "cross_market_corr", "market_type": "crypto_intraday", "direction": "short", "n": 1405, "gross_pct": -0.1833, "t_gross":  -5.27 },
+    { "signal_id": "mean_reversion",    "market_type": "crypto_intraday", "direction": "short", "n":  126, "gross_pct":  1.3690, "t_gross":  10.14 },
+    { "signal_id": "mlofi",             "market_type": "crypto_intraday", "direction": "short", "n": 1307, "gross_pct": -0.3283, "t_gross": -11.21 },
+    { "signal_id": "momentum",          "market_type": "crypto_intraday", "direction": "short", "n":  567, "gross_pct": -0.0628, "t_gross":  -2.00 },
+    { "signal_id": "ofi",               "market_type": "crypto_intraday", "direction": "short", "n":  313, "gross_pct": -0.0495, "t_gross":  -0.82 },
+    { "signal_id": "cross_market_corr", "market_type": "event_financial", "direction": "long",  "n": 2767, "gross_pct":  0.3169, "t_gross":   7.43 },
+    { "signal_id": "mean_reversion",    "market_type": "event_financial", "direction": "long",  "n": 4200, "gross_pct":  0.5520, "t_gross":  16.94 },
+    { "signal_id": "mlofi",             "market_type": "event_financial", "direction": "long",  "n": 4284, "gross_pct": -0.1344, "t_gross":  -5.15 },
+    { "signal_id": "momentum",          "market_type": "event_financial", "direction": "long",  "n": 7661, "gross_pct":  0.2035, "t_gross":  11.31 },
+    { "signal_id": "news_sentiment",    "market_type": "event_financial", "direction": "long",  "n": 1852, "gross_pct":  0.0256, "t_gross":   0.68 },
+    { "signal_id": "ofi",               "market_type": "event_financial", "direction": "long",  "n": 7539, "gross_pct":  0.1720, "t_gross":   8.69 },
+    { "signal_id": "spread_compression","market_type": "event_financial", "direction": "long",  "n":  127, "gross_pct": -1.8622, "t_gross":  -9.78 },
+    { "signal_id": "cross_market_corr", "market_type": "event_financial", "direction": "short", "n": 3100, "gross_pct": -0.1231, "t_gross":  -3.08 },
+    { "signal_id": "mean_reversion",    "market_type": "event_financial", "direction": "short", "n": 2387, "gross_pct":  0.0246, "t_gross":   0.82 },
+    { "signal_id": "mlofi",             "market_type": "event_financial", "direction": "short", "n": 4942, "gross_pct": -0.6484, "t_gross": -24.41 },
+    { "signal_id": "momentum",          "market_type": "event_financial", "direction": "short", "n": 1694, "gross_pct": -0.6697, "t_gross": -10.89 },
+    { "signal_id": "news_sentiment",    "market_type": "event_financial", "direction": "short", "n":  317, "gross_pct": -1.0904, "t_gross":  -8.57 },
+    { "signal_id": "ofi",               "market_type": "event_financial", "direction": "short", "n": 1292, "gross_pct": -0.4663, "t_gross":  -8.75 },
+    { "signal_id": "spread_compression","market_type": "event_financial", "direction": "short", "n":  625, "gross_pct": -0.6560, "t_gross":  -7.13 },
+    { "signal_id": "mean_reversion",    "market_type": "event_short", "direction": "long",  "n":  336, "gross_pct": 0.0, "t_gross": 0, "note": "static midpoint — no 4h drift on World Cup markets at 30-46d horizon" },
+    { "signal_id": "mlofi",             "market_type": "event_short", "direction": "long",  "n":  141, "gross_pct": 0.0, "t_gross": 0 },
+    { "signal_id": "momentum",          "market_type": "event_short", "direction": "long",  "n":  482, "gross_pct": 0.0, "t_gross": 0 },
+    { "signal_id": "news_sentiment",    "market_type": "event_short", "direction": "long",  "n":  113, "gross_pct": 0.0, "t_gross": 0 },
+    { "signal_id": "ofi",               "market_type": "event_short", "direction": "long",  "n":  421, "gross_pct": 0.0, "t_gross": 0 },
+    { "signal_id": "ofi",               "market_type": "event_short", "direction": "short", "n":   35, "gross_pct": 0.0, "t_gross": 0 }
+  ]
+}

--- a/scripts/measure-rt-cost.js
+++ b/scripts/measure-rt-cost.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Measure real round-trip execution cost per market_type from `paper_trades`.
+ *
+ * Real cost = fees + observed slippage on buys. SELL slippage in paper data is
+ * 0 (exits use midpoint), so the BUY side carries the round-trip's slippage
+ * burden. Computed as:
+ *   per_trade_cost_pct = SUM(fee)/SUM(value_usd) + AVG(|slippage_pct|)/100
+ *   rt_cost_pct        = 2 × per_trade_cost_pct
+ *
+ * Window: trades after `paper_account.last_reset_at` only — pre-reset data has
+ * different config (direction multiplier flip, fee changes, etc.).
+ *
+ * Output: JSON map `{ market_type: rt_cost_fraction }` to stdout, plus a
+ * formatted table to stderr. Used by `seed-per-direction-weights.js` as the
+ * cost prior for t_net scaling.
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://... NODE_TLS_REJECT_UNAUTHORIZED=0 \
+ *     node scripts/measure-rt-cost.js [--min-trades N] [--format=json|table]
+ *
+ * Flags:
+ *   --min-trades N  Drop market_types with fewer than N trades (default 10).
+ *                   With <N trades the slippage estimate has too much noise.
+ *   --format        Default 'both' — table to stderr + JSON to stdout.
+ *                   'json' = JSON only; 'table' = table only.
+ *   --default-rt    Fallback RT cost for market_types with insufficient data
+ *                   (default 0.01 = 1% — close to the empirical 1.08% measured
+ *                   2026-05-13 on event_financial/event_long).
+ *
+ * Empirical reading 2026-05-13 (post-reset 2026-05-11):
+ *   event_financial  RT 1.08% (n=49)
+ *   event_long       RT 1.06% (n=14)
+ *   crypto_*         no data — used default 1.0%
+ *   event_short      no data — used default 1.0%
+ */
+const { Pool } = require('pg');
+
+function parseArgs(argv) {
+  const args = { minTrades: 10, format: 'both', defaultRt: 0.01 };
+  for (let i = 2; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === '--min-trades') args.minTrades = parseInt(argv[++i], 10);
+    else if (k.startsWith('--format=')) args.format = k.slice('--format='.length);
+    else if (k === '--format') args.format = argv[++i];
+    else if (k === '--default-rt') args.defaultRt = parseFloat(argv[++i]);
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  try {
+    const res = await pool.query(`
+      WITH reset_cutoff AS (
+        SELECT last_reset_at FROM paper_account ORDER BY id LIMIT 1
+      ),
+      trades_with_type AS (
+        SELECT t.*, m.market_type
+        FROM paper_trades t
+        JOIN markets m ON m.id = t.market_id
+        CROSS JOIN reset_cutoff
+        WHERE t.time >= reset_cutoff.last_reset_at
+          AND t.executed_size > 0
+          AND t.value_usd > 0
+      )
+      SELECT
+        market_type,
+        COUNT(*) AS n_trades,
+        SUM(value_usd) AS total_value_usd,
+        SUM(fee) AS total_fees,
+        AVG(ABS(COALESCE(slippage_pct, 0))) AS avg_slip_pct,
+        SUM(fee) / NULLIF(SUM(value_usd), 0) AS fee_rate,
+        AVG(ABS(COALESCE(slippage_pct, 0))) / 100.0 AS slip_rate
+      FROM trades_with_type
+      GROUP BY 1 ORDER BY 1
+    `);
+
+    const types = res.rows.filter((r) => Number(r.n_trades) >= args.minTrades);
+    const dropped = res.rows.filter((r) => Number(r.n_trades) < args.minTrades);
+
+    const costs = {};
+    for (const r of types) {
+      const feeRate = Number(r.fee_rate) || 0;
+      const slipRate = Number(r.slip_rate) || 0;
+      // RT = 2 × per-trade cost (entry + exit). One side carries slippage
+      // (BUY), the other doesn't (SELL = midpoint in paper). Fee applies
+      // both sides. So RT ≈ 2×fee + slip_buy (≈ 2×slip_rate average).
+      costs[r.market_type] = 2 * (feeRate + slipRate);
+    }
+    // Fill defaults for any known market_type not present in observations.
+    // Default is conservative — overestimating cost slightly is safer than
+    // under-estimating (the seed multiplier becomes too cautious, not too
+    // permissive).
+    const ALL_TYPES = ['crypto_intraday', 'crypto_daily', 'event_financial', 'event_short', 'event_long'];
+    for (const t of ALL_TYPES) {
+      if (!(t in costs)) costs[t] = args.defaultRt;
+    }
+
+    if (args.format === 'table' || args.format === 'both') {
+      const fmt = (n, w = 8, d = 4) => Number(n).toFixed(d).padStart(w);
+      const out = [];
+      out.push('');
+      out.push(`Real RT execution cost per market_type (post-last-reset, n_min=${args.minTrades})`);
+      out.push('-'.repeat(78));
+      out.push(`market_type           n_trades   fee_rate   slip_rate     rt_cost`);
+      out.push('-'.repeat(78));
+      for (const r of types) {
+        const feeRate = Number(r.fee_rate) || 0;
+        const slipRate = Number(r.slip_rate) || 0;
+        const rt = costs[r.market_type];
+        out.push(
+          `${r.market_type.padEnd(22)}${String(r.n_trades).padStart(8)}  ${fmt(feeRate)}    ${fmt(slipRate)}    ${fmt(rt)}`
+        );
+      }
+      if (dropped.length > 0) {
+        out.push('');
+        out.push(`Dropped (n < ${args.minTrades}, default=${args.defaultRt}):`);
+        for (const r of dropped) {
+          out.push(`  ${r.market_type} (n=${r.n_trades})`);
+        }
+      }
+      out.push('-'.repeat(78));
+      out.push('');
+      process.stderr.write(out.join('\n') + '\n');
+    }
+
+    if (args.format === 'json' || args.format === 'both') {
+      process.stdout.write(JSON.stringify(costs, null, 2) + '\n');
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('Error:', err.message);
+  process.exitCode = 1;
+});

--- a/scripts/seed-per-direction-weights.js
+++ b/scripts/seed-per-direction-weights.js
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * Seed per-direction signal_weights rows from cost-aware t-stat data.
+ *
+ * PR-D of the per-direction-weights series. Reads cost-aware t-stat
+ * measurements (data/cost-aware-tstat-*.json) and per-(market_type) RT cost
+ * (either from --rt-cost-json or measured via scripts/measure-rt-cost.js),
+ * computes the cost-aware t_net per cell, then writes per-direction rows to
+ * signal_weights.
+ *
+ * Formula:
+ *   t_net = t_gross × (gross_pct − rt_cost_pct) / gross_pct
+ *   scale = clip(1 + 0.05 × t_net, 0.05, 2.0)
+ *   weight_per_direction = current_all_weight × scale
+ *
+ * Why this scaling:
+ *   - scale = 1 when t_net = 0 (preserves current weight under no-evidence).
+ *   - scale = 2 when t_net = +20 (strong positive evidence doubles the weight).
+ *   - scale = 0.05 floor (clipped) means strongly anti-edge cells get
+ *     5% of base, not 0 — preserves a non-degenerate starting point that
+ *     Optuna can refine. Pure-zero would freeze the cell completely and
+ *     prevent re-exploration.
+ *   - 0.05 slope = roughly 1σ of evidence → 5% scale change. Modest;
+ *     keeps the seed conservative.
+ *
+ * For cells where we have NO measurement (event_long, event_short until
+ * next measurement cycle), no per-direction rows are written. Combiner
+ * falls back to the '__all__' direction row via PR-B's lookup chain.
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://... NODE_TLS_REJECT_UNAUTHORIZED=0 \
+ *     node scripts/seed-per-direction-weights.js \
+ *       --tstat data/cost-aware-tstat-2026-05-13.json \
+ *       [--rt-cost data/rt-cost-2026-05-13.json] \
+ *       [--default-rt 0.01] \
+ *       [--dry-run]
+ *
+ * Flags:
+ *   --tstat PATH       JSON of t-stat measurements (required).
+ *   --rt-cost PATH     JSON of per-market_type RT cost; if omitted, uses the
+ *                      rt_cost_assumption_pct from the tstat file's _meta.
+ *   --default-rt N     Fallback for market_types without measured RT cost
+ *                      (default 0.01 = 1%).
+ *   --dry-run          Print planned writes without persisting.
+ *   --skip-disabled    Skip signals in SIGNAL_TYPES_DISABLED env (default ON).
+ *                      Pass --no-skip-disabled to override.
+ *
+ * Exit status:
+ *   0 — applied (or dry-run completed)
+ *   1 — error
+ */
+const { Pool } = require('pg');
+const fs = require('fs');
+
+const DEFAULT_DISABLED = (process.env.SIGNAL_TYPES_DISABLED || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+function parseArgs(argv) {
+  const args = {
+    tstat: null,
+    rtCost: null,
+    defaultRt: 0.01,
+    dryRun: false,
+    skipDisabled: true,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === '--tstat') args.tstat = argv[++i];
+    else if (k === '--rt-cost') args.rtCost = argv[++i];
+    else if (k === '--default-rt') args.defaultRt = parseFloat(argv[++i]);
+    else if (k === '--dry-run') args.dryRun = true;
+    else if (k === '--skip-disabled') args.skipDisabled = true;
+    else if (k === '--no-skip-disabled') args.skipDisabled = false;
+  }
+  if (!args.tstat) {
+    console.error('Error: --tstat <path> is required.');
+    process.exit(1);
+  }
+  return args;
+}
+
+/**
+ * Compute t_net from t_gross given the cost.
+ * t_net = t_gross × (gross − cost) / gross.
+ * Edge case: gross = 0 → t_gross would also be 0 → return 0.
+ */
+function computeTNet({ t_gross, gross_pct, rt_cost_pct }) {
+  if (gross_pct === 0) return 0;
+  return t_gross * (gross_pct - rt_cost_pct) / gross_pct;
+}
+
+/**
+ * Map t_net to a scale multiplier for the existing __all__ weight.
+ * clip(1 + 0.05 × t_net, 0.05, 2.0)
+ */
+function scaleFromTNet(t_net) {
+  const raw = 1 + 0.05 * t_net;
+  return Math.max(0.05, Math.min(2.0, raw));
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const tstatFile = JSON.parse(fs.readFileSync(args.tstat, 'utf-8'));
+  const rtCostMap = args.rtCost ? JSON.parse(fs.readFileSync(args.rtCost, 'utf-8')) : null;
+  const fallbackRtPct = tstatFile._meta?.rt_cost_assumption_pct ?? (args.defaultRt * 100);
+
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  try {
+    // Read current '__all__' weights (base) per (signal, market_type).
+    const baseRes = await pool.query(`
+      SELECT signal_type, market_type, weight, is_enabled
+      FROM signal_weights
+      WHERE direction = '__all__' AND market_type != '__global__'
+    `);
+    const base = new Map();  // key: "sig|type" → { weight, is_enabled }
+    for (const r of baseRes.rows) {
+      base.set(`${r.signal_type}|${r.market_type}`, {
+        weight: Number(r.weight),
+        is_enabled: r.is_enabled,
+      });
+    }
+
+    const writes = [];
+    const skipped = [];
+
+    for (const cell of tstatFile.cells) {
+      const { signal_id, market_type, direction, n, gross_pct, t_gross } = cell;
+
+      // Skip disabled signals — SIGNAL_TYPES_DISABLED zeros them at combiner
+      // level anyway, so per-direction rows here would be wasted writes.
+      if (args.skipDisabled && DEFAULT_DISABLED.includes(signal_id)) {
+        skipped.push({ signal_id, market_type, direction, reason: 'in SIGNAL_TYPES_DISABLED' });
+        continue;
+      }
+
+      const baseEntry = base.get(`${signal_id}|${market_type}`);
+      if (!baseEntry) {
+        skipped.push({ signal_id, market_type, direction, reason: 'no __all__ row for base' });
+        continue;
+      }
+      // Keep is_enabled mirrored from the __all__ row — if upstream disabled
+      // the signal globally for this type, per-direction shouldn't override.
+      if (!baseEntry.is_enabled) {
+        skipped.push({ signal_id, market_type, direction, reason: '__all__ is_enabled=false' });
+        continue;
+      }
+      // Skip cells with zero information (gross=0 and t_gross=0 → static
+      // midpoint, no measurable drift). Writing a per-direction row with
+      // scale=1.0 would just duplicate the __all__ row. Fallback to __all__
+      // via the combiner's lookup chain is cleaner.
+      if (gross_pct === 0 && t_gross === 0) {
+        skipped.push({ signal_id, market_type, direction, reason: 'zero information (gross=0, t_gross=0)' });
+        continue;
+      }
+
+      const rtPct = rtCostMap?.[market_type] != null
+        ? rtCostMap[market_type] * 100
+        : fallbackRtPct;
+      const t_net = computeTNet({ t_gross, gross_pct, rt_cost_pct: rtPct });
+      const scale = scaleFromTNet(t_net);
+      const newWeight = baseEntry.weight * scale;
+
+      writes.push({
+        signal_id,
+        market_type,
+        direction,
+        n,
+        gross_pct,
+        rt_pct: rtPct,
+        t_gross,
+        t_net: Number(t_net.toFixed(3)),
+        base_weight: Number(baseEntry.weight.toFixed(4)),
+        scale: Number(scale.toFixed(3)),
+        new_weight: Number(newWeight.toFixed(4)),
+      });
+    }
+
+    // Reporting (always, even in dry-run)
+    console.log('');
+    console.log(`Seed plan (${writes.length} writes, ${skipped.length} skipped):`);
+    console.log('-'.repeat(105));
+    console.log(
+      [
+        'signal'.padEnd(22),
+        'type'.padEnd(18),
+        'dir'.padEnd(6),
+        'n'.padStart(6),
+        'gross%'.padStart(8),
+        't_gross'.padStart(8),
+        't_net'.padStart(8),
+        'base'.padStart(8),
+        'scale'.padStart(7),
+        'new_w'.padStart(8),
+      ].join(' | ')
+    );
+    console.log('-'.repeat(105));
+    for (const w of writes) {
+      console.log(
+        [
+          w.signal_id.padEnd(22),
+          w.market_type.padEnd(18),
+          w.direction.padEnd(6),
+          String(w.n).padStart(6),
+          w.gross_pct.toFixed(3).padStart(8),
+          w.t_gross.toFixed(2).padStart(8),
+          w.t_net.toFixed(2).padStart(8),
+          w.base_weight.toFixed(3).padStart(8),
+          w.scale.toFixed(3).padStart(7),
+          w.new_weight.toFixed(3).padStart(8),
+        ].join(' | ')
+      );
+    }
+    console.log('-'.repeat(105));
+
+    if (skipped.length > 0) {
+      console.log(`\nSkipped (${skipped.length}):`);
+      for (const s of skipped) {
+        console.log(`  ${s.signal_id}@${s.market_type}:${s.direction} → ${s.reason}`);
+      }
+    }
+
+    if (args.dryRun) {
+      console.log('\n(dry-run — no writes applied)');
+      return;
+    }
+
+    // Actual writes.
+    let applied = 0;
+    for (const w of writes) {
+      await pool.query(
+        `INSERT INTO signal_weights
+           (signal_type, market_type, direction, weight, is_enabled, min_confidence, updated_at)
+         VALUES ($1, $2, $3, $4, true, 0.0, NOW())
+         ON CONFLICT (signal_type, market_type, direction)
+         DO UPDATE SET weight = EXCLUDED.weight, updated_at = EXCLUDED.updated_at`,
+        [w.signal_id, w.market_type, w.direction, w.new_weight]
+      );
+      applied++;
+    }
+    console.log(`\nApplied: ${applied} per-direction rows.`);
+  } finally {
+    await pool.end();
+  }
+}
+
+// Only run main() when invoked directly (`node seed-per-direction-weights.js`).
+// When required by the unit test, `module.parent` is non-null and we skip exec.
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('Error:', err.message);
+    process.exitCode = 1;
+  });
+}
+
+// Exports for unit tests.
+module.exports = { computeTNet, scaleFromTNet };

--- a/scripts/seed-per-direction-weights.test.js
+++ b/scripts/seed-per-direction-weights.test.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for the cost-aware seed scaling formulas (PR-D).
+ *
+ * Pure-Node test runner — runs outside the vitest pipeline since this is a
+ * script-level utility. Exit 0 = pass, 1 = fail.
+ *
+ * Usage: node scripts/seed-per-direction-weights.test.js
+ */
+const assert = require('node:assert/strict');
+const { computeTNet, scaleFromTNet } = require('./seed-per-direction-weights.js');
+
+const cases = [
+  // computeTNet
+  { name: 'computeTNet: gross_pct=0 → 0', fn: () =>
+    assert.equal(computeTNet({ t_gross: 0, gross_pct: 0, rt_cost_pct: 1 }), 0) },
+
+  { name: 'computeTNet: positive gross, cost < gross → smaller positive t_net', fn: () => {
+    // mean_reversion crypto_intraday SHORT 2026-05-13: 10.14 × (1.369-1.08)/1.369 ≈ 2.14
+    const t = computeTNet({ t_gross: 10.14, gross_pct: 1.369, rt_cost_pct: 1.08 });
+    assert.ok(Math.abs(t - 2.14) < 0.05, `got ${t}, expected ~2.14`);
+  } },
+
+  { name: 'computeTNet: positive gross, cost > gross → flips negative', fn: () => {
+    // mean_reversion event_financial LONG: 16.94 × (0.552-1.08)/0.552 ≈ -16.2
+    const t = computeTNet({ t_gross: 16.94, gross_pct: 0.552, rt_cost_pct: 1.08 });
+    assert.ok(Math.abs(t - -16.2) < 0.1, `got ${t}, expected ~-16.2`);
+  } },
+
+  { name: 'computeTNet: negative gross stays/grows negative', fn: () => {
+    // mlofi event_financial SHORT: -24.41 × (-0.648-1.08)/-0.648 ≈ -65.1
+    const t = computeTNet({ t_gross: -24.41, gross_pct: -0.648, rt_cost_pct: 1.08 });
+    assert.ok(Math.abs(t - -65.1) < 0.5, `got ${t}, expected ~-65.1`);
+  } },
+
+  // scaleFromTNet
+  { name: 'scaleFromTNet: t=0 → 1.0', fn: () =>
+    assert.ok(Math.abs(scaleFromTNet(0) - 1.0) < 1e-9) },
+  { name: 'scaleFromTNet: t=+20 → 2.0 (cap)', fn: () =>
+    assert.ok(Math.abs(scaleFromTNet(20) - 2.0) < 1e-9) },
+  { name: 'scaleFromTNet: t=+100 → still 2.0 (cap)', fn: () =>
+    assert.equal(scaleFromTNet(100), 2.0) },
+  { name: 'scaleFromTNet: t=-30 → 0.05 (floor)', fn: () =>
+    assert.equal(scaleFromTNet(-30), 0.05) },
+  { name: 'scaleFromTNet: t=+10 → 1.5', fn: () =>
+    assert.ok(Math.abs(scaleFromTNet(10) - 1.5) < 1e-9) },
+  { name: 'scaleFromTNet: t=-10 → 0.5', fn: () =>
+    assert.ok(Math.abs(scaleFromTNet(-10) - 0.5) < 1e-9) },
+
+  // End-to-end
+  { name: 'end-to-end: mean_reversion crypto_intraday SHORT (the surviving edge cell)', fn: () => {
+    const t_net = computeTNet({ t_gross: 10.14, gross_pct: 1.369, rt_cost_pct: 1.08 });
+    const w = 1.6649 * scaleFromTNet(t_net);  // base × scale
+    // t_net≈2.14 → scale=1+0.107=1.107 → w ≈ 1.6649×1.107 ≈ 1.843
+    assert.ok(Math.abs(w - 1.843) < 0.01, `got ${w}, expected ~1.843`);
+  } },
+
+  { name: 'end-to-end: mean_reversion event_financial LONG (no longer positive net)', fn: () => {
+    const t_net = computeTNet({ t_gross: 16.94, gross_pct: 0.552, rt_cost_pct: 1.08 });
+    const w = 1.325 * scaleFromTNet(t_net);
+    // t_net≈-16.2 → scale=1-0.81=0.19 → w ≈ 0.252
+    assert.ok(Math.abs(w - 0.252) < 0.01, `got ${w}, expected ~0.252`);
+  } },
+
+  { name: 'end-to-end: mlofi event_financial SHORT (catastrophic anti-edge → floor)', fn: () => {
+    const t_net = computeTNet({ t_gross: -24.41, gross_pct: -0.648, rt_cost_pct: 1.08 });
+    const w = 1.98 * scaleFromTNet(t_net);
+    // t_net≈-65 → clipped to 0.05 → w=0.099
+    assert.ok(Math.abs(w - 0.099) < 0.001, `got ${w}, expected ~0.099`);
+  } },
+];
+
+let failed = 0;
+for (const c of cases) {
+  try {
+    c.fn();
+    console.log(`  ✓ ${c.name}`);
+  } catch (err) {
+    console.error(`  ✗ ${c.name}\n    ${err.message}`);
+    failed++;
+  }
+}
+console.log(`\n${cases.length - failed}/${cases.length} passed`);
+process.exitCode = failed > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary

PR-D of the per-direction-weights series. Adds the measurement + seed workflow that populates `signal_weights` per-direction rows using cost-aware t-stat data + real RT cost from `paper_trades`.

## Critical finding (2026-05-13 measurement)

Real RT execution cost from paper_trades = **1.08%** (vs the 0.5% prior used in PR #212's initial t-stat). With realistic cost:

- **Only 1 of 24 measured cells has positive cost-aware net edge**: `mean_reversion crypto_intraday SHORT` t_net=+2.14 (n=126).
- Every other event_financial / crypto_intraday cell is anti-edge net.
- event_short cells (6 measured): gross=0 across the board — static midpoints on World Cup markets, no measurable 4h drift.
- event_long: deferred — 122k predictions × per-row price seeks too slow on e2-micro (>60min without query rewrite).

This explains the 26.3% live WR on event_financial LONG — even mean_reversion (the previous "leader" at +1.60 t_net under 0.5% cost) is anti-edge (-16.2 t_net) when measured against the real cost.

## Components

| File | Purpose |
|---|---|
| `scripts/measure-rt-cost.js` | Per-(market_type) RT cost from paper_trades (fee + observed slippage). Outputs JSON. |
| `scripts/seed-per-direction-weights.js` | Reads t-stat + RT cost, computes scale = clip(1 + 0.05×t_net, 0.05, 2.0), writes per-direction rows. Supports `--dry-run`. |
| `scripts/seed-per-direction-weights.test.js` | Pure-Node test runner (13/13 pass). Covers formula edge cases + end-to-end pinned to real measurements. |
| `data/cost-aware-tstat-2026-05-13.json` | Versioned snapshot of the 2026-05-13 measurement (30 cells). |

## Scaling formula

```
t_net  = t_gross × (gross_pct − rt_cost_pct) / gross_pct
scale  = clip(1 + 0.05 × t_net, 0.05, 2.0)
weight = base_weight (from __all__ row) × scale
```

Floor 0.05 (not 0) preserves Optuna's ability to explore later. Cap 2.0 prevents single-cell over-weighting.

## Dry-run output (verified on VM)

8 writes planned, 22 skipped (SIGNAL_TYPES_DISABLED + is_enabled=false + zero-information cells):

| signal | type | dir | t_net | base | scale | new_w |
|---|---|---|---|---|---|---|
| **mean_reversion** | **crypto_intraday** | **short** | **+2.14** | **1.665** | **1.107** | **1.843 ← only edge cell** |
| mean_reversion | crypto_intraday | long | -56.6 | 1.665 | 0.050 (floor) | 0.083 |
| momentum | crypto_intraday | long | -60.6 | 0.879 | 0.050 (floor) | 0.044 |
| momentum | crypto_intraday | short | -36.4 | 0.879 | 0.050 (floor) | 0.044 |
| mean_reversion | event_financial | long | -16.2 | 1.325 | 0.190 | 0.252 |
| mean_reversion | event_financial | short | -35.2 | 1.325 | 0.050 (floor) | 0.066 |
| momentum | event_financial | long | -48.7 | 0.247 | 0.050 (floor) | 0.012 |
| momentum | event_financial | short | -28.5 | 0.247 | 0.050 (floor) | 0.012 |

## Operational plan post-merge

1. CI auto-deploys → scripts land on VM.
2. `docker exec polymarket-dashboard-api node /app/scripts/seed-per-direction-weights.js --tstat /app/data/cost-aware-tstat-2026-05-13.json --dry-run` to review.
3. Apply (drop `--dry-run`).
4. Restart dashboard → `SignalEngine.syncWeightsFromDB()` picks up the new rows via PR-B's `setPerDirectionTypeWeights`.
5. Validate: 8 per-direction rows present; `mean_reversion crypto_intraday SHORT` weight ≈ 1.843.

## Expected behavioural effect

- Live trade frequency **drops** (correct response: ~no edge net of cost).
- mean_reversion event_financial LONG contribution halved (1.325 → 0.252).
- Only signal with positive seed: mean_reversion crypto_intraday SHORT (boosted to 1.843). But crypto_intraday markets are sparse in current pool → may produce zero LIVE SHORTs until rotator opens that supply (see `project_smart_market_selection_for_edge.md` for the structural follow-up).
- hawkes / volume_anomaly / resolution_prior keep `__all__` weights via PR-B's fallback — not measured yet, so unchanged.

## Tests
- 13/13 cases pass via `node scripts/seed-per-direction-weights.test.js`.
- Existing repo tests (1002) unaffected — this PR only adds scripts + data, no code paths in packages.

## Follow-ups
- event_long t-stat measurement (needs query rewrite for e2-micro).
- PR-E: deprecate `__all__` lookup path once per-direction fully populates.
- PR-C: Optuna per-direction param space + backtest disaggregation (deferred until per-direction shows empirical value).
- Phase 4 of Market Intelligence: edge-aware rotator (separate plan).

Design: \`docs/plans/2026-05-13-per-direction-weights-design.md\`
Builds on: #218 (PR-A schema), #219 (PR-B combiner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cost-aware signal weighting: Signals are now weighted based on measured execution costs and statistical performance metrics across market types, optimizing allocation for net returns after fees and slippage.

* **Tests**
  * Comprehensive test coverage added for cost-aware weight calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/220)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->