### PR TITLE
feat(phase4): edge_capacity schema + measurement scripts (PR-A)

### DIFF
--- a/docs/plans/2026-05-13-phase4-edge-aware-scorer-design.md
+++ b/docs/plans/2026-05-13-phase4-edge-aware-scorer-design.md
@@ -1,0 +1,220 @@
+# Phase 4 — Edge-Aware MarketScorer (cost-aware edge_capacity dim)
+
+**Date**: 2026-05-13
+**Series**: Market Intelligence Phase 4 (extends Phases 1+2+2.5)
+**Trigger**: After PR-D (#220) cost-aware seed landed, the system is "trading near zero" because only 1 of 24 measured (signal, market_type, direction) cells has positive cost-aware net edge. The MarketRotator keeps selecting the same 49 markets agnostic to whether their cohorts have any net edge. We need scoring to be conscious of cost-aware edge availability.
+
+## Problem (user 2026-05-13)
+
+> "la elección de mercados tendría que ser lo bastante inteligente y consciente de esto como para buscar mejor cuando no hay suficientes buenos"
+
+Current MarketScorer 8-dim formula:
+- tradeability, liquidity, ttr, volatility, dataQuality, typeExpectedValue, realizedVolatility, shadowExpectedValue
+
+`typeExpectedValue` (Phase 2 contribution) is RAW Sharpe per market_type — not cost-aware, derived from realized live trade PnL. It correlates with realized profit only AFTER trades close. Phase 4 adds a FORWARD-LOOKING dimension grounded in generator_predictions × cost-aware t_net.
+
+## Goal
+
+A 9th dim **`edge_capacity`** = how much positive cost-aware edge a market_type's signal cohort holds. Markets in types with high edge_capacity get scored UP; markets in types with zero/negative edge_capacity get scored DOWN. ScorerWeightOptimizer tunes the dim's weight via the existing 300-trial random search on score↔pnl correlation.
+
+## Non-goals (deferred)
+
+- **Active explore-mode regime switch.** Initially we let the natural scoring bias do the work — types with high edge_capacity rise, types without sink. A formal "explore-mode" state (widening candidate pool, sampling cold types) can come in Phase 4.1 if needed.
+- **Per-(signal, direction) market-specific scoring.** edge_capacity aggregates across cells within a type. A market within a "low edge" type might still be a great candidate for the one edge cell that exists — but that requires per-market t-stat which we don't have.
+- **PR-C of per-direction series** (Optuna per-direction param space + backtest disaggregation). Held behind Phase 4 validation: if cost-aware edge_capacity drives meaningful improvement, then PR-C makes sense.
+
+## edge_capacity formula
+
+Given the cost-aware t-stat dataset (e.g. `data/cost-aware-tstat-2026-05-13.json`), for each market_type:
+
+```
+edge_capacity(market_type) = Σ max(0, t_net) over all (signal_id, direction) cells in this market_type
+```
+
+Then normalize for the scorer:
+
+```
+edge_capacity_score = clamp(edge_capacity / EDGE_CAPACITY_NORM, 0, 1)
+```
+
+Where `EDGE_CAPACITY_NORM = 10` initially — corresponds to "one cell at t_net=10" or "two cells at t_net=5" being "fully covered". Tunable.
+
+**Edge cases:**
+- No cells measured for this type → return null (treated like volatility/dataQuality — drops from compositeScore renormalization).
+- All cells anti-edge → edge_capacity = 0 → score = 0 (full penalty).
+- One strong cell (e.g. mean_reversion crypto_intraday SHORT t_net=+2.14) → edge_capacity = 2.14 → score = 0.214.
+
+**Sample post-2026-05-13:**
+| market_type | edge_capacity | edge_capacity_score |
+|---|---|---|
+| crypto_intraday | 2.14 (mean_reversion SHORT only) | 0.214 |
+| event_financial | 0.0 (all cells anti-edge net) | 0.000 |
+| event_short | null (gross=0 across all, unmeasurable) | null → drops |
+| event_long | null (not yet measured) | null → drops |
+| crypto_daily | null (no predictions in 3d window) | null → drops |
+
+Result: crypto_intraday gets a 0.214 score in this dim, event_financial gets 0.0 (penalty), others fall back to renormalized 8 dims.
+
+## Schema
+
+### New table
+
+```sql
+CREATE TABLE IF NOT EXISTS market_type_edge_capacity (
+  market_type      VARCHAR(32) PRIMARY KEY,
+  edge_capacity    DOUBLE PRECISION NOT NULL,
+  n_cells_positive INT NOT NULL,
+  n_cells_measured INT NOT NULL,
+  rt_cost_pct      DOUBLE PRECISION NOT NULL,
+  source           TEXT NOT NULL,  -- e.g. 'measure-edge-capacity.js 2026-05-13'
+  updated_at       TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+Why a separate table (not extending category_performance):
+- Different cadence (edge_capacity refreshes after t-stat measurements; category_performance after live trades close)
+- Different semantics (forward-looking generator_predictions vs realized live PnL)
+- Different data source (generator_predictions + price_history + rt_cost vs paper_positions)
+
+### Extend market_score_history
+
+```sql
+ALTER TABLE market_score_history
+  ADD COLUMN IF NOT EXISTS score_edge_capacity FLOAT;
+```
+
+Existing rows get NULL. Optimizer query learns to handle the new column.
+
+### Extend scorer_weights
+
+```sql
+ALTER TABLE scorer_weights
+  ADD COLUMN IF NOT EXISTS edge_capacity FLOAT;
+```
+
+Default NULL = use hardcoded WEIGHTS.edge_capacity from MarketScorer.ts.
+
+### Optional: extend paper_positions
+
+```sql
+-- For audit of scoring decisions at trade time (post-Phase 4 trades only)
+ALTER TABLE paper_positions
+  ADD COLUMN IF NOT EXISTS score_edge_capacity_at_entry FLOAT;
+```
+
+Deferred to PR-B follow-up if needed (the JSONB `score_dimensions_at_entry` already captures all dims; explicit column is redundant).
+
+## Measurement script — `scripts/measure-edge-capacity.js`
+
+```
+DATABASE_URL=postgres://... node scripts/measure-edge-capacity.js \
+  [--window 7d] [--horizon 4h] [--rt-cost-json data/rt-cost.json] [--min-n 50] [--dry-run]
+```
+
+Pipeline:
+1. Read RT cost map (from `scripts/measure-rt-cost.js --format=json` output, or fallback to 1% default).
+2. Query `generator_predictions` for (signal_id, market_type, direction) cells with `time >= NOW() - window` and `direction IN ('long','short')` (skip SIGNAL_TYPES_DISABLED).
+3. Per cell, compute t_gross from forward 4h drift in price_history; compute t_net = t_gross × (gross_pct − rt_cost_pct) / gross_pct.
+4. Aggregate per market_type: `edge_capacity = Σ max(0, t_net)`.
+5. UPSERT into `market_type_edge_capacity` with provenance.
+
+Includes a `--dry-run` flag for review before persisting (mirrors PR-D seed script pattern).
+
+## Initial seed
+
+The cost-aware data we already have in `data/cost-aware-tstat-2026-05-13.json` is enough to compute initial edge_capacity values. PR-A includes a one-time seed step:
+```bash
+node scripts/seed-edge-capacity-from-tstat.js --tstat data/cost-aware-tstat-2026-05-13.json
+```
+Output: 1 row for `crypto_intraday` (edge_capacity=2.14), 1 row for `event_financial` (edge_capacity=0.0). Other types: no row → MarketScorer treats as null.
+
+## MarketScorer integration
+
+Add to `ScoreDimensions` (line 29):
+```typescript
+edgeCapacity: number | null;  // null when no measured cells for this type
+```
+
+Add static method:
+```typescript
+static edgeCapacityScore(rawEdgeCapacity: number | null): number | null {
+  if (rawEdgeCapacity === null) return null;
+  if (rawEdgeCapacity < 0) return 0;
+  const NORM = 10;
+  return Math.min(1, rawEdgeCapacity / NORM);
+}
+```
+
+Add to WEIGHTS (line 7) — initial 0.05 (small, lets the 8 existing dims dominate while Optuna learns):
+```typescript
+edgeCapacity: 0.05
+```
+
+Add loader, mirroring loadAllCategoryMetrics:
+```typescript
+async loadEdgeCapacityMap(): Promise<Map<string, number | null>> {
+  const rows = await pool.query('SELECT market_type, edge_capacity FROM market_type_edge_capacity');
+  // map.set('crypto_intraday', 2.14) etc; types absent from table → not in map
+}
+```
+
+Pass 1 + Pass 2 of `scoreAllMarkets` compute `edgeCapacity` per market_type and feed into compositeScore. Pass-through to market_score_history as `score_edge_capacity`.
+
+## ScorerWeightOptimizer integration
+
+Add `edgeCapacity` to:
+- `randomWeights()` — uniform [0.0, 0.20] (lower than other dims because the dim is highly informative when present but null often).
+- `loadClosedTrades` query — extract via `score_dimensions_at_entry ? 'edgeCapacity'`. Filter for non-null entries.
+- Normalization step — include in targetSum that sums to (1 - shadowExpectedValue).
+- `saveWeights` — INSERT new column.
+
+After Phase 4 lands, Optuna can tune the dim per market_type as it does for the others. The starting weight 0.05 is a hand-set prior.
+
+## Cron refresh — PR-D
+
+`Scheduler.ts` in data-collector adds:
+```typescript
+// Refresh edge_capacity from generator_predictions nightly
+cron.schedule('30 2 * * *', async () => {
+  await refreshEdgeCapacity();
+});
+```
+
+Function calls into `measureEdgeCapacityAndUpsert()` (extracted from `measure-edge-capacity.js`). Same hook as MarketPerformanceTracker.updateCategoryPriors().
+
+## Validation criteria
+
+Post-deploy (24-72h):
+1. `market_type_edge_capacity` table populated for crypto_intraday + event_financial.
+2. Market scores in `market_score_history` show the new dim contribution.
+3. crypto_intraday markets get a measurable score uplift vs event_financial.
+4. **If active rotator pool composition shifts toward crypto_intraday** (more markets of that type get warmed up) → success signal.
+5. **If live SHORT trades start emerging** (mean_reversion crypto_intraday SHORT is the one boosted cell) → primary success.
+
+## Risks
+
+- **Initial weight 0.05 may be too low to move the rotator decisions**. Optuna will tune it but needs ≥30 closed trades per type — we currently have 0 on most types. Mitigation: start with 0.05 as hand-set anchor; once enough data accumulates Optuna refines.
+- **edge_capacity is sample-size sensitive**. A cell with n=50 and t_net=+5 contributes the same as a cell with n=5000 and t_net=+5. Future refinement: weight by sqrt(n) or use a confidence-adjusted version.
+- **No measurement for crypto_daily / event_long / event_short** today. Those types will have null edge_capacity → drop from renormalized score. That might actually hurt them in rotator selection vs types with measured data. Acceptable: types without measurement get "neutral" treatment (null drops), not penalty.
+
+## Out-of-scope (separate work)
+
+- Phase 4.1: active explore-mode (regime switch + widened candidate pool).
+- Per-(signal, direction) measurement persisted (not aggregated to market_type) — would let MarketRotator pick markets where the SPECIFIC profitable cell can fire.
+- t-stat measurement infrastructure that handles event_long efficiently (the 122k predictions × per-row seeks problem on e2-micro).
+- shadowExpectedValue per-type override (out of scope per existing MarketScorer.ts:374 note; addresses different need).
+
+## Sub-PRs
+
+| PR | Branch | Scope | Risk |
+|---|---|---|---|
+| PR-A | feat/phase4-edge-capacity-schema | Schema (table + columns + indexes), measurement script `measure-edge-capacity.js`, seed script from existing tstat data, schema tests | Low |
+| PR-B | feat/phase4-marketscorer-edge-capacity | MarketScorer integration (dim, weight default, loader, Pass 1+2). New tests in MarketScorer.test.ts. Persists to market_score_history. | Medium |
+| PR-C | feat/phase4-optimizer-edge-capacity | ScorerWeightOptimizer extension. Adds edge_capacity to randomWeights, normalization, query filter, saveWeights. Tests updated. | Medium |
+| PR-D | feat/phase4-edge-capacity-cron | Scheduler.ts adds nightly refresh. Hook same as updateCategoryPriors. Tests for the cron function. | Low |
+
+Total ~4 PRs, similar to per-direction series. Each PR is independently testable and reversible.
+
+## Acceptance
+
+Plan signed off by project owner. PRs land sequentially with deploy + 24h validation between each. After PR-D, observe rotation behavior for 1 week before considering Phase 4.1.

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -317,6 +317,30 @@ async function main(): Promise<void> {
       `);
       console.log('realized_volatility columns ensured on markets / scorer_weights / market_score_history');
 
