### PR TITLE
feat(aed): generator_edge history table + getLatestEdgePerCell (Phase 5 Pilar 1-B)

### DIFF
--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -341,6 +341,52 @@ async function main(): Promise<void> {
       `);
       console.log('[server] edge_capacity (Phase 4) schema ensured');
 
+      // Phase 5 Pilar 1-B (2026-05-15): generator_edge history table.
+      // Append-only per-(signal, type, direction) t-stat measurements for
+      // trending. Mirrors init/032_generator_edge.sql for existing volumes.
+      await query(`
+        CREATE TABLE IF NOT EXISTS generator_edge (
+          id            BIGSERIAL,
+          measured_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          signal_id     VARCHAR(50) NOT NULL,
+          market_type   VARCHAR(32) NOT NULL,
+          direction     VARCHAR(8) NOT NULL,
+          window_days   INT NOT NULL,
+          horizon_hours INT NOT NULL,
+          sample_size   INT,
+          n             INT NOT NULL,
+          gross_pct     DOUBLE PRECISION,
+          t_gross       DOUBLE PRECISION,
+          rt_cost_pct   DOUBLE PRECISION NOT NULL,
+          t_net         DOUBLE PRECISION,
+          source        TEXT,
+          PRIMARY KEY (measured_at, id)
+        );
+      `);
+      await query(`
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'generator_edge_direction_check'
+              AND conrelid = 'generator_edge'::regclass
+          ) THEN
+            ALTER TABLE generator_edge
+              ADD CONSTRAINT generator_edge_direction_check
+              CHECK (direction IN ('long','short'));
+          END IF;
+        END $$;
+      `);
+      await query(`
+        CREATE INDEX IF NOT EXISTS idx_generator_edge_cell
+          ON generator_edge (signal_id, market_type, direction, measured_at DESC);
+      `);
+      await query(`
+        CREATE INDEX IF NOT EXISTS idx_generator_edge_measured_at
+          ON generator_edge (measured_at DESC);
+      `);
+      console.log('[server] generator_edge (Phase 5 Pilar 1-B) schema ensured');
+
       // Post-init hook applies signal_weights per-type migration.
       // Task 2 of per-type-optimizer plan: extends signal_weights with market_type column
       // and per-type weight bootstrap rows. Matches data-collector 025_signal_weights_per_type.sql

--- a/packages/data-collector/src/database/init/032_generator_edge.sql
+++ b/packages/data-collector/src/database/init/032_generator_edge.sql
@@ -1,0 +1,58 @@
+-- 032_generator_edge.sql
+-- Phase 5 Pilar 1-B (2026-05-15): append-only history of cost-aware t-stat
+-- measurements per (signal_id, market_type, direction) cell. Captures every
+-- nightly refresh so we can trend edge over time (instead of just snapshotting
+-- the latest value in market_type_edge_capacity).
+--
+-- Why a separate table from market_type_edge_capacity:
+--   - market_type_edge_capacity is per-(market_type) aggregate of positive
+--     t_net across cells. ONE row per type, overwritten each refresh.
+--   - generator_edge is per-(signal, type, direction) row PER measurement,
+--     append-only. Lets us answer questions like "is mean_reversion long
+--     trending toward positive t_net over the last 30 days?" or "did the
+--     last 7 measurements agree?"
+--
+-- Retention: keep all rows for now (~14 cells × 5 types × 1 measurement/day
+-- = ~70 rows/day = ~25k rows/year). Cheap. Add CAGG / retention policy if
+-- volume grows.
+
+CREATE TABLE IF NOT EXISTS generator_edge (
+  id            BIGSERIAL,
+  measured_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  signal_id     VARCHAR(50) NOT NULL,
+  market_type   VARCHAR(32) NOT NULL,
+  direction     VARCHAR(8) NOT NULL,
+  window_days   INT NOT NULL,
+  horizon_hours INT NOT NULL,
+  sample_size   INT,            -- null when full-data measurement
+  n             INT NOT NULL,
+  gross_pct     DOUBLE PRECISION,
+  t_gross       DOUBLE PRECISION,
+  rt_cost_pct   DOUBLE PRECISION NOT NULL,
+  t_net         DOUBLE PRECISION,
+  source        TEXT,
+  PRIMARY KEY (measured_at, id)
+);
+
+-- CHECK direction constraint defensively. Defer NOT VALID + VALIDATE since
+-- the table starts empty.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'generator_edge_direction_check'
+      AND conrelid = 'generator_edge'::regclass
+  ) THEN
+    ALTER TABLE generator_edge
+      ADD CONSTRAINT generator_edge_direction_check
+      CHECK (direction IN ('long','short'));
+  END IF;
+END $$;
+
+-- Lookup index for "latest measurement per cell" queries.
+CREATE INDEX IF NOT EXISTS idx_generator_edge_cell
+  ON generator_edge (signal_id, market_type, direction, measured_at DESC);
+
+-- Lookup index for "all measurements at a given time" / batch-load by source.
+CREATE INDEX IF NOT EXISTS idx_generator_edge_measured_at
+  ON generator_edge (measured_at DESC);

--- a/packages/data-collector/src/services/EdgeCapacityRefresher.test.ts
+++ b/packages/data-collector/src/services/EdgeCapacityRefresher.test.ts
@@ -8,7 +8,7 @@ vi.mock('../database/connection.js', () => ({
   query: vi.fn(),
 }));
 
-import { computeEdgeCapacity, refreshEdgeCapacity } from './EdgeCapacityRefresher.js';
+import { computeEdgeCapacity, refreshEdgeCapacity, getLatestEdgePerCell } from './EdgeCapacityRefresher.js';
 import { query } from '../database/connection.js';
 
 describe('computeEdgeCapacity (TS port)', () => {
@@ -190,5 +190,91 @@ describe('refreshEdgeCapacity (integration, Phase 5 Pilar 1-A per-type sampling)
     await refreshEdgeCapacity();
     const selectStmt = capturedSql.find(s => s.includes('FROM generator_predictions'));
     expect(selectStmt).toContain('LIMIT 10000');
+  });
+
+  // ─── Phase 5 Pilar 1-B: generator_edge persistence ──────────────────
+  it('persists each measured cell to generator_edge with computed t_net', async () => {
+    const insertedRows: any[][] = [];
+    (query as any).mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (typeof sql === 'string' && sql.includes('SELECT DISTINCT market_type')) {
+        return { rows: [{ market_type: 'event_long' }] };
+      }
+      if (typeof sql === 'string' && sql.includes('FROM generator_predictions')) {
+        return { rows: [
+          // cell with positive t_gross → t_net should be t_gross × (gross-rtPct)/gross
+          { signal_id: 'spread_compression', market_type: 'event_long', direction: 'long', n: 99, gross_pct: 0.88, t_gross: 1.71 },
+          // cell with gross=0 → t_net=0
+          { signal_id: 'mean_reversion', market_type: 'event_long', direction: 'long', n: 100, gross_pct: 0, t_gross: 0 },
+          // cell under minN → should NOT be persisted
+          { signal_id: 'tiny', market_type: 'event_long', direction: 'short', n: 5, gross_pct: 1, t_gross: 5 },
+        ]};
+      }
+      if (typeof sql === 'string' && sql.startsWith('INSERT INTO generator_edge')) {
+        insertedRows.push(params ?? []);
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+    await refreshEdgeCapacity({ defaultRtCost: 0.01, minN: 50 });
+    expect(insertedRows.length).toBe(2);  // 'tiny' filtered out
+    // First row: t_net = 1.71 × (0.88-1) / 0.88 ≈ -0.233
+    const firstParams = insertedRows[0];
+    // params: signal_id, market_type, direction, window_days, horizon_hours,
+    //         sample_size, n, gross_pct, t_gross, rt_cost_pct, t_net, source
+    expect(firstParams[0]).toBe('spread_compression');
+    expect(firstParams[10]).toBeCloseTo(-0.233, 2);
+    // Second row: gross_pct=0 → t_net=0
+    expect(insertedRows[1][10]).toBe(0);
+  });
+
+  it('persistence failure does not abort the per-type loop', async () => {
+    let insertCalls = 0;
+    (query as any).mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (typeof sql === 'string' && sql.includes('SELECT DISTINCT market_type')) {
+        return { rows: [{ market_type: 'event_long' }] };
+      }
+      if (typeof sql === 'string' && sql.includes('FROM generator_predictions')) {
+        return { rows: [
+          { signal_id: 'mean_reversion', market_type: 'event_long', direction: 'long', n: 200, gross_pct: 0.5, t_gross: 3 },
+        ]};
+      }
+      if (typeof sql === 'string' && sql.startsWith('INSERT INTO generator_edge')) {
+        insertCalls++;
+        throw new Error('simulated history insert failure');
+      }
+      return { rows: [], rowCount: 1 };
+    });
+    const { upserts } = await refreshEdgeCapacity({ minN: 50 });
+    // The market_type_edge_capacity upsert should still happen even if
+    // generator_edge inserts failed.
+    expect(upserts).toBe(1);
+    expect(insertCalls).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('getLatestEdgePerCell (Phase 5 Pilar 1-B reporting)', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('returns rows sorted by t_net DESC (positive edge first)', async () => {
+    (query as any).mockResolvedValueOnce({
+      rows: [
+        { signal_id: 'a', market_type: 't', direction: 'long', n: 100, gross_pct: 0.5, t_gross: 2, t_net: -1.0, rt_cost_pct: 1, measured_at: new Date('2026-05-15') },
+        { signal_id: 'b', market_type: 't', direction: 'short', n: 100, gross_pct: 1.5, t_gross: 10, t_net: 3.5, rt_cost_pct: 1, measured_at: new Date('2026-05-15') },
+        { signal_id: 'c', market_type: 't', direction: 'long', n: 100, gross_pct: 0.0, t_gross: 0, t_net: 0, rt_cost_pct: 1, measured_at: new Date('2026-05-15') },
+      ],
+    });
+    const out = await getLatestEdgePerCell();
+    expect(out.map(r => r.signal_id)).toEqual(['b', 'c', 'a']);  // 3.5, 0, -1.0
+  });
+
+  it('issues a DISTINCT ON query to fetch latest per cell', async () => {
+    let capturedSql = '';
+    (query as any).mockImplementation(async (sql: string) => {
+      capturedSql = sql;
+      return { rows: [] };
+    });
+    await getLatestEdgePerCell();
+    expect(capturedSql).toContain('DISTINCT ON (signal_id, market_type, direction)');
+    expect(capturedSql).toContain('measured_at DESC');
   });
 });

--- a/packages/data-collector/src/services/EdgeCapacityRefresher.ts
+++ b/packages/data-collector/src/services/EdgeCapacityRefresher.ts
@@ -80,6 +80,49 @@ export interface RefreshOptions {
 }
 
 /**
+ * Phase 5 Pilar 1-B: persist every cell measurement into `generator_edge`
+ * (append-only). One row per (signal, type, direction) — captures the raw
+ * t_gross + computed t_net + sample_size at this measurement time. Lets
+ * downstream queries trend a specific cell over time (instead of just
+ * snapshotting the per-type aggregate in market_type_edge_capacity).
+ *
+ * Skipped: cells under minN are dropped (insufficient stat power, would
+ * just add noise to trends). Cells with gross=0 are kept (zero-information
+ * but documents that we measured + got nothing — useful for "is X cell
+ * still flat?" queries).
+ */
+async function persistCellsToHistory(
+  cells: Cell[],
+  rtCost: number,
+  windowDays: number,
+  horizonHours: number,
+  sampleSize: number | null,
+  source: string,
+  minN: number,
+): Promise<void> {
+  const rtPct = rtCost * 100;
+  for (const c of cells) {
+    if (c.n < minN) continue;
+    // t_net = t_gross × (gross_pct - rt_cost_pct) / gross_pct. Edge cases:
+    // gross_pct=0 → t_net=0; t_gross=null → t_net=null.
+    let tNet: number | null = null;
+    if (c.t_gross != null && c.gross_pct !== 0) {
+      tNet = c.t_gross * (c.gross_pct - rtPct) / c.gross_pct;
+    } else if (c.t_gross != null && c.gross_pct === 0) {
+      tNet = 0;
+    }
+    await query(
+      `INSERT INTO generator_edge
+         (signal_id, market_type, direction, window_days, horizon_hours,
+          sample_size, n, gross_pct, t_gross, rt_cost_pct, t_net, source)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+      [c.signal_id, c.market_type, c.direction, windowDays, horizonHours,
+       sampleSize, c.n, c.gross_pct, c.t_gross, rtPct, tNet, source],
+    );
+  }
+}
+
+/**
  * Build the t-stat SQL for a single market_type with optional sampling.
  * Phase 5 Pilar 1-A: when sampleSize is set, we use `ORDER BY random() LIMIT N`
  * to avoid the LATERAL bulk-scan timeout on e2-micro. The price_history seek
@@ -210,6 +253,59 @@ async function measureCellsForType(
  * sampling. Calibrated N=10000 takes 47-150s/type on e2-micro. perTypeTimeoutMs
  * caps each type at 300s so a slow type doesn't block the others.
  */
