### PR TITLE
feat(aed): health-of-edge in daily-review (Phase 5 Pilar 4-A+B)

### DIFF
--- a/scripts/daily-review-prompt.md
+++ b/scripts/daily-review-prompt.md
@@ -122,6 +122,10 @@ The executor restricts live trades to `ALLOWED_MARKET_TYPES`. Other market types
 - `category_performance`: cumulative win_rate / Sharpe / prior per market_type
 - `shadow_summary`: blocked signals recorded as shadow trades, aggregated per market_type
 - `shadow_summary_by_direction`: same fields as shadow_summary, additionally split by `direction` ('long'|'short'). Use this to detect SHORT-bias inflation before recommending promotion.
+- `edge_cohorts_positive` (Phase 5 Pilar 4-A): per-(signal, market_type, direction) cells with measured `t_net > 0` (cost-aware forward-drift t-stat from `generator_edge`). Each row: signal_id, market_type, direction, t_net, n, rt_cost_pct, measured_at. **Empty list = no measured edge anywhere in the active universe** (data says system has no positive expected return).
+- `edge_cohorts_traded` (Phase 5 Pilar 4-A): (market_type, direction, n_trades, total_pnl, wins) over the last 7 days from live paper trades.
+- `edge_gap` (Phase 5 Pilar 4-A): **CRITICAL ALERT** when non-empty. Rows here are (market_type, direction) we are TRADING in production but have NO signal with measured positive cost-aware edge for. Each row = capital burning in a cohort the data says is anti-edge. If non-empty, surface as a finding with severity HIGH at minimum.
+- `edge_measurement_freshness` (Phase 5 Pilar 4-A): per-market_type latest `measured_at` + `hours_since`. If `hours_since > 48` for an active type, the nightly cron is failing for that type — surface as INFRA issue.
 
 ### Shadow → Live promotion recommendation
 
@@ -275,6 +279,33 @@ The `review_history` section contains metrics from previous daily reviews. Compa
 **If a metric has been bad for 2+ consecutive days**, escalate severity by one level and prefix with `[PERSISTENT]`.
 
 **If a metric improved after a PR was merged**, note: "Fix in PR #N appears effective (metric improved from X to Y)."
+
+## Health-of-Edge Analysis (Phase 5 Pilar 4-A — MANDATORY section)
+
+Phase 5 introduces three operational signals about whether our trading universe has any measured cost-aware edge:
+
+### 1. `edge_cohorts_positive` (what works)
+
+Per-(signal, market_type, direction) cells where the latest measurement shows `t_net > 0` (cost-aware drift > round-trip cost). **Empty list is a profound signal**: it means we measured every cohort and found nothing tradeable. Do NOT recommend continued trading in this state without explicit mention.
+
+Render in the issue:
+- A table listing each cell with t_net, n, market_type, direction, measured_at
+- If empty, a paragraph stating: "No cohort in the active universe currently has measured positive cost-aware edge. The system is trading at a net negative expected value. Recommend: pause new opens; rely on Pilar 1 measurements to flag emerging edge."
+
+### 2. `edge_gap` (what we trade WITHOUT edge — CRITICAL)
+
+Rows here are (market_type, direction) we executed trades in (last 7d) but for which **no signal has positive measured cost-aware edge**. This is "burning capital in cohorts the data says are anti-edge". 
+
+If `edge_gap` is non-empty:
+- Severity: at least HIGH (CRITICAL if cumulative pnl < -$50 across rows)
+- Recommendation: add specific gates that block opens in these (type, direction) combos OR build a new signal that DOES have edge there
+- Reference: `feedback_realistic_costs.md` — this is the recurring "trade despite negative net t-stat" failure mode
+
+### 3. `edge_measurement_freshness` (infra health)
+
+Per market_type, latest `measured_at` and `hours_since`. Stale (>48h) means the nightly cron is failing for that type — measurement infrastructure broken. Surface as INFRA issue.
+
+Cross-check with `optimization_runs` and dashboard logs to confirm the EdgeCapacityRefresher cron is firing without errors.
 
 ## Step 3: Generate Outputs (MANDATORY — do this BEFORE Step 4)
 

