### PR TITLE
feat(optimizer): ScorerWeightOptimizer discovers edge_capacity (Phase 4 PR-C)

### DIFF
--- a/packages/data-collector/src/services/ScorerWeightOptimizer.test.ts
+++ b/packages/data-collector/src/services/ScorerWeightOptimizer.test.ts
@@ -196,3 +196,88 @@ describe('optimizeScorerWeights — realizedVolatility', () => {
     expect(selectWithFilter).toBeDefined();
   });
 });
+
+// ─── Phase 4: edgeCapacity in optimizer ──────────────────────────────────
+describe('optimizeScorerWeights — edgeCapacity (Phase 4)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('saveWeights INSERT includes edge_capacity column and param', async () => {
+    const captured: Array<{ sql: string; params: unknown[] }> = [];
+    (query as unknown as Mock).mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (typeof sql === 'string' && sql.startsWith('INSERT INTO scorer_weights')) {
+        captured.push({ sql, params: params ?? [] });
+      }
+      if (typeof sql === 'string' && sql.includes('SELECT DISTINCT market_type FROM markets')) {
+        return { rows: [{ market_type: 'crypto_intraday' }] };
+      }
+      if (typeof sql === 'string' && sql.includes('FROM paper_positions pp')) {
+        return {
+          rows: Array.from({ length: 50 }, (_, i) => ({
+            score_dimensions_at_entry: {
+              tradeability: 0.5, liquidity: 0.5, ttr: 0.5,
+              typeExpectedValue: 0.7, realizedVolatility: 0.4,
+              // Some rows have edge_capacity (post-Phase-4 entries), others don't.
+              ...(i % 2 === 0 ? { edgeCapacity: 0.2 } : {}),
+            },
+            realized_pnl: '10',
+          })),
+        };
+      }
+      return { rowCount: 1, rows: [] };
+    });
+
+    await optimizeScorerWeights();
+
+    expect(captured.length).toBeGreaterThan(0);
+    for (const c of captured) {
+      // INSERT statement references the column
+      expect(c.sql).toContain('edge_capacity');
+      expect(c.sql).toContain('EXCLUDED.edge_capacity');
+      // params[8] is edge_capacity in the new 12-param INSERT order.
+      // Should be a non-null number (random sample, possibly normalized).
+      expect(typeof c.params[8]).toBe('number');
+      expect(Number.isFinite(c.params[8] as number)).toBe(true);
+    }
+  });
+
+  it('normalization: saved weights sum to ~1.0 with edgeCapacity included', async () => {
+    const captured: Array<{ params: unknown[] }> = [];
+    (query as unknown as Mock).mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (typeof sql === 'string' && sql.startsWith('INSERT INTO scorer_weights')) {
+        captured.push({ params: params ?? [] });
+      }
+      if (typeof sql === 'string' && sql.includes('SELECT DISTINCT market_type FROM markets')) {
+        return { rows: [{ market_type: 'crypto_intraday' }] };
+      }
+      if (typeof sql === 'string' && sql.includes('FROM paper_positions pp')) {
+        return {
+          rows: Array.from({ length: 50 }, () => ({
+            score_dimensions_at_entry: {
+              tradeability: 0.5, liquidity: 0.5, ttr: 0.5,
+              typeExpectedValue: 0.7, realizedVolatility: 0.4,
+            },
+            realized_pnl: '10',
+          })),
+        };
+      }
+      return { rowCount: 1, rows: [] };
+    });
+
+    await optimizeScorerWeights();
+    expect(captured.length).toBeGreaterThan(0);
+    for (const c of captured) {
+      // params order in saveWeights:
+      //   1:market_type, 2:tradeability, 3:liquidity, 4:volatility, 5:ttr,
+      //   6:data_quality, 7:type_expected_value, 8:realized_volatility,
+      //   9:edge_capacity, 10:n_trades, 11:n_trials, 12:best_value
+      const sum =
+        (c.params[1] as number) + (c.params[2] as number) + (c.params[3] as number) +
+        (c.params[4] as number) + (c.params[5] as number) + (c.params[6] as number) +
+        (c.params[7] as number) + (c.params[8] as number);
+      // (shadowExpectedValue is fixed at WEIGHTS.shadowExpectedValue = 0.05,
+      // not in saveWeights params — but the optimizable dims should normalize
+      // so that all 9 fields would sum to 1 once shadow is added.)
+      expect(sum + 0.05).toBeCloseTo(1.0, 2);
+    }
+  });
+});

