### PR TITLE
feat(scheduler): nightly edge_capacity refresh cron (Phase 4 PR-D)

### DIFF
--- a/packages/data-collector/src/services/EdgeCapacityRefresher.test.ts
+++ b/packages/data-collector/src/services/EdgeCapacityRefresher.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Phase 4 PR-D — tests for the TS port of edge_capacity computation
+ * (mirrors scripts/measure-edge-capacity.test.js test suite).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../database/connection.js', () => ({
+  query: vi.fn(),
+}));
+
+import { computeEdgeCapacity, refreshEdgeCapacity } from './EdgeCapacityRefresher.js';
+import { query } from '../database/connection.js';
+
+describe('computeEdgeCapacity (TS port)', () => {
+  it('empty input → empty map', () => {
+    const got = computeEdgeCapacity([], null, 0.01, 50);
+    expect(got.size).toBe(0);
+  });
+
+  it('single positive net cell → edge_capacity > 0', () => {
+    // mean_reversion crypto_intraday SHORT 2026-05-13:
+    // gross=+1.369%, t_gross=+10.14, n=126. With rt=1.08% → t_net ≈ 2.14
+    const got = computeEdgeCapacity(
+      [{ signal_id: 'mean_reversion', market_type: 'crypto_intraday', direction: 'short', n: 126, gross_pct: 1.369, t_gross: 10.14 }],
+      null, 0.0108, 50,
+    );
+    const e = got.get('crypto_intraday')!;
+    expect(e.sum).toBeCloseTo(2.14, 1);
+    expect(e.positive).toBe(1);
+    expect(e.measured).toBe(1);
+  });
+
+  it('cells under min_n are dropped', () => {
+    const got = computeEdgeCapacity(
+      [{ signal_id: 'x', market_type: 'event_short', direction: 'long', n: 30, gross_pct: 1.0, t_gross: 5 }],
+      null, 0.01, 50,
+    );
+    expect(got.size).toBe(0);
+  });
+
+  it('anti-edge cells contribute 0, not negative', () => {
+    const got = computeEdgeCapacity(
+      [
+        { signal_id: 'mean_reversion', market_type: 'crypto_intraday', direction: 'short', n: 126, gross_pct: 1.369, t_gross: 10.14 },
+        { signal_id: 'momentum', market_type: 'crypto_intraday', direction: 'long', n: 3000, gross_pct: -0.06, t_gross: -3.25 },
+      ],
+      null, 0.0108, 50,
+    );
+    const e = got.get('crypto_intraday')!;
+    expect(e.sum).toBeCloseTo(2.14, 1);
+    expect(e.positive).toBe(1);
+    expect(e.measured).toBe(2);
+  });
+
+  it('all cells anti-edge → edge_capacity = 0', () => {
+    const got = computeEdgeCapacity(
+      [
+        { signal_id: 'mean_reversion', market_type: 'event_financial', direction: 'long', n: 4200, gross_pct: 0.552, t_gross: 16.94 },
+        { signal_id: 'momentum', market_type: 'event_financial', direction: 'long', n: 7661, gross_pct: 0.203, t_gross: 11.31 },
+      ],
+      null, 0.0108, 50,
+    );
+    const e = got.get('event_financial')!;
+    expect(e.sum).toBe(0);
+    expect(e.positive).toBe(0);
+    expect(e.measured).toBe(2);
+  });
+
+  it('zero-information cells (gross=0) are measured but contribute 0', () => {
+    const got = computeEdgeCapacity(
+      [{ signal_id: 'mean_reversion', market_type: 'event_short', direction: 'long', n: 336, gross_pct: 0, t_gross: 0 }],
+      null, 0.01, 50,
+    );
+    const e = got.get('event_short')!;
+    expect(e.sum).toBe(0);
+    expect(e.positive).toBe(0);
+    expect(e.measured).toBe(1);
+  });
+
+  it('per-type rt_cost map override is honored', () => {
+    const cheap = computeEdgeCapacity(
+      [{ signal_id: 's', market_type: 'aaa', direction: 'long', n: 100, gross_pct: 0.6, t_gross: 5 }],
+      new Map([['aaa', 0.005]]), 0.05, 50,
+    );
+    const expensive = computeEdgeCapacity(
+      [{ signal_id: 's', market_type: 'aaa', direction: 'long', n: 100, gross_pct: 0.6, t_gross: 5 }],
+      new Map([['aaa', 0.015]]), 0.05, 50,
+    );
+    expect(cheap.get('aaa')!.sum).toBeGreaterThan(0);
+    expect(expensive.get('aaa')!.sum).toBe(0);
+  });
+});
+
+describe('refreshEdgeCapacity (integration)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('runs SELECT then UPSERTs one row per market_type with measurable cells', async () => {
+    let upsertCount = 0;
+    (query as any).mockImplementation(async (sql: string) => {
+      if (typeof sql === 'string' && sql.includes('FROM generator_predictions')) {
+        return {
+          rows: [
+            { signal_id: 'mean_reversion', market_type: 'crypto_intraday', direction: 'short', n: 126, gross_pct: 1.369, t_gross: 10.14 },
+            { signal_id: 'momentum', market_type: 'event_financial', direction: 'long', n: 4200, gross_pct: 0.20, t_gross: 11 },
+          ],
+        };
+      }
+      if (typeof sql === 'string' && sql.startsWith('INSERT INTO market_type_edge_capacity')) {
+        upsertCount++;
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const { upserts, perType } = await refreshEdgeCapacity({ defaultRtCost: 0.0108, minN: 50 });
+    expect(upserts).toBe(2);
+    expect(upsertCount).toBe(2);
+    expect(perType.has('crypto_intraday')).toBe(true);
+    expect(perType.has('event_financial')).toBe(true);
+  });
+
+  it('passes window/horizon into the SQL', async () => {
+    const capturedSql: string[] = [];
+    (query as any).mockImplementation(async (sql: string) => {
+      if (typeof sql === 'string') capturedSql.push(sql);
+      return { rows: [], rowCount: 0 };
+    });
+
+    await refreshEdgeCapacity({ windowDays: 3, horizonHours: 6, minN: 100 });
+
+    const selectStmt = capturedSql.find(s => s.includes('FROM generator_predictions'));
+    expect(selectStmt).toBeDefined();
+    expect(selectStmt).toContain("INTERVAL '3 days'");
+    expect(selectStmt).toContain("INTERVAL '6 hours'");
+    expect(selectStmt).toContain("INTERVAL '7 hours'");
+  });
+});