--- a/scripts/daily-review.sh
+++ b/scripts/daily-review.sh
@@ -349,6 +349,105 @@ signal_weights=$(query_json "
   ) t;
 ")
 
+# Phase 5 Pilar 4-A (2026-05-15): health-of-edge metrics.
+# Surface the gap between "cohorts we trade" and "cohorts where measurement
+# says we have positive cost-aware edge". When the gap > 0, we're burning
+# capital in cohorts the data says are anti-edge. Daily-review prompt should
+# treat a non-empty edge_gap as CRITICAL.
+
+# 15a. Cohorts with positive cost-aware edge (latest measurement per cell, t_net > 0)
+edge_cohorts_positive=$(query_json "
+  SELECT COALESCE(json_agg(t), '[]'::json) FROM (
+    WITH latest AS (
+      SELECT DISTINCT ON (signal_id, market_type, direction)
+        signal_id, market_type, direction, t_net, n, rt_cost_pct, measured_at
+      FROM generator_edge
+      ORDER BY signal_id, market_type, direction, measured_at DESC
+    )
+    SELECT
+      signal_id, market_type, direction,
+      ROUND(t_net::numeric, 2)::float AS t_net,
+      n::float AS n,
+      ROUND(rt_cost_pct::numeric, 3)::float AS rt_cost_pct,
+      measured_at
+    FROM latest
+    WHERE t_net > 0
+    ORDER BY t_net DESC
+    LIMIT 30
+  ) t
+")
+
+# 15b. Cohorts traded in last 7 days (type, side, count, pnl)
+edge_cohorts_traded=$(query_json "
+  SELECT COALESCE(json_agg(t), '[]'::json) FROM (
+    SELECT
+      m.market_type,
+      p.side AS direction,
+      COUNT(*)::float AS n_trades,
+      ROUND(COALESCE(SUM(p.realized_pnl), 0)::numeric, 2)::float AS total_pnl,
+      COUNT(*) FILTER (WHERE p.realized_pnl > 0)::float AS wins
+    FROM paper_positions p
+    JOIN markets m ON m.id = p.market_id
+    WHERE p.opened_at >= NOW() - INTERVAL '7 days'
+      AND p.realized_pnl IS NOT NULL
+    GROUP BY 1, 2
+    ORDER BY 3 DESC
+  ) t
+")
+
+# 15c. Edge gap — (type, direction) traded but NO signal has positive edge.
+# When this returns rows, we are burning capital on cohorts that have been
+# measured as anti-edge net. CRITICAL signal for the daily-review.
+edge_gap=$(query_json "
+  SELECT COALESCE(json_agg(t), '[]'::json) FROM (
+    WITH latest_positive AS (
+      SELECT DISTINCT market_type, direction
+      FROM (
+        SELECT DISTINCT ON (signal_id, market_type, direction)
+          signal_id, market_type, direction, t_net
+        FROM generator_edge
+        ORDER BY signal_id, market_type, direction, measured_at DESC
+      ) le
+      WHERE t_net > 0
+    ),
+    traded AS (
+      SELECT m.market_type, p.side AS direction,
+             COUNT(*) AS n_trades,
+             ROUND(SUM(p.realized_pnl)::numeric, 2) AS total_pnl
+      FROM paper_positions p
+      JOIN markets m ON m.id = p.market_id
+      WHERE p.opened_at >= NOW() - INTERVAL '7 days'
+        AND p.realized_pnl IS NOT NULL
+      GROUP BY 1, 2
+    )
+    SELECT
+      t.market_type, t.direction,
+      t.n_trades::float AS n_trades,
+      t.total_pnl::float AS total_pnl
+    FROM traded t
+    LEFT JOIN latest_positive lp
+      ON lp.market_type = t.market_type AND lp.direction = t.direction
+    WHERE lp.market_type IS NULL
+    ORDER BY 3 DESC
+  ) t
+")
+
+# 15d. Measurement freshness — when was each market_type last measured?
+# Stale (> 48h) means the nightly cron isn't running or is timing out for
+# that type. The daily-review should alert when hours_since > 48.
+edge_measurement_freshness=$(query_json "
+  SELECT COALESCE(json_agg(t), '[]'::json) FROM (
+    SELECT
+      market_type,
+      MAX(measured_at) AS latest_measurement,
+      ROUND((EXTRACT(EPOCH FROM (NOW() - MAX(measured_at)))/3600)::numeric, 1)::float
+        AS hours_since
+    FROM generator_edge
+    GROUP BY market_type
+    ORDER BY hours_since DESC
+  ) t
+")
+
 # 16. Consecutive losses (from recently closed positions with negative PnL)
 consecutive_losses=$(query_one "
   SELECT row_to_json(t) FROM (
@@ -648,6 +747,10 @@ jq -n \
   --argjson trades_by_type "$trades_by_type" \
   --argjson shadow_summary "$shadow_summary" \
   --argjson shadow_summary_by_direction "$shadow_summary_by_direction" \
+  --argjson edge_cohorts_positive "$edge_cohorts_positive" \
+  --argjson edge_cohorts_traded "$edge_cohorts_traded" \
+  --argjson edge_gap "$edge_gap" \
+  --argjson edge_measurement_freshness "$edge_measurement_freshness" \
   --argjson review_history "$(cat "$HISTORY_FILE" 2>/dev/null | jq 'sort_by(.date) | .[-7:]' 2>/dev/null || echo "[]")" \
   '{
     generated_at: $ts,
@@ -680,5 +783,9 @@ jq -n \
     trades_by_type: $trades_by_type,
     shadow_summary: $shadow_summary,
     shadow_summary_by_direction: $shadow_summary_by_direction,
+    edge_cohorts_positive: $edge_cohorts_positive,
+    edge_cohorts_traded: $edge_cohorts_traded,
+    edge_gap: $edge_gap,
+    edge_measurement_freshness: $edge_measurement_freshness,
     review_history: $review_history
   }'

--- a/scripts/format-review.js
+++ b/scripts/format-review.js
@@ -175,6 +175,11 @@ const realPnlCheck = data.real_pnl_check || null;
 const categoryPerformance = Array.isArray(data.category_performance) ? data.category_performance : [];
 const tradesByType = Array.isArray(data.trades_by_type) ? data.trades_by_type : [];
 const shadowSummary = Array.isArray(data.shadow_summary) ? data.shadow_summary : [];
+// Phase 5 Pilar 4-A (2026-05-15): health-of-edge metrics.
+const edgeCohortsPositive = Array.isArray(data.edge_cohorts_positive) ? data.edge_cohorts_positive : [];
+const edgeCohortsTraded = Array.isArray(data.edge_cohorts_traded) ? data.edge_cohorts_traded : [];
+const edgeGap = Array.isArray(data.edge_gap) ? data.edge_gap : [];
+const edgeMeasurementFreshness = Array.isArray(data.edge_measurement_freshness) ? data.edge_measurement_freshness : [];
 const generatedAt = data.generated_at || new Date().toISOString();
 
 // ── Trading-state derived signals ───────────────────────────────────────────
@@ -196,6 +201,27 @@ const alerts = []; // { level: 'critical'|'warning', message: string }
 // Drawdown > 10% (max_drawdown stored as percentage, e.g. 10.0 = 10%)
 if (account && account.max_drawdown != null && account.max_drawdown > 10) {
   alerts.push({ level: 'critical', message: `Drawdown at ${fmtPctRaw(account.max_drawdown)} (threshold: 10%)` });
+}
+
+// Phase 5 Pilar 4-A: edge_gap = trading without measured edge. The biggest
+// failure mode in production. Critical when cumulative loss > $50 across rows.
+if (edgeGap.length > 0) {
+  const totalLoss = edgeGap.reduce((s, r) => s + (Number(r.total_pnl) < 0 ? Number(r.total_pnl) : 0), 0);
+  const level = totalLoss < -50 ? 'critical' : 'warning';
+  alerts.push({
+    level,
+    message: `Edge gap: trading ${edgeGap.length} (type, direction) cohort(s) WITHOUT measured cost-aware edge. Cumulative loss: ${fmtUsd(totalLoss)}`,
+  });
+}
+
+// Phase 5 Pilar 4-A: measurement infra. Stale edge measurement (>48h) means
+// the nightly EdgeCapacityRefresher cron is failing for some types.
+const staleMeasurements = edgeMeasurementFreshness.filter((r) => Number(r.hours_since) > 48);
+if (staleMeasurements.length > 0) {
+  alerts.push({
+    level: 'warning',
+    message: `Edge measurement stale (>48h) for ${staleMeasurements.length} market_type(s): ${staleMeasurements.map((r) => r.market_type).join(', ')}`,
+  });
 }
 
 // 5+ consecutive losses. The metric is a cumulative DB counter, so when the
@@ -382,7 +408,18 @@ function buildMarkdown() {
   // Performance breakdown — three independent sources, separated so live and
   // shadow numbers are not visually adjacent (shadow is theoretical-no-fees
   // and was being mistaken for promotion candidates).
-  if (tradesByType.length > 0 || categoryPerformance.length > 0 || shadowSummary.length > 0) {
+  if (
+    tradesByType.length > 0 ||
+    categoryPerformance.length > 0 ||
+    shadowSummary.length > 0 ||
+    // Phase 5 Pilar 4-A (2026-05-15): include the Performance Breakdown
+    // section even when there are no trades — Health-of-Edge ("we measured
+    // and found nothing") is one of the most important findings to surface
+    // in exactly that case.
+    edgeCohortsPositive.length > 0 ||
+    edgeGap.length > 0 ||
+    edgeMeasurementFreshness.length > 0
+  ) {
     ln(`## Performance Breakdown`);
     ln();
 
@@ -410,6 +447,52 @@ function buildMarkdown() {
         ln(`| ${c.market_type || 'N/A'} | ${fmt(c.n_trades, 0)} | ${fmtPct(c.win_rate)} | ${fmtUsd(c.avg_pnl)} | ${fmt(c.sharpe_ratio, 3)} | ${fmt(c.prior, 3)} |`);
       }
       ln();
+    }
+
+    // Phase 5 Pilar 4-A (2026-05-15): Health-of-Edge section. Shows whether
+    // we measured any positive cost-aware edge anywhere, and whether we're
+    // trading in cohorts the data says are anti-edge (the "edge gap").
+    if (edgeCohortsPositive.length > 0 || edgeGap.length > 0 || edgeMeasurementFreshness.length > 0) {
+      ln(`### Health of Edge (cost-aware measurement)`);
+      ln();
+
+      if (edgeCohortsPositive.length === 0) {
+        ln(`> **No cohort in the active universe currently has measured positive cost-aware edge** (t_net > 0). The system is operating in a measured-anti-edge regime.`);
+      } else {
+        ln(`**Cohorts with positive cost-aware edge** (top ${Math.min(edgeCohortsPositive.length, 10)} by t_net):`);
+        ln();
+        ln(`| Signal | Type | Dir | t_net | n | RT cost % |`);
+        ln(`|--------|------|-----|-------|---|-----------|`);
+        for (const c of edgeCohortsPositive.slice(0, 10)) {
+          ln(`| ${c.signal_id || 'N/A'} | ${c.market_type || 'N/A'} | ${c.direction || 'N/A'} | ${fmt(c.t_net, 2)} | ${fmt(c.n, 0)} | ${fmt(c.rt_cost_pct, 2)} |`);
+        }
+      }
+      ln();
+
+      if (edgeGap.length > 0) {
+        ln(`**Edge gap — trading WITHOUT measured edge** (capital at risk in anti-edge cohorts):`);
+        ln();
+        ln(`| Type | Direction | Trades | PnL (7d) |`);
+        ln(`|------|-----------|--------|----------|`);
+        for (const g of edgeGap) {
+          ln(`| ${g.market_type || 'N/A'} | ${g.direction || 'N/A'} | ${fmt(g.n_trades, 0)} | ${fmtUsd(g.total_pnl)} |`);
+        }
+        ln();
+      }
+
+      if (edgeMeasurementFreshness.length > 0) {
+        const stale = edgeMeasurementFreshness.filter((r) => Number(r.hours_since) > 48);
+        if (stale.length > 0) {
+          ln(`**Measurement freshness — stale (>48h)**:`);
+          ln();
+          ln(`| Type | Latest measurement | Hours since |`);
+          ln(`|------|-------------------|-------------|`);
+          for (const f of stale) {
+            ln(`| ${f.market_type || 'N/A'} | ${fmtDateShort(f.latest_measurement)} | ${fmt(f.hours_since, 1)} |`);
+          }
+          ln();
+        }
+      }
     }
 
     // Shadow — theoretical, NOT directly comparable to live


### PR DESCRIPTION
## Summary

Combines Pilar 4-A (queries + prompt) and 4-B (rendering) into one PR. The daily auto-review now surfaces whether our trading universe has any measured cost-aware edge, and whether we're burning capital in cohorts the data says are anti-edge.

## What it surfaces

Three new daily-review sections sourced from \`generator_edge\` (Pilar 1-B):

1. **edge_cohorts_positive**: cells where latest \`t_net > 0\`. Empty = no measured edge anywhere.
2. **edge_gap**: (type, direction) we trade but have NO measured edge for. WARNING when present, CRITICAL when cumulative loss < -$50. **The single biggest failure mode in our trading right now.**
3. **edge_measurement_freshness**: per-type latest measurement age. Stale (>48h) = cron failing for that type.

## Changes

**scripts/daily-review.sh**
- 4 new query blocks (15a-15d) producing JSON arrays.
- Resilient: returns null/[] when generator_edge doesn't exist (pre-Pilar-1B-deploy).
- Passed to final jq alongside existing fields.

**scripts/daily-review-prompt.md**
- New 'Health-of-Edge Analysis (MANDATORY)' section walks Claude through each signal.
- JSON section list updated.

**scripts/format-review.js**
- Parses new edge_* fields.
- New alerts: edge_gap (severity dependent on cumulative PnL) + stale measurements.
- New 'Health of Edge' subsection in the Performance Breakdown markdown.
- Outer conditional widened so the section renders even when no trades (the "no edge anywhere" case matters most then).

## Smoke test (local)

Input: 1 positive cell (mean_reversion crypto_intraday short t_net=2.14) + 1 gap row (event_financial long -$49.38).

Output:
\`\`\`
[WARNING] Edge gap: trading 1 (type, direction) cohort(s) WITHOUT measured cost-aware edge. Cumulative loss: -$49.38

### Health of Edge (cost-aware measurement)
**Cohorts with positive cost-aware edge** (top 1 by t_net):
| Signal | Type | Dir | t_net | n | RT cost % |
| mean_reversion | crypto_intraday | short | 2.14 | 126 | 1.08 |

**Edge gap — trading WITHOUT measured edge**:
| Type | Direction | Trades | PnL (7d) |
| event_financial | long | 11 | -$49.38 |
\`\`\`

## Validation post-deploy

- [ ] Tomorrow's daily-review: markdown has 'Health of Edge' subsection
- [ ] After 02:30 UTC cron + this PR-Pilar1B-deploy: positive cohorts table populates if any cell has t_net > 0
- [ ] Slack/Gmail mentions edge_gap if trading in cohorts without measured edge

Builds on: #229 (Pilar 1-B generator_edge — provides the data)
Design: \`project_phase5_aed_design.md\` memory

🤖 Generated with [Claude Code](https://claude.com/claude-code)