--- a/packages/data-collector/src/services/ScorerWeightOptimizer.ts
+++ b/packages/data-collector/src/services/ScorerWeightOptimizer.ts
@@ -48,12 +48,27 @@ function randomWeights(): ScorerWeights {
     typeExpectedValue:   r(),
     realizedVolatility:  r(), // 5th optimizable dim
     shadowExpectedValue: WEIGHTS.shadowExpectedValue, // fixed; not optimized in this pass
+    // Phase 4 (2026-05-13): edgeCapacity sampled uniform [0.0, 0.20]. Narrower
+    // range than the 5 main dims because the dim is highly informative when
+    // present but null often (only types with measurements contribute). A wide
+    // range would over-weight one dim's variance. ScorerWeightOptimizer treats
+    // it as the 6th optimizable dim — normalization below includes it in
+    // targetSum so the saved row remains internally consistent.
+    edgeCapacity:        Math.random() * 0.20,
   };
 }
 
 // ── DB helpers ─────────────────────────────────────────────────────────────
 
 async function loadClosedTrades(marketType: string | null): Promise<ClosedTrade[]> {
+  // We do NOT filter on `? 'edgeCapacity'` because pre-Phase 4 trades don't
+  // have that key in score_dimensions_at_entry. Those trades still contribute
+  // their existing dim values; edgeCapacity is treated as null when missing
+  // (drops from compositeScore renormalization). Once enough post-Phase-4
+  // trades accumulate Optuna can compute a meaningful correlation for the
+  // new dim. Until then, the random search just floats edgeCapacity weight
+  // without an information gradient — which is fine, the dim only kicks in
+  // for trades that recorded it.
   const result = await query<{
     score_dimensions_at_entry: Record<string, number | null>;
     realized_pnl: string;
@@ -82,6 +97,10 @@ async function loadClosedTrades(marketType: string | null): Promise<ClosedTrade[
         typeExpectedValue:   d.typeExpectedValue   ?? 0.5,
         realizedVolatility:  d.realizedVolatility  ?? null,
         shadowExpectedValue: d.shadowExpectedValue ?? 0.5, // neutral when historical entry pre-dates dim
+        // Phase 4: undefined → compositeScore drops it from renormalization,
+        // matching the production semantics where pre-Phase-4 trades had no
+        // edge_capacity contribution.
+        edgeCapacity:        d.edgeCapacity ?? null,
       },
       pnl: parseFloat(r.realized_pnl),
     };
@@ -96,9 +115,9 @@ async function saveWeights(
   await query(
     `INSERT INTO scorer_weights
        (market_type, tradeability, liquidity, volatility, ttr, data_quality,
-        type_expected_value, realized_volatility,
+        type_expected_value, realized_volatility, edge_capacity,
         n_trades, n_trials, best_value, updated_at)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW())
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, NOW())
      ON CONFLICT (market_type) DO UPDATE SET
        tradeability        = EXCLUDED.tradeability,
        liquidity           = EXCLUDED.liquidity,
@@ -107,6 +126,7 @@ async function saveWeights(
        data_quality        = EXCLUDED.data_quality,
        type_expected_value = EXCLUDED.type_expected_value,
        realized_volatility = EXCLUDED.realized_volatility,
+       edge_capacity       = EXCLUDED.edge_capacity,
        n_trades            = EXCLUDED.n_trades,
        n_trials            = EXCLUDED.n_trials,
        best_value          = EXCLUDED.best_value,
@@ -114,7 +134,8 @@ async function saveWeights(
     [
       marketType,
       weights.tradeability, weights.liquidity, weights.volatility,
-      weights.ttr, weights.dataQuality, weights.typeExpectedValue, weights.realizedVolatility,
+      weights.ttr, weights.dataQuality, weights.typeExpectedValue,
+      weights.realizedVolatility, weights.edgeCapacity ?? WEIGHTS.edgeCapacity,
       meta.nTrades, meta.nTrials, meta.bestValue,
     ],
   );
@@ -133,24 +154,27 @@ function runRandomSearch(trades: ClosedTrade[]): { weights: ScorerWeights; bestV
     }
   }
 
-  // Normalize the 5 optimizable dims so that the saved row sums to 1.0 across
-  // all 8 ScorerWeights fields, so loadWeights() doesn't log a warning.
+  // Normalize the 6 optimizable dims so the saved row sums to 1.0 across all
+  // 9 ScorerWeights fields. Phase 4 (2026-05-13): edgeCapacity joined the
+  // optimizable set.
   const optimizableSum =
     bestWeights.tradeability + bestWeights.liquidity +
     bestWeights.ttr + bestWeights.typeExpectedValue +
-    bestWeights.realizedVolatility;
-  // Excludes volatility, dataQuality (computed from price_history at enrich time)
-  // and shadowExpectedValue (fixed at WEIGHTS.shadowExpectedValue, not optimized).
+    bestWeights.realizedVolatility +
+    (bestWeights.edgeCapacity ?? WEIGHTS.edgeCapacity);
+  // Excludes volatility, dataQuality (computed from price_history at enrich
+  // time) and shadowExpectedValue (fixed; not optimized in this pass).
   const targetSum = 1 - WEIGHTS.volatility - WEIGHTS.dataQuality - WEIGHTS.shadowExpectedValue;
   if (optimizableSum > 0) {
     const scale = targetSum / optimizableSum;
     bestWeights = {
       ...bestWeights,
-      tradeability:       bestWeights.tradeability       * scale,
-      liquidity:          bestWeights.liquidity          * scale,
-      ttr:                bestWeights.ttr                * scale,
-      typeExpectedValue:  bestWeights.typeExpectedValue  * scale,
-      realizedVolatility: bestWeights.realizedVolatility * scale,
+      tradeability:       bestWeights.tradeability                                          * scale,
+      liquidity:          bestWeights.liquidity                                             * scale,
+      ttr:                bestWeights.ttr                                                   * scale,
+      typeExpectedValue:  bestWeights.typeExpectedValue                                     * scale,
+      realizedVolatility: bestWeights.realizedVolatility                                    * scale,
+      edgeCapacity:       (bestWeights.edgeCapacity ?? WEIGHTS.edgeCapacity)                * scale,
     };
   }
 


### PR DESCRIPTION
## Summary

Phase 4 PR-C. Extends \`ScorerWeightOptimizer\` (300-trial random search) to include \`edge_capacity\` as the 6th optimizable dim. After enough closed trades accumulate per market_type (MIN_TRADES=30), the optimizer tunes \`scorer_weights.edge_capacity\` per type — replacing the hand-set 0.05 anchor (PR-B) with a data-driven value.

## Changes

**ScorerWeightOptimizer.ts**
- \`randomWeights()\` samples \`edgeCapacity\` uniform [0.0, 0.20]. Narrower than the 5 main dims (0.05-0.65) because the dim is highly informative when present but null often.
- \`loadClosedTrades\` extracts \`edgeCapacity\` from \`score_dimensions_at_entry\`. No \`? 'edgeCapacity'\` jsonb filter — pre-Phase-4 trades stay eligible (they just contribute null on the new dim).
- \`saveWeights\` INSERT extends from 11 to 12 params: adds \`edge_capacity\` column + corresponding \`EXCLUDED.edge_capacity\` in ON CONFLICT.
- Normalization step (\`runRandomSearch\`) now includes \`edgeCapacity\` in the 6-dim optimizable sum that's scaled to \`targetSum = 1 - volatility - dataQuality - shadowExpectedValue\`.

**ScorerWeightOptimizer.test.ts**
- New: 2 tests covering INSERT shape + post-normalization sum invariant.
- 1013 tests pass (1011 prior + 2 new), tsc clean.

## Validation post-deploy

Phase 4 PR-C runs no immediate action on deploy. The optimizer cron is weekly (Mon 03:17 UTC) plus on-demand. After enough trades close per type:
- [ ] \`SELECT market_type, edge_capacity FROM scorer_weights\` shows non-NULL values per type.
- [ ] MarketScorer.loadWeights picks them up (already wired in PR-B).
- [ ] No regression: \`market_score\` stays sane in \`market_score_history\`.

Until trades accumulate, the optimizer skips per-type optimization (MIN_TRADES=30 not met). MarketScorer falls back to WEIGHTS.edgeCapacity 0.05 anchor — same as PR-B.

## Follow-ups
- PR-D: Scheduler.ts nightly cron to refresh \`market_type_edge_capacity\` from generator_predictions. The optimizer (this PR) tunes the WEIGHT of edge_capacity; PR-D refreshes the VALUE.

Design: \`docs/plans/2026-05-13-phase4-edge-aware-scorer-design.md\`
Builds on: #221 (schema), #222 (scorer integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)