### PR TITLE
fix(workflow): surface skipped daily-review issue creation

### DIFF
--- a/.github/workflows/daily-trade-review-claude.yml
+++ b/.github/workflows/daily-trade-review-claude.yml
@@ -188,6 +188,29 @@ jobs:
             --dangerously-skip-permissions \
             2>&1 | tee claude-output.log
 
+      - name: Verify daily-review issue was created
+        id: verify_issue
+        if: always() && steps.gather.outputs.data_collected == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Claude's session occasionally exits without creating the daily issue
+          # (judgment call when system seems healthy). Step 3 of the prompt is
+          # mandatory but not workflow-enforced. This step surfaces those misses
+          # so the audit trail stays complete.
+          TODAY=$(date -u +%Y-%m-%d)
+          # Use --search created:>=TODAY so the count is unambiguous even if the
+          # daily issue title is unconventional.
+          COUNT=$(gh issue list --label daily-review --state all \
+            --search "created:>=$TODAY" --json number --jq 'length' || echo "0")
+          echo "Daily-review issues created today ($TODAY): $COUNT"
+          if [ "$COUNT" = "0" ]; then
+            echo "::warning::Claude completed analysis but did NOT create a daily-review issue today. Step 3 was skipped. Check claude-output.log for the reasoning."
+            echo "issue_created=false" >> $GITHUB_OUTPUT
+          else
+            echo "issue_created=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Send notifications
         if: always() && steps.gather.outputs.data_collected == 'true'
         env:


### PR DESCRIPTION
## Summary

- Claude's daily-review session occasionally exits without creating the daily issue (judgment call when system seems healthy)
- Confirmed on 2026-05-16: workflow ran success, Claude completed analysis, but no daily-review issue was created
- Step 3 of `daily-review-prompt.md` already labels issue creation as MANDATORY, but the workflow didn't enforce it
- This PR adds a post-analysis check that emits a workflow `::warning::` if no daily-review issue was created today

## Why a warning, not an auto-stub issue

- Auto-creating a placeholder issue would pollute the daily-review label with low-quality stubs
- The `::warning::` is enough to surface the skip in workflow UI and Slack notifications without losing visibility
- If skips become frequent, follow-up: tighten the prompt or auto-stub the issue

## Test plan

- [ ] Verify the new step runs in the next daily-review run (2026-05-18 08:00 UTC)
- [ ] If Claude creates an issue: step shows `issue_created=true` with COUNT >= 1
- [ ] If Claude skips: step emits `::warning::` visible in workflow log
- [ ] Workflow does not break the notification pipeline either way

## Related

- Found during daily auto-review analysis 2026-05-17
- See `project_session_2026-05-15_wrap.md` for the original issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a verification step to the daily trade review workflow to confirm that the review issue was successfully created.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->