--- a/packages/data-collector/src/services/EdgeCapacityRefresher.ts
+++ b/packages/data-collector/src/services/EdgeCapacityRefresher.ts
@@ -1,0 +1,175 @@
+/**
+ * Phase 4 PR-D — Nightly refresh of `market_type_edge_capacity` from
+ * `generator_predictions` × `price_history` 4h-forward drift, minus
+ * per-(market_type) round-trip cost.
+ *
+ * Same formula as `scripts/measure-edge-capacity.js` (the ad-hoc CLI tool).
+ * Ported here as a TS service so `Scheduler.ts` can call it directly via
+ * `cron.schedule` without spawning a subprocess (saves ~50MB of overhead
+ * on the e2-micro VM).
+ *
+ * Cron schedule: nightly at 02:30 UTC, just before `compute-market-priors`
+ * (02:45). MarketScorer reads `market_type_edge_capacity` on each
+ * `scoreAllMarkets` call (hourly at :17), so the next scoring run after
+ * the refresh picks up the new values automatically.
+ */
+import { pino } from 'pino';
+import { query } from '../database/connection.js';
+
+const logger = pino({ name: 'EdgeCapacityRefresher' });
+
+interface Cell {
+  signal_id: string;
+  market_type: string;
+  direction: 'long' | 'short';
+  n: number;
+  gross_pct: number;
+  t_gross: number | null;
+}
+
+interface EdgeCapacityEntry {
+  sum: number;
+  positive: number;
+  measured: number;
+  rt: number;
+}
+
+/**
+ * Compute edge_capacity per market_type from a flat list of cell measurements.
+ * Mirrors the JS computeEdgeCapacity in scripts/measure-edge-capacity.js so
+ * unit tests cover both paths identically. Pure function.
+ */
+export function computeEdgeCapacity(
+  cells: Cell[],
+  rtCostMap: Map<string, number> | null,
+  defaultRt: number,
+  minN: number,
+): Map<string, EdgeCapacityEntry> {
+  const perType = new Map<string, EdgeCapacityEntry>();
+  for (const c of cells) {
+    if (c.n < minN) continue;
+    const rt = rtCostMap?.has(c.market_type) ? rtCostMap.get(c.market_type)! : defaultRt;
+    if (!perType.has(c.market_type)) {
+      perType.set(c.market_type, { sum: 0, positive: 0, measured: 0, rt });
+    }
+    const entry = perType.get(c.market_type)!;
+    entry.measured++;
+    if (c.gross_pct === 0 || c.t_gross == null || c.t_gross === 0) continue;
+    const tNet = c.t_gross * (c.gross_pct - rt * 100) / c.gross_pct;
+    if (tNet > 0) {
+      entry.sum += tNet;
+      entry.positive++;
+    }
+  }
+  return perType;
+}
+
+export interface RefreshOptions {
+  windowDays?: number;
+  horizonHours?: number;
+  defaultRtCost?: number;  // fraction (e.g. 0.0108 = 1.08%)
+  rtCostMap?: Map<string, number>;
+  minN?: number;
+  source?: string;
+}
+
+/**
+ * Refresh `market_type_edge_capacity` table for all market_types with enough
+ * generator_predictions in the window. Returns the upserted entries (useful
+ * for tests + logging).
+ */
+export async function refreshEdgeCapacity(options: RefreshOptions = {}): Promise<{
+  upserts: number;
+  perType: Map<string, EdgeCapacityEntry>;
+}> {
+  const windowDays = options.windowDays ?? 7;
+  const horizonHours = options.horizonHours ?? 4;
+  const defaultRt = options.defaultRtCost ?? 0.01;
+  const minN = options.minN ?? 50;
+  const source = options.source ?? `EdgeCapacityRefresher cron ${new Date().toISOString().slice(0, 10)}`;
+
+  // The SQL mirrors scripts/measure-edge-capacity.js. Plain string interpolation
+  // is fine here because windowDays / horizonHours are server-controlled
+  // integers. We keep the LATERAL-style correlated subquery — slow on e2-micro
+  // (event_long timed out at 60+ min on 2026-05-13) but acceptable nightly.
+  // event_long would need a CAGG rewrite for production; tracked in
+  // project_phase4_deferred.md.
+  const sql = `
+    WITH outcomes AS (
+      SELECT
+        g.signal_id,
+        g.market_type,
+        g.direction,
+        g.yes_price_at_signal::numeric AS y0,
+        (
+          SELECT p.close::numeric
+          FROM price_history p
+          WHERE p.market_id = g.market_id
+            AND p.time >= g.time + INTERVAL '${horizonHours} hours'
+            AND p.time <  g.time + INTERVAL '${horizonHours + 1} hours'
+          ORDER BY p.time ASC LIMIT 1
+        ) AS y1
+      FROM generator_predictions g
+      WHERE g.time >= NOW() - INTERVAL '${windowDays} days'
+        AND g.direction IN ('long','short')
+    ),
+    edges AS (
+      SELECT signal_id, market_type, direction,
+             CASE WHEN direction='long' THEN y1 - y0 ELSE y0 - y1 END AS gross_edge
+      FROM outcomes WHERE y1 IS NOT NULL
+    )
+    SELECT
+      signal_id, market_type, direction,
+      COUNT(*)::int AS n,
+      (AVG(gross_edge) * 100)::float AS gross_pct,
+      CASE WHEN STDDEV(gross_edge) > 0 THEN
+        (AVG(gross_edge) * SQRT(COUNT(*)) / STDDEV(gross_edge))::float
+      END AS t_gross
+    FROM edges
+    GROUP BY 1, 2, 3
+  `;
+
+  const res = await query<{
+    signal_id: string;
+    market_type: string;
+    direction: string;
+    n: number;
+    gross_pct: number | null;
+    t_gross: number | null;
+  }>(sql);
+
+  const cells: Cell[] = res.rows.map((r) => ({
+    signal_id: r.signal_id,
+    market_type: r.market_type,
+    direction: r.direction as 'long' | 'short',
+    n: Number(r.n),
+    gross_pct: r.gross_pct == null ? 0 : Number(r.gross_pct),
+    t_gross: r.t_gross == null ? null : Number(r.t_gross),
+  }));
+
+  const perType = computeEdgeCapacity(cells, options.rtCostMap ?? null, defaultRt, minN);
+
+  let upserts = 0;
+  for (const [marketType, entry] of perType.entries()) {
+    await query(
+      `INSERT INTO market_type_edge_capacity
+         (market_type, edge_capacity, n_cells_positive, n_cells_measured, rt_cost_pct, source, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, NOW())
+       ON CONFLICT (market_type) DO UPDATE SET
+         edge_capacity    = EXCLUDED.edge_capacity,
+         n_cells_positive = EXCLUDED.n_cells_positive,
+         n_cells_measured = EXCLUDED.n_cells_measured,
+         rt_cost_pct      = EXCLUDED.rt_cost_pct,
+         source           = EXCLUDED.source,
+         updated_at       = NOW()`,
+      [marketType, entry.sum, entry.positive, entry.measured, entry.rt * 100, source],
+    );
+    upserts++;
+  }
+
+  logger.info(
+    { upserts, types: [...perType.keys()] },
+    'edge_capacity refreshed',
+  );
+  return { upserts, perType };
+}