+/**
+ * Phase 5 Pilar 1-B reporting helper: latest measurement per (signal, type,
+ * direction) cell, with t_net > 0 indicating cost-aware positive edge. Used
+ * by Pilar 4-A health-of-edge daily-review queries to answer "what cohorts
+ * currently have measurable edge?".
+ *
+ * Returns rows ordered by t_net DESC NULLS LAST so the most-positive cells
+ * appear first. Includes ALL measured cells (positive, zero, negative) —
+ * caller filters by t_net > 0 if they want only "edge" cells.
+ */
+export async function getLatestEdgePerCell(): Promise<Array<{
+  signal_id: string;
+  market_type: string;
+  direction: string;
+  n: number;
+  gross_pct: number | null;
+  t_gross: number | null;
+  t_net: number | null;
+  rt_cost_pct: number;
+  measured_at: Date;
+}>> {
+  const res = await query<{
+    signal_id: string;
+    market_type: string;
+    direction: string;
+    n: number;
+    gross_pct: number | null;
+    t_gross: number | null;
+    t_net: number | null;
+    rt_cost_pct: number;
+    measured_at: Date;
+  }>(
+    `SELECT DISTINCT ON (signal_id, market_type, direction)
+       signal_id, market_type, direction, n, gross_pct, t_gross, t_net,
+       rt_cost_pct, measured_at
+     FROM generator_edge
+     ORDER BY signal_id, market_type, direction, measured_at DESC`,
+  );
+  return res.rows
+    .map((r) => ({
+      signal_id: r.signal_id,
+      market_type: r.market_type,
+      direction: r.direction,
+      n: Number(r.n),
+      gross_pct: r.gross_pct == null ? null : Number(r.gross_pct),
+      t_gross: r.t_gross == null ? null : Number(r.t_gross),
+      t_net: r.t_net == null ? null : Number(r.t_net),
+      rt_cost_pct: Number(r.rt_cost_pct),
+      measured_at: r.measured_at,
+    }))
+    .sort((a, b) => (b.t_net ?? -Infinity) - (a.t_net ?? -Infinity));
+}
+
 export async function refreshEdgeCapacity(options: RefreshOptions = {}): Promise<{
   upserts: number;
   perType: Map<string, EdgeCapacityEntry>;
@@ -252,6 +348,18 @@ export async function refreshEdgeCapacity(options: RefreshOptions = {}): Promise
       skipped.push(marketType);
       continue;
     }