+      // Phase 4 (2026-05-13): edge_capacity infrastructure. Mirrors
+      // init/031_edge_capacity.sql for existing volumes. See
+      // docs/plans/2026-05-13-phase4-edge-aware-scorer-design.md.
+      await query(`
+        CREATE TABLE IF NOT EXISTS market_type_edge_capacity (
+          market_type      VARCHAR(32) PRIMARY KEY,
+          edge_capacity    DOUBLE PRECISION NOT NULL,
+          n_cells_positive INT NOT NULL DEFAULT 0,
+          n_cells_measured INT NOT NULL DEFAULT 0,
+          rt_cost_pct      DOUBLE PRECISION NOT NULL,
+          source           TEXT NOT NULL,
+          updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+      `);
+      await query(`
+        ALTER TABLE market_score_history
+          ADD COLUMN IF NOT EXISTS score_edge_capacity FLOAT;
+      `);
+      await query(`
+        ALTER TABLE scorer_weights
+          ADD COLUMN IF NOT EXISTS edge_capacity FLOAT;
+      `);
+      console.log('[server] edge_capacity (Phase 4) schema ensured');
+
       // Post-init hook applies signal_weights per-type migration.
       // Task 2 of per-type-optimizer plan: extends signal_weights with market_type column
       // and per-type weight bootstrap rows. Matches data-collector 025_signal_weights_per_type.sql