--- a/packages/data-collector/src/services/Scheduler.ts
+++ b/packages/data-collector/src/services/Scheduler.ts
@@ -14,6 +14,7 @@ import {
   updateShadowCategoryPerformance,
   resolveShadowTrades,
 } from './MarketPerformanceTracker.js';
+import { refreshEdgeCapacity } from './EdgeCapacityRefresher.js';
 import { NewsCollector } from '../collectors/NewsCollector.js';
 
 const logger = pino({ name: 'scheduler' });
@@ -111,6 +112,11 @@ export class Scheduler {
     this.defineJob('match-external-markets', '0 3 * * *', this.matchExternalMarkets.bind(this));  // Daily at 3 UTC
     this.defineJob('optimize-scorer-weights', '17 3 * * 1', this.optimizeScorerWeights.bind(this));  // Every Monday at 03:17 UTC
     this.defineJob('compute-market-priors', '45 2 * * *', this.computeMarketPriors.bind(this));  // Daily at 02:45 UTC
+    // Phase 4 (2026-05-13): refresh per-(market_type) cost-aware edge_capacity
+    // from generator_predictions × price_history forward drift. Runs just
+    // before compute-market-priors so both data sources are fresh for the next
+    // MarketScorer cycle. See docs/plans/2026-05-13-phase4-edge-aware-scorer-design.md.
+    this.defineJob('refresh-edge-capacity', '30 2 * * *', this.refreshEdgeCapacity.bind(this));  // Daily at 02:30 UTC
     this.defineJob('collect-news', '*/15 * * * *', this.collectNews.bind(this));  // News pipeline every 15 minutes
     this.defineJob('compute-realized-volatility', '*/15 * * * *', computeRealizedVolatility);  // Every 15 min
   }