+
+    // Phase 5 Pilar 1-B (2026-05-15): persist per-cell measurements to
+    // generator_edge for trending. Append-only — every refresh adds rows so
+    // we can answer "is X cell drifting positive over the last 30d?".
+    // Best-effort; failure to insert one row should NOT abort the type.
+    const rtForType = options.rtCostMap?.get(marketType) ?? defaultRt;
+    await persistCellsToHistory(
+      cells, rtForType, windowDays, horizonHours, sampleSize, source, minN,
+    ).catch((err) => {
+      logger.warn({ marketType, err: (err as Error).message }, 'persistCellsToHistory failed (non-fatal)');
+    });
+
     const oneTypeMap = computeEdgeCapacity(cells, options.rtCostMap ?? null, defaultRt, minN);
     for (const [mt, entry] of oneTypeMap.entries()) {
       perTypeAcc.set(mt, entry);


### PR DESCRIPTION
## Summary

Second PR of **Phase 5 AED**. Adds an append-only history table of per-cell t-stat measurements so we can trend edge over time (not just snapshot the latest per-type aggregate).

## Why

\`market_type_edge_capacity\` (PR-A) has ONE row per type, overwritten each refresh. Good for runtime scoring but loses history. \`generator_edge\` is append-only per-(signal, type, direction) — lets us answer:
- "Is cell X trending toward positive t_net over the last 30 days?"
- "Did the last 7 measurements agree?"
- Pilar 4-A's "what cohorts currently have measurable edge?" query

## Schema

\`\`\`sql
CREATE TABLE generator_edge (
  id            BIGSERIAL,
  measured_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
  signal_id     VARCHAR(50) NOT NULL,
  market_type   VARCHAR(32) NOT NULL,
  direction     VARCHAR(8) CHECK (direction IN ('long','short')),
  window_days   INT NOT NULL,
  horizon_hours INT NOT NULL,
  sample_size   INT,                  -- null = full-data
  n             INT NOT NULL,
  gross_pct, t_gross, rt_cost_pct, t_net DOUBLE PRECISION,
  source        TEXT,
  PRIMARY KEY (measured_at, id)
);
\`\`\`

Plus index for trending lookups: \`(signal_id, market_type, direction, measured_at DESC)\`.

## Wiring

- \`persistCellsToHistory()\` in EdgeCapacityRefresher writes each measured cell after the per-type loop. Pre-computes t_net at write time using the same cost we used for the per-type aggregate.
- Persistence is **best-effort, non-fatal**: a history write hiccup doesn't block the per-type-edge upsert (which is operational data the scorer reads).
- \`getLatestEdgePerCell()\` reporting helper: DISTINCT ON ... ORDER BY measured_at DESC. Returns rows sorted by t_net DESC NULLS LAST in JS. Used by Pilar 4-A.

## Edge cases handled

- \`gross_pct=0, t_gross=0\` → t_net=0 (zero-information cell kept, documents flatness)
- \`t_gross=null\` → t_net=null (insufficient data)
- \`n < minN\` → skipped (would add noise to trends)
- History insert failure → logged + skipped, doesn't abort per-type loop

## Tests (1029 pass / 14 skipped, +4 new)

- Cells with positive t_gross persist with correct computed t_net
- gross=0 → t_net=0
- n < minN → NOT persisted
- Persistence failure does not abort the per-type loop
- getLatestEdgePerCell: sort order, DISTINCT ON SQL shape

## Validation post-deploy

- [ ] \`SELECT COUNT(*) FROM generator_edge\` after tomorrow's 02:30 UTC cron: ~14-50 rows (one per measured cell across active types)
- [ ] \`SELECT * FROM generator_edge ORDER BY measured_at DESC LIMIT 5\` shows fresh rows with source=\`EdgeCapacityRefresher cron 2026-05-16 (sample N=10000)\`
- [ ] t_net values match manual computation: t_gross × (gross-rt_pct)/gross
- [ ] After 2 days: COUNT grows ~+50; trends per cell visible via SELECT WHERE signal_id=...

## Follow-up

- **Pilar 4-A**: daily-review SQL queries that consume \`getLatestEdgePerCell\` to surface "cohorts with edge > 0", "gap = traded vs edge"
- **Pilar 4-B**: format-review.js rendering

Builds on: #228 (Pilar 1-A per-type sampling)
Design: \`project_phase5_aed_design.md\` memory file

🤖 Generated with [Claude Code](https://claude.com/claude-code)