--- a/packages/data-collector/src/database/init/031_edge_capacity.sql
+++ b/packages/data-collector/src/database/init/031_edge_capacity.sql
@@ -1,0 +1,38 @@
+-- 031_edge_capacity.sql
+-- Phase 4 of Market Intelligence: cost-aware edge_capacity per market_type as
+-- a 9th MarketScorer dimension. Markets in market_types with positive net edge
+-- get scored UP; markets in types with no positive cost-aware cells get scored
+-- DOWN. Drives the rotator toward cohorts where the system has measurable edge.
+--
+-- Source data: generator_predictions × price_history forward drift, minus
+-- per-(market_type) round-trip cost from paper_trades. Refreshed nightly by
+-- scripts/measure-edge-capacity.js (data-collector cron, PR-D).
+--
+-- See docs/plans/2026-05-13-phase4-edge-aware-scorer-design.md.
+
+-- Storage for the per-(market_type) edge capacity values. Separate from
+-- category_performance because:
+--   - different cadence (edge_capacity refreshes after t-stat measurements;
+--     category_performance after live trades close)
+--   - forward-looking (generator_predictions × 4h drift) vs realized (live PnL)
+--   - sourced from a different pipeline (predictions + RT cost vs paper_positions)
+CREATE TABLE IF NOT EXISTS market_type_edge_capacity (
+  market_type      VARCHAR(32) PRIMARY KEY,
+  edge_capacity    DOUBLE PRECISION NOT NULL,
+  n_cells_positive INT NOT NULL DEFAULT 0,
+  n_cells_measured INT NOT NULL DEFAULT 0,
+  rt_cost_pct      DOUBLE PRECISION NOT NULL,
+  source           TEXT NOT NULL,
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- New score dimension persisted alongside the other 8. NULL for rows written
+-- before Phase 4 deployed; new rows after deploy will populate.
+ALTER TABLE market_score_history
+  ADD COLUMN IF NOT EXISTS score_edge_capacity FLOAT;
+
+-- ScorerWeightOptimizer tunes this per-type via 300-trial random search once
+-- enough closed trades accumulate (MIN_TRADES_FOR_PER_TYPE=30 per type).
+-- NULL = use the hardcoded WEIGHTS.edgeCapacity default in MarketScorer.ts.
+ALTER TABLE scorer_weights
+  ADD COLUMN IF NOT EXISTS edge_capacity FLOAT;

--- a/scripts/measure-edge-capacity.js
+++ b/scripts/measure-edge-capacity.js
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * Phase 4 — Measure per-(market_type) edge_capacity from generator_predictions
+ * and upsert into market_type_edge_capacity. Run nightly via Scheduler.ts
+ * (Phase 4 PR-D) or ad-hoc.
+ *
+ * edge_capacity = Σ max(0, t_net) across (signal_id, direction) cells for the
+ * market_type, where:
+ *   t_gross = AVG(gross_edge) × √n / STDDEV(gross_edge)
+ *   t_net   = t_gross × (gross_pct − rt_cost_pct) / gross_pct
+ *   gross_edge = (y1 − y0) for long, (y0 − y1) for short
+ *   y0 = yes_price_at_signal, y1 = price 4h forward
+ *
+ * Each market_type aggregates positive net-t-stat cells (signals where the
+ * forward drift exceeds round-trip cost). Anti-edge cells contribute 0 (not
+ * negative — they don't subtract from positive cells; they just don't add).
+ *
+ * Source of round-trip cost per market_type:
+ *   - If --rt-cost-json: JSON map { market_type: rt_cost_fraction }
+ *   - Else: --default-rt (default 0.01 = 1%)
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://... node scripts/measure-edge-capacity.js \
+ *     [--window 7d] [--horizon 4h] [--rt-cost-json data/rt-cost.json] \
+ *     [--default-rt 0.01] [--min-n 50] [--source LABEL] [--dry-run]
+ *
+ * Flags:
+ *   --window 7d        Lookback for generator_predictions. Default 7d.
+ *   --horizon 4h       Forward price horizon (matches MAX_HOLD_TIME_HOURS).
+ *   --rt-cost-json     Per-(market_type) cost map. From measure-rt-cost.js --format=json.
+ *   --default-rt 0.01  Fallback when type has no rt_cost row. 1% conservative.
+ *   --min-n 50         Skip cells with fewer than N observations.
+ *   --source LABEL     Provenance string written to upsert row.
+ *   --dry-run          Print planned upserts without persisting.
+ */
+const { Pool } = require('pg');
+const fs = require('fs');
+
+function parseArgs(argv) {
+  const args = {
+    window: '7d',
+    horizon: '4h',
+    rtCostJson: null,
+    defaultRt: 0.01,
+    minN: 50,
+    source: 'measure-edge-capacity.js',
+    dryRun: false,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === '--window') args.window = argv[++i];
+    else if (k === '--horizon') args.horizon = argv[++i];
+    else if (k === '--rt-cost-json') args.rtCostJson = argv[++i];
+    else if (k === '--default-rt') args.defaultRt = parseFloat(argv[++i]);
+    else if (k === '--min-n') args.minN = parseInt(argv[++i], 10);
+    else if (k === '--source') args.source = argv[++i];
+    else if (k === '--dry-run') args.dryRun = true;
+  }
+  return args;
+}
+
+function intervalLiteral(s) {
+  const m = String(s).match(/^(\d+)([dh])$/);
+  if (!m) throw new Error(`Invalid window/horizon: ${s}`);
+  return `INTERVAL '${m[1]} ${m[2] === 'd' ? 'days' : 'hours'}'`;
+}
+
+/**
+ * Compute per-market_type edge_capacity from the array of cell rows returned
+ * by the t-stat SQL. Each row has { signal_id, market_type, direction, n,
+ * gross_pct, t_gross }. We compute t_net per cell using the per-type rt_cost
+ * map (falling back to defaultRt) and sum max(0, t_net) per market_type.
+ *
+ * Skips cells where gross_pct is 0 (no information — static midpoints) and
+ * where n < minN (insufficient statistical power).
+ */
+function computeEdgeCapacity(cells, rtCostMap, defaultRt, minN) {
+  const perType = new Map();  // market_type → { sum, positive, measured, rt }
+  for (const c of cells) {
+    if (c.n < minN) continue;
+    const rt = (rtCostMap && rtCostMap[c.market_type] != null)
+      ? Number(rtCostMap[c.market_type])
+      : defaultRt;
+    if (!perType.has(c.market_type)) {
+      perType.set(c.market_type, { sum: 0, positive: 0, measured: 0, rt });
+    }
+    const entry = perType.get(c.market_type);
+    entry.measured++;
+    // Zero-information cell (gross=0, static midpoint) → contributes 0.
+    if (c.gross_pct === 0 || c.t_gross === 0 || c.t_gross == null) continue;
+    const tNet = c.t_gross * (c.gross_pct - rt * 100) / c.gross_pct;
+    if (tNet > 0) {
+      entry.sum += tNet;
+      entry.positive++;
+    }
+  }
+  return perType;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const rtCostMap = args.rtCostJson ? JSON.parse(fs.readFileSync(args.rtCostJson, 'utf-8')) : null;
+  const windowSql = intervalLiteral(args.window);
+  const horizonSql = intervalLiteral(args.horizon);
+  const horizonHi = intervalLiteral(args.horizon.replace(/(\d+)([dh])/, (_, n, u) =>
+    `${parseInt(n, 10) + 1}${u}`));
+
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  try {
+    // Query cells (signal × type × direction) with per-cell t_gross + n + gross_pct.
+    // This is the same shape as scripts/p2-tstat.js but aggregated for edge_capacity.
+    const sql = `
+      WITH outcomes AS (
+        SELECT
+          g.signal_id,
+          g.market_type,
+          g.direction,
+          g.yes_price_at_signal::numeric AS y0,
+          (
+            SELECT p.close::numeric
+            FROM price_history p
+            WHERE p.market_id = g.market_id
+              AND p.time >= g.time + ${horizonSql}
+              AND p.time <  g.time + ${horizonHi}
+            ORDER BY p.time ASC
+            LIMIT 1
+          ) AS y1
+        FROM generator_predictions g
+        WHERE g.time >= NOW() - ${windowSql}
+          AND g.direction IN ('long','short')
+      ),
+      edges AS (
+        SELECT signal_id, market_type, direction,
+               CASE WHEN direction='long' THEN y1 - y0 ELSE y0 - y1 END AS gross_edge
+        FROM outcomes WHERE y1 IS NOT NULL
+      )
+      SELECT
+        signal_id, market_type, direction,
+        COUNT(*) AS n,
+        (AVG(gross_edge) * 100)::float AS gross_pct,
+        CASE WHEN STDDEV(gross_edge) > 0 THEN
+          (AVG(gross_edge) * SQRT(COUNT(*)) / STDDEV(gross_edge))::float
+        END AS t_gross
+      FROM edges
+      GROUP BY 1, 2, 3
+    `;
+    const res = await pool.query(sql);
+    const cells = res.rows.map((r) => ({
+      signal_id: r.signal_id,
+      market_type: r.market_type,
+      direction: r.direction,
+      n: Number(r.n),
+      gross_pct: r.gross_pct == null ? 0 : Number(r.gross_pct),
+      t_gross: r.t_gross == null ? null : Number(r.t_gross),
+    }));
+
+    const perType = computeEdgeCapacity(cells, rtCostMap, args.defaultRt, args.minN);
+
+    // Report
+    console.log('');
+    console.log(`edge_capacity per market_type (window=${args.window}, horizon=${args.horizon}, min_n=${args.minN}, default_rt=${args.defaultRt}):`);
+    console.log('-'.repeat(96));
+    console.log(
+      [
+        'market_type'.padEnd(20),
+        'edge_capacity'.padStart(14),
+        'positive_cells'.padStart(15),
+        'measured_cells'.padStart(15),
+        'rt_pct'.padStart(8),
+      ].join(' | ')
+    );
+    console.log('-'.repeat(96));
+    const upserts = [];
+    for (const [mt, e] of perType.entries()) {
+      console.log(
+        [
+          mt.padEnd(20),
+          e.sum.toFixed(4).padStart(14),
+          String(e.positive).padStart(15),
+          String(e.measured).padStart(15),
+          (e.rt * 100).toFixed(2).padStart(8),
+        ].join(' | ')
+      );
+      upserts.push({ market_type: mt, edge_capacity: e.sum, positive: e.positive, measured: e.measured, rt: e.rt });
+    }
+    console.log('-'.repeat(96));
+
+    if (args.dryRun) {
+      console.log('\n(dry-run — no writes applied)');
+      return;
+    }
+
+    for (const u of upserts) {
+      await pool.query(
+        `INSERT INTO market_type_edge_capacity
+           (market_type, edge_capacity, n_cells_positive, n_cells_measured, rt_cost_pct, source, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, NOW())
+         ON CONFLICT (market_type) DO UPDATE SET
+           edge_capacity    = EXCLUDED.edge_capacity,
+           n_cells_positive = EXCLUDED.n_cells_positive,
+           n_cells_measured = EXCLUDED.n_cells_measured,
+           rt_cost_pct      = EXCLUDED.rt_cost_pct,
+           source           = EXCLUDED.source,
+           updated_at       = NOW()`,
+        [u.market_type, u.edge_capacity, u.positive, u.measured, u.rt * 100, args.source]
+      );
+    }
+    console.log(`\nUpserted: ${upserts.length} market_type rows.`);
+  } finally {
+    await pool.end();
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('Error:', err.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { computeEdgeCapacity };

--- a/scripts/measure-edge-capacity.test.js
+++ b/scripts/measure-edge-capacity.test.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for the edge_capacity computation (Phase 4 PR-A).
+ */
+const assert = require('node:assert/strict');
+const { computeEdgeCapacity } = require('./measure-edge-capacity.js');
+
+const cases = [
+  {
+    name: 'empty input → empty map',
+    fn: () => {
+      const got = computeEdgeCapacity([], null, 0.01, 50);
+      assert.equal(got.size, 0);
+    },
+  },
+  {
+    name: 'single positive net cell → edge_capacity > 0',
+    fn: () => {
+      const cells = [
+        // mean_reversion crypto_intraday SHORT 2026-05-13: gross=+1.369%, t_gross=+10.14, n=126
+        // With rt=1.08%: t_net ≈ 10.14 × (1.369 - 1.08) / 1.369 ≈ 2.14
+        { signal_id: 'mean_reversion', market_type: 'crypto_intraday', direction: 'short', n: 126, gross_pct: 1.369, t_gross: 10.14 },
+      ];
+      const got = computeEdgeCapacity(cells, null, 0.0108, 50);
+      const e = got.get('crypto_intraday');
+      assert.ok(e, 'crypto_intraday entry exists');
+      assert.ok(Math.abs(e.sum - 2.14) < 0.05, `sum got ${e.sum}, expected ~2.14`);
+      assert.equal(e.positive, 1);
+      assert.equal(e.measured, 1);
+    },
+  },
+  {
+    name: 'cells under min_n are dropped',
+    fn: () => {
+      const cells = [
+        { signal_id: 'x', market_type: 'event_short', direction: 'long', n: 30, gross_pct: 1.0, t_gross: 5 },
+      ];
+      const got = computeEdgeCapacity(cells, null, 0.01, 50);
+      assert.equal(got.size, 0);
+    },
+  },
+  {
+    name: 'anti-edge cells contribute 0 (not negative) to the sum',
+    fn: () => {
+      const cells = [
+        // good cell t_net ≈ +2.14
+        { signal_id: 'mean_reversion', market_type: 'crypto_intraday', direction: 'short', n: 126, gross_pct: 1.369, t_gross: 10.14 },
+        // bad cell t_net very negative — should NOT subtract
+        { signal_id: 'momentum', market_type: 'crypto_intraday', direction: 'long', n: 3000, gross_pct: -0.06, t_gross: -3.25 },
+      ];
+      const got = computeEdgeCapacity(cells, null, 0.0108, 50);
+      const e = got.get('crypto_intraday');
+      assert.ok(Math.abs(e.sum - 2.14) < 0.05, `sum got ${e.sum}, expected ~2.14`);
+      assert.equal(e.positive, 1, 'one positive cell counted');
+      assert.equal(e.measured, 2, 'both cells measured');
+    },
+  },
+  {
+    name: 'event_financial post 2026-05-13: every cell anti-edge net → edge_capacity = 0',
+    fn: () => {
+      const cells = [
+        { signal_id: 'mean_reversion', market_type: 'event_financial', direction: 'long', n: 4200, gross_pct: 0.552, t_gross: 16.94 },
+        { signal_id: 'momentum', market_type: 'event_financial', direction: 'long', n: 7661, gross_pct: 0.203, t_gross: 11.31 },
+        { signal_id: 'mean_reversion', market_type: 'event_financial', direction: 'short', n: 2387, gross_pct: 0.025, t_gross: 0.82 },
+      ];
+      const got = computeEdgeCapacity(cells, null, 0.0108, 50);
+      const e = got.get('event_financial');
+      assert.equal(e.sum, 0, 'edge_capacity is 0 when no cell beats cost');
+      assert.equal(e.positive, 0);
+      assert.equal(e.measured, 3);
+    },
+  },
+  {
+    name: 'zero-information cells (gross=0, t=0) measured but do not contribute',
+    fn: () => {
+      const cells = [
+        // event_short World Cup: static midpoints → gross=0
+        { signal_id: 'mean_reversion', market_type: 'event_short', direction: 'long', n: 336, gross_pct: 0, t_gross: 0 },
+      ];
+      const got = computeEdgeCapacity(cells, null, 0.01, 50);
+      const e = got.get('event_short');
+      assert.equal(e.sum, 0);
+      assert.equal(e.positive, 0);
+      assert.equal(e.measured, 1, 'cell is measured (counted) but contributes 0');
+    },
+  },
+  {
+    name: 'per-type rt_cost map override is honored',
+    fn: () => {
+      const cells = [
+        // gross=0.6%. With rt=0.5% → t_net = 5 × 0.1/0.6 ≈ +0.83 (positive)
+        // With rt=1.5% → t_net = 5 × -0.9/0.6 ≈ -7.5 (negative)
+        { signal_id: 's', market_type: 'aaa', direction: 'long', n: 100, gross_pct: 0.6, t_gross: 5 },
+      ];
+      const cheap = computeEdgeCapacity(cells, { aaa: 0.005 }, 0.05, 50);
+      const expensive = computeEdgeCapacity(cells, { aaa: 0.015 }, 0.05, 50);
+      assert.ok(cheap.get('aaa').sum > 0, 'cheap RT cost: positive edge');
+      assert.equal(expensive.get('aaa').sum, 0, 'expensive RT cost: no edge');
+    },
+  },
+];
+
+let failed = 0;
+for (const c of cases) {
+  try {
+    c.fn();
+    console.log(`  ✓ ${c.name}`);
+  } catch (err) {
+    console.error(`  ✗ ${c.name}\n    ${err.message}`);
+    failed++;
+  }
+}
+console.log(`\n${cases.length - failed}/${cases.length} passed`);
+process.exitCode = failed > 0 ? 1 : 0;

--- a/scripts/seed-edge-capacity-from-tstat.js
+++ b/scripts/seed-edge-capacity-from-tstat.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Phase 4 PR-A — Seed `market_type_edge_capacity` from a versioned cost-aware
+ * t-stat JSON file (e.g. data/cost-aware-tstat-2026-05-13.json). One-shot
+ * bootstrap so we have edge_capacity values on day 1 of Phase 4 without
+ * waiting for the nightly measurement cron (PR-D) to fire.
+ *
+ * Reads the same shape as scripts/seed-per-direction-weights.js — keeps the
+ * data file as the single source of truth for both seed scripts.
+ *
+ * edge_capacity per market_type = Σ max(0, t_net) across cells in that type.
+ * t_net = t_gross × (gross_pct − rt_cost_pct) / gross_pct. The rt_cost_pct
+ * comes from the tstat _meta.rt_cost_assumption_pct (the value the t-stat
+ * was computed under), since changing it ex-post would invalidate the
+ * t_gross numbers anyway.
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://... node scripts/seed-edge-capacity-from-tstat.js \
+ *     --tstat data/cost-aware-tstat-2026-05-13.json [--min-n 50] [--dry-run]
+ */
+const { Pool } = require('pg');
+const fs = require('fs');
+const { computeEdgeCapacity } = require('./measure-edge-capacity.js');
+
+function parseArgs(argv) {
+  const args = { tstat: null, minN: 50, dryRun: false };
+  for (let i = 2; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === '--tstat') args.tstat = argv[++i];
+    else if (k === '--min-n') args.minN = parseInt(argv[++i], 10);
+    else if (k === '--dry-run') args.dryRun = true;
+  }
+  if (!args.tstat) {
+    console.error('Error: --tstat <path> is required.');
+    process.exit(1);
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const data = JSON.parse(fs.readFileSync(args.tstat, 'utf-8'));
+  const rtPct = Number(data._meta?.rt_cost_assumption_pct ?? 1.0);
+  // Normalize cells to match measure-edge-capacity.js' expected shape.
+  const cells = (data.cells || []).map((c) => ({
+    signal_id: c.signal_id,
+    market_type: c.market_type,
+    direction: c.direction,
+    n: Number(c.n),
+    gross_pct: Number(c.gross_pct),
+    t_gross: c.t_gross == null ? null : Number(c.t_gross),
+  }));
+
+  // RT cost map: same value for every market_type (the t-stat was computed
+  // under a single rtcost assumption). computeEdgeCapacity multiplies by 100
+  // internally to convert to pct, so we pass the fraction.
+  const rtCostMap = {};
+  const sourceLabel = `seed-edge-capacity-from-tstat.js ${data._meta?.generated_at || 'unknown'}`;
+
+  const perType = computeEdgeCapacity(cells, null, rtPct / 100, args.minN);
+
+  console.log('');
+  console.log(`edge_capacity seed from ${args.tstat} (rt=${rtPct.toFixed(2)}%, min_n=${args.minN}):`);
+  console.log('-'.repeat(96));
+  console.log(
+    [
+      'market_type'.padEnd(20),
+      'edge_capacity'.padStart(14),
+      'positive_cells'.padStart(15),
+      'measured_cells'.padStart(15),
+    ].join(' | ')
+  );
+  console.log('-'.repeat(96));
+  const upserts = [];
+  for (const [mt, e] of perType.entries()) {
+    console.log(
+      [
+        mt.padEnd(20),
+        e.sum.toFixed(4).padStart(14),
+        String(e.positive).padStart(15),
+        String(e.measured).padStart(15),
+      ].join(' | ')
+    );
+    upserts.push({ market_type: mt, edge_capacity: e.sum, positive: e.positive, measured: e.measured });
+  }
+  console.log('-'.repeat(96));
+
+  if (args.dryRun) {
+    console.log('\n(dry-run — no writes applied)');
+    return;
+  }
+
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  try {
+    for (const u of upserts) {
+      await pool.query(
+        `INSERT INTO market_type_edge_capacity
+           (market_type, edge_capacity, n_cells_positive, n_cells_measured, rt_cost_pct, source, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, NOW())
+         ON CONFLICT (market_type) DO UPDATE SET
+           edge_capacity    = EXCLUDED.edge_capacity,
+           n_cells_positive = EXCLUDED.n_cells_positive,
+           n_cells_measured = EXCLUDED.n_cells_measured,
+           rt_cost_pct      = EXCLUDED.rt_cost_pct,
+           source           = EXCLUDED.source,
+           updated_at       = NOW()`,
+        [u.market_type, u.edge_capacity, u.positive, u.measured, rtPct, sourceLabel]
+      );
+    }
+    console.log(`\nUpserted: ${upserts.length} market_type rows.`);
+  } finally {
+    await pool.end();
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('Error:', err.message);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

Phase 4 of Market Intelligence (the user's 2026-05-13 insight: rotator needs to be cost-aware-edge-conscious). PR-A ships the data infrastructure; PR-B wires it into MarketScorer as a 9th dim, PR-C extends the optimizer, PR-D adds the nightly refresh cron.

## Why

After PR-D #220 the system trades near-zero — only 1 of 24 measured cells has positive cost-aware net edge. The MarketRotator keeps selecting the same 49 markets agnostic of edge availability. Phase 4 introduces \`edge_capacity\` per market_type so the rotator gets biased toward cohorts where the system actually has measurable forward-edge.

## Formula

\`\`\`
edge_capacity(market_type) = Σ max(0, t_net) across (signal_id, direction) cells
t_net = t_gross × (gross_pct − rt_cost_pct) / gross_pct
\`\`\`

Anti-edge cells contribute 0 (they don't subtract from positive cells). Zero-information cells (static midpoints, gross=0) are measured but contribute 0.

## Initial seed values (from data/cost-aware-tstat-2026-05-13.json @ 1.08% RT)

| market_type | edge_capacity | positive_cells | measured_cells |
|---|---|---|---|
| crypto_intraday | **2.1406** | 1 | 10 |
| event_financial | 0.0000 | 0 | 14 |
| event_short | 0.0000 | 0 | 5 (static midpoints) |

## Changes

- \`init/031_edge_capacity.sql\` + \`server.ts\` boot ALTER mirror: CREATE TABLE \`market_type_edge_capacity\` + ADD COLUMN \`score_edge_capacity\` (market_score_history) + ADD COLUMN \`edge_capacity\` (scorer_weights). All idempotent.
- \`scripts/measure-edge-capacity.js\`: reads generator_predictions × price_history 4h drift, computes t_net per cell, upserts per market_type. Supports \`--dry-run\`, \`--rt-cost-json\`, \`--default-rt\`. Exports \`computeEdgeCapacity\` for reuse.
- \`scripts/seed-edge-capacity-from-tstat.js\`: one-shot bootstrap from versioned tstat JSON (uses the rt_cost_assumption_pct embedded in _meta). Lets us populate the table on day 1 without waiting for PR-D's cron.
- \`scripts/measure-edge-capacity.test.js\`: pure-node test runner. **7/7 pass.** Covers empty input, single positive cell, min_n filter, anti-edge → 0 not negative, all-anti-edge → 0, zero-information cells, per-type rt_cost map.

## Operational plan post-merge

1. Deploy auto-ships migration + scripts.
2. Verify schema: \`\d market_type_edge_capacity\` shows the new table; \`market_score_history\` has \`score_edge_capacity FLOAT\`; \`scorer_weights\` has \`edge_capacity FLOAT\`.
3. Apply seed:
   \`\`\`bash
   docker exec polymarket-dashboard-api node /app/scripts/seed-edge-capacity-from-tstat.js --tstat /app/data/cost-aware-tstat-2026-05-13.json
   \`\`\`
4. Verify: \`SELECT * FROM market_type_edge_capacity\` → 3 rows (crypto_intraday=2.14, event_financial=0, event_short=0).
5. PR-B will read these rows from MarketScorer.

## Tests
- \`node scripts/measure-edge-capacity.test.js\` → 7/7 pass.
- Existing 1002 vitest tests unaffected (only adds files + extends server.ts boot ALTER block).

## Follow-ups
- PR-B: MarketScorer integrates \`edgeCapacity\` as 9th dim (weight 0.05 initial).
- PR-C: ScorerWeightOptimizer discovers and tunes \`edge_capacity\` weight per market_type.
- PR-D: Scheduler.ts nightly cron at 02:30 UTC refreshes the table.

Deferred items captured in \`project_phase4_deferred.md\`: active explore-mode regime, per-market scoring, event_long t-stat infra.

Design: \`docs/plans/2026-05-13-phase4-edge-aware-scorer-design.md\`
Builds on: #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced edge_capacity scoring dimension to market evaluation, accounting for rotation costs and capacity constraints in market selection.

* **Documentation**
  * Added Phase 4 design documentation for cost-aware market scoring enhancements.

* **Tests**
  * Added test suite for edge capacity measurement validation across multiple scenarios.

* **Chores**
  * Extended database schema to support edge capacity persistence and weight optimization; added measurement and data seeding utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/221)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->