@@ -509,6 +515,21 @@ export class Scheduler {
     await updateCategoryPriors();
     await updateShadowCategoryPerformance();
     await resolveShadowTrades();
+  }
+
+  /**
+   * Phase 4 (2026-05-13): nightly refresh of `market_type_edge_capacity` from
+   * generator_predictions. MarketScorer reads on next scoreAllMarkets (hourly :17).
+   * Daily at 02:30 UTC. Uses 1% default RT cost per type — production should
+   * later pass a measured per-type cost map from scripts/measure-rt-cost.js.
+   */
+  private async refreshEdgeCapacity(): Promise<void> {
+    await refreshEdgeCapacity({
+      windowDays: 7,
+      horizonHours: 4,
+      defaultRtCost: 0.01,
+      minN: 50,
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

Final PR of the Phase 4 series. Adds a nightly cron at **02:30 UTC** that re-measures cost-aware edge_capacity per market_type and upserts into \`market_type_edge_capacity\`. Runs just before the existing \`compute-market-priors\` cron (02:45) so MarketScorer's next hourly :17 scoring sees fresh values.

## Changes

**EdgeCapacityRefresher.ts (new)**
- TS port of \`scripts/measure-edge-capacity.js\`. Same semantics, no subprocess overhead.
- \`refreshEdgeCapacity(options)\` orchestrates SELECT + UPSERT.
- Pure \`computeEdgeCapacity\` exported for tests.

**Scheduler.ts**
- New cron \`refresh-edge-capacity\` at \`'30 2 * * *'\`.
- Calls with windowDays=7, horizonHours=4, defaultRtCost=0.01, minN=50.

**Tests (9 new, 1020 total pass)**
- 7 pure-helper tests (mirror the JS counterpart).
- 2 integration tests (mocked DB).

## Notes
- event_long may time out on e2-micro (60+ min on 2026-05-13). Tracked as project_phase4_deferred.md item 3 (CAGG rewrite needed).
- Initial seed from PR-A's bootstrap already on VM (crypto_intraday=2.14, event_financial=0, event_short=0). First cron firing replaces.

## Phase 4 series complete

| PR | Scope |
|---|---|
| #221 PR-A | schema + scripts + seed |
| #222 PR-B | MarketScorer 9th dim |
| #223 PR-C | ScorerWeightOptimizer extension |
| this PR-D | nightly cron |

Design: \`docs/plans/2026-05-13-phase4-edge-aware-scorer-design.md\`
Builds on: #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated daily edge capacity refresh job, running at 02:30 UTC to aggregate per-market-type metrics with customizable parameters for improved data accuracy.

* **Tests**
  * Added comprehensive test suite validating edge capacity computation across multiple scenarios, including edge case handling and market-type-specific configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/224)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->