### PR TITLE
feat(generator): favorite_longshot_bias — Tier 1 Sprint 2 generator

### DIFF
--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -575,6 +575,18 @@ async function main(): Promise<void> {
       `);
       console.log('[server] signal_weights.resolution_prior row ensured');
 
+      // favorite_longshot_bias bootstrap (Sprint 2, 2026-05-17). Starts at
+      // weight 0.0 so the generator emits signals (visible in
+      // generator_predictions for Pilar 1 measurement) but does not influence
+      // the combiner until the optimizer ratchets it up from cost-aware
+      // t-stat evidence.
+      await query(`
+        INSERT INTO signal_weights (signal_type, weight, market_type, direction, is_enabled, min_confidence, updated_at)
+        VALUES ('favorite_longshot_bias', 0.0, '__global__', '__all__', true, 0.0, NOW())
+        ON CONFLICT (signal_type, market_type, direction) DO NOTHING;
+      `);
+      console.log('[server] signal_weights.favorite_longshot_bias row ensured');
+
       // direction_multiplier per-(market_type) bootstrap. Mirror init/028_*.sql
       // for existing VMs whose volume already initialized (so 028 won't re-run).
       // See docs/plans/2026-04-30-direction-multiplier-per-type-design.md.

--- a/packages/dashboard/src/services/BacktestService.ts
+++ b/packages/dashboard/src/services/BacktestService.ts
@@ -30,6 +30,7 @@ import {
   MultiLevelOFISignal,
   SpreadCompressionGenerator,
   ResolutionPriorGenerator,
+  FavoriteLongshotBiasGenerator,
   PriceRangeWeightModifier,
   type ISignal,
   type OrderBookSnapshot,
@@ -680,6 +681,9 @@ export class BacktestService extends EventEmitter {
           break;
         case 'resolution_prior':
           signals.push(new ResolutionPriorGenerator());
+          break;
+        case 'favorite_longshot_bias':
+          signals.push(new FavoriteLongshotBiasGenerator());
           break;
         default:
           console.warn(`[BacktestService] Unknown signal type: ${type}`);

--- a/packages/dashboard/src/services/SignalEngine.ts
+++ b/packages/dashboard/src/services/SignalEngine.ts
@@ -37,6 +37,7 @@ import {
   AttentionSpikeGenerator,
   NewsSentimentGenerator,
   ResolutionPriorGenerator,
+  FavoriteLongshotBiasGenerator,
   WeightedAverageCombiner,
   DurationWeightModifier,
   PriceRangeWeightModifier,
@@ -243,6 +244,7 @@ export class SignalEngine extends EventEmitter {
     this.signals.set('spread_compression', new SpreadCompressionGenerator());
     this.signals.set('cross_market_corr', new CrossMarketCorrelationGenerator());
     this.signals.set('resolution_prior', new ResolutionPriorGenerator());
+    this.signals.set('favorite_longshot_bias', new FavoriteLongshotBiasGenerator());
 
     // External data signals
     this.signals.set('price_divergence', new PriceDivergenceGenerator());

--- a/packages/signals/src/index.ts
+++ b/packages/signals/src/index.ts
@@ -87,6 +87,11 @@ export {
   DEFAULT_RESOLUTION_PRIOR_PARAMS,
   type ResolutionPriorParams,
 } from './signals/market-structure/ResolutionPriorGenerator.js';
+export {
+  FavoriteLongshotBiasGenerator,
+  DEFAULT_FAVORITE_LONGSHOT_BIAS_PARAMS,
+  type FavoriteLongshotBiasParams,
+} from './signals/market-structure/FavoriteLongshotBiasGenerator.js';
 
 // External Data Signals
 export { PriceDivergenceGenerator } from './signals/external/PriceDivergenceGenerator.js';
@@ -267,6 +272,7 @@ import { SentimentSignal } from './signals/sentiment/SentimentSignal.js';
 import { EventDrivenSignal } from './signals/event/EventDrivenSignal.js';
 import { RLSignal } from './signals/rl/RLSignal.js';
 import { ResolutionPriorGenerator } from './signals/market-structure/ResolutionPriorGenerator.js';
+import { FavoriteLongshotBiasGenerator } from './signals/market-structure/FavoriteLongshotBiasGenerator.js';
 import type { ISignal, SignalConfig } from './core/types/signal.types.js';
 
 const signalRegistry: Record<string, () => ISignal> = {
@@ -281,6 +287,7 @@ const signalRegistry: Record<string, () => ISignal> = {
   event_driven: () => new EventDrivenSignal(),
   rl: () => new RLSignal(),
   resolution_prior: () => new ResolutionPriorGenerator(),
+  favorite_longshot_bias: () => new FavoriteLongshotBiasGenerator(),
 };
 
 /**

--- a/packages/signals/src/signals/market-structure/FavoriteLongshotBiasGenerator.test.ts
+++ b/packages/signals/src/signals/market-structure/FavoriteLongshotBiasGenerator.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import {
+  FavoriteLongshotBiasGenerator,
+  DEFAULT_FAVORITE_LONGSHOT_BIAS_PARAMS,
+} from './FavoriteLongshotBiasGenerator.js';
+import type { SignalContext, PriceBar } from '../../core/types/signal.types.js';
+
+const NOW = new Date('2026-05-17T12:00:00Z');
+
+function bars(closes: number[]): PriceBar[] {
+  return closes.map((close, i) => ({
+    time: new Date(NOW.getTime() - (closes.length - i) * 60_000),
+    open: close,
+    high: close * 1.01,
+    low: close * 0.99,
+    close,
+    volume: 1000,
+    tradeCount: 1,
+  }));
+}
+
+function context(closes: number[]): SignalContext {
+  return {
+    market: {
+      id: 'mkt',
+      question: 'q',
+      isActive: true,
+      isResolved: false,
+      tokenIdYes: 'tok-yes',
+    },
+    priceBars: bars(closes),
+    recentTrades: [],
+    currentTime: NOW,
+  };
+}
+
+describe('FavoriteLongshotBiasGenerator', () => {
+  describe('basic behaviour', () => {
+    it('signalId is "favorite_longshot_bias"', () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      expect(gen.signalId).toBe('favorite_longshot_bias');
+    });
+
+    it('uses sensible defaults: longshotThreshold=0.10, favoriteThreshold=0.90', () => {
+      expect(DEFAULT_FAVORITE_LONGSHOT_BIAS_PARAMS.longshotThreshold).toBe(0.10);
+      expect(DEFAULT_FAVORITE_LONGSHOT_BIAS_PARAMS.favoriteThreshold).toBe(0.90);
+    });
+
+    it('isReady requires at least one price bar', () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      expect(gen.isReady(context([]))).toBe(false);
+      expect(gen.isReady(context([0.5]))).toBe(true);
+    });
+
+    it('getRequiredLookback returns 0 (point estimate only)', () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      expect(gen.getRequiredLookback()).toBe(0);
+    });
+  });
+
+  describe('longshot band (price < longshotThreshold)', () => {
+    it('emits LONG when price is well below longshotThreshold', async () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      const out = await gen.compute(context([0.03]));
+      expect(out).not.toBeNull();
+      expect(out!.direction).toBe('LONG');
+      expect(out!.strength).toBeGreaterThan(0);
+    });
+
+    it('strength scales with distance from boundary (deeper longshot = stronger)', async () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      const out01 = await gen.compute(context([0.01]));
+      const out08 = await gen.compute(context([0.08]));
+      expect(out01).not.toBeNull();
+      expect(out08).not.toBeNull();
+      expect(out01!.strength).toBeGreaterThan(out08!.strength);
+    });
+
+    it('returns null near the boundary (strength below minStrength)', async () => {
+      // price = 0.099 → magnitude = (0.10 - 0.099) / 0.10 = 0.01, below default 0.05 minStrength
+      const gen = new FavoriteLongshotBiasGenerator();
+      const out = await gen.compute(context([0.099]));
+      expect(out).toBeNull();
+    });
+  });
+
+  describe('favorite band (price > favoriteThreshold)', () => {
+    it('emits SHORT when price is well above favoriteThreshold', async () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      const out = await gen.compute(context([0.97]));
+      expect(out).not.toBeNull();
+      expect(out!.direction).toBe('SHORT');
+      expect(out!.strength).toBeLessThan(0);
+    });
+
+    it('strength magnitude scales with distance from boundary (deeper favorite = stronger)', async () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      const out99 = await gen.compute(context([0.99]));
+      const out92 = await gen.compute(context([0.92]));
+      expect(out99).not.toBeNull();
+      expect(out92).not.toBeNull();
+      expect(Math.abs(out99!.strength)).toBeGreaterThan(Math.abs(out92!.strength));
+    });
+
+    it('returns null near the boundary (strength below minStrength)', async () => {
+      // price = 0.901 → magnitude = (0.901 - 0.90) / 0.10 = 0.01, below default 0.05 minStrength
+      const gen = new FavoriteLongshotBiasGenerator();
+      const out = await gen.compute(context([0.901]));
+      expect(out).toBeNull();
+    });
+  });
+
+  describe('mid-range (no edge)', () => {
+    it('returns null when price is in (longshotThreshold, favoriteThreshold)', async () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      for (const p of [0.15, 0.30, 0.50, 0.70, 0.85]) {
+        const out = await gen.compute(context([p]));
+        expect(out, `price ${p} should not emit a signal`).toBeNull();
+      }
+    });
+  });
+
+  describe('terminal / invalid prices', () => {
+    it('returns null when price is 0 (market resolved NO)', async () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      expect(await gen.compute(context([0]))).toBeNull();
+    });
+
+    it('returns null when price is 1 (market resolved YES)', async () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      expect(await gen.compute(context([1]))).toBeNull();
+    });
+
+    it('returns null on negative price (data corruption)', async () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      expect(await gen.compute(context([-0.05]))).toBeNull();
+    });
+
+    it('returns null on price > 1 (data corruption)', async () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      expect(await gen.compute(context([1.05]))).toBeNull();
+    });
+
+    it('returns null on empty price bars', async () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      expect(await gen.compute(context([]))).toBeNull();
+    });
+  });
+
+  describe('output shape', () => {
+    it('strength stays within [-1, 1]', async () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      const longshot = await gen.compute(context([0.001]));
+      const favorite = await gen.compute(context([0.999]));
+      expect(longshot!.strength).toBeGreaterThanOrEqual(-1);
+      expect(longshot!.strength).toBeLessThanOrEqual(1);
+      expect(favorite!.strength).toBeGreaterThanOrEqual(-1);
+      expect(favorite!.strength).toBeLessThanOrEqual(1);
+    });
+
+    it('confidence is in [0.4, 0.9] for non-null outputs', async () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      for (const p of [0.001, 0.05, 0.08, 0.92, 0.95, 0.999]) {
+        const out = await gen.compute(context([p]));
+        expect(out, `price ${p} should emit`).not.toBeNull();
+        expect(out!.confidence).toBeGreaterThanOrEqual(0.4);
+        expect(out!.confidence).toBeLessThanOrEqual(0.9);
+      }
+    });
+
+    it('confidence scales with edge magnitude', async () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      const weak = await gen.compute(context([0.08]));
+      const strong = await gen.compute(context([0.01]));
+      expect(strong!.confidence).toBeGreaterThan(weak!.confidence);
+    });
+
+    it('attaches diagnostic metadata (currentPrice, band)', async () => {
+      const gen = new FavoriteLongshotBiasGenerator();
+      const out = await gen.compute(context([0.05]));
+      expect(out!.metadata).toMatchObject({
+        currentPrice: 0.05,
+        band: 'longshot',
+      });
+    });
+  });
+
+  describe('parameter overrides', () => {
+    it('respects custom longshotThreshold', async () => {
+      const gen = new FavoriteLongshotBiasGenerator({ longshotThreshold: 0.20 });
+      const out = await gen.compute(context([0.15])); // would be null under default
+      expect(out).not.toBeNull();
+      expect(out!.direction).toBe('LONG');
+    });
+
+    it('respects custom favoriteThreshold', async () => {
+      const gen = new FavoriteLongshotBiasGenerator({ favoriteThreshold: 0.80 });
+      const out = await gen.compute(context([0.85])); // would be null under default
+      expect(out).not.toBeNull();
+      expect(out!.direction).toBe('SHORT');
+    });
+
+    it('respects custom minStrength gate', async () => {
+      const lax = new FavoriteLongshotBiasGenerator({ minStrength: 0.0 });
+      const strict = new FavoriteLongshotBiasGenerator({ minStrength: 0.5 });
+      const out_lax = await lax.compute(context([0.09]));
+      const out_strict = await strict.compute(context([0.09]));
+      expect(out_lax).not.toBeNull();
+      expect(out_strict).toBeNull();
+    });
+  });
+});

--- a/packages/signals/src/signals/market-structure/FavoriteLongshotBiasGenerator.ts
+++ b/packages/signals/src/signals/market-structure/FavoriteLongshotBiasGenerator.ts
@@ -1,0 +1,127 @@
+import { BaseSignal } from '../../core/base/BaseSignal.js';
+import type {
+  SignalContext,
+  SignalOutput,
+} from '../../core/types/signal.types.js';
+
+export interface FavoriteLongshotBiasParams extends Record<string, unknown> {
+  /**
+   * Upper bound of the longshot band. When price < longshotThreshold the
+   * market is under-pricing the YES outcome relative to its long-run
+   * frequency; the literature reports 3–8% under-pricing for sub-0.10
+   * binary contracts. Default 0.10.
+   */
+  longshotThreshold: number;
+  /**
+   * Lower bound of the favorite band. When price > favoriteThreshold the
+   * market is over-pricing YES (lottery-aversion driving demand for the
+   * "sure thing"). Default 0.90 (symmetric to longshotThreshold).
+   */
+  favoriteThreshold: number;
+  /**
+   * Minimum |strength| required to emit. Prices just inside the band emit
+   * a near-zero signal that the combiner would discard anyway. Default 0.05.
+   */
+  minStrength: number;
+}
+
+export const DEFAULT_FAVORITE_LONGSHOT_BIAS_PARAMS: FavoriteLongshotBiasParams = {
+  longshotThreshold: 0.10,
+  favoriteThreshold: 0.90,
+  minStrength: 0.05,
+};
+
+/**
+ * FavoriteLongshotBiasGenerator
+ *
+ * Codifies the favorite-longshot bias documented in prediction-market
+ * literature (Wolfers/Zitzewitz 2004, Manski 2006). Two regimes:
+ *
+ *   1. Longshot band (price < longshotThreshold): YES outcomes priced below
+ *      ~0.10 historically resolve YES more often than the price implies.
+ *      Empirical mispricing is 3–8%. The generator emits LONG.
+ *
+ *   2. Favorite band (price > favoriteThreshold): YES outcomes priced above
+ *      ~0.90 historically resolve YES less often than the price implies
+ *      (lottery-aversion + supply imbalance). The generator emits SHORT.
+ *
+ * In the mid-range no clear directional bias exists in the literature, so
+ * the generator returns null.
+ *
+ * Mathematical structure:
+ *
+ *   longshot: magnitude = (longshotThreshold - price) / longshotThreshold
+ *             direction = LONG, strength = +magnitude
+ *   favorite: magnitude = (price - favoriteThreshold) / (1 - favoriteThreshold)
+ *             direction = SHORT, strength = -magnitude
+ *   confidence = 0.4 + 0.5 × magnitude  (clamped to [0, 1] by BaseSignal)
+ *
+ * Output is bounded by `createOutput` to strength ∈ [-1, 1] and
+ * confidence ∈ [0, 1]; magnitudes near 1.0 happen only at price ≈ 0 or
+ * ≈ 1, which the terminal-price check filters before computation.
+ */
+export class FavoriteLongshotBiasGenerator extends BaseSignal<FavoriteLongshotBiasParams> {
+  readonly signalId = 'favorite_longshot_bias';
+  readonly name = 'Favorite-Longshot Bias';
+  readonly description =
+    'Exploits the empirical under-pricing of longshots (price < 0.10) and over-pricing of favorites (price > 0.90) in binary prediction markets';
+
+  protected parameters: FavoriteLongshotBiasParams;
+
+  constructor(config?: Partial<FavoriteLongshotBiasParams>) {
+    super();
+    this.parameters = {
+      ...DEFAULT_FAVORITE_LONGSHOT_BIAS_PARAMS,
+      ...config,
+    };
+  }
+
+  getRequiredLookback(): number {
+    return 0;
+  }
+
+  isReady(context: SignalContext): boolean {
+    return context.priceBars.length > 0;
+  }
+
+  async compute(context: SignalContext): Promise<SignalOutput | null> {
+    const { longshotThreshold, favoriteThreshold, minStrength } = this.parameters;
+
+    const bars = context.priceBars;
+    if (bars.length === 0) return null;
+
+    const currentPrice = bars[bars.length - 1].close;
+    if (currentPrice <= 0 || currentPrice >= 1) return null;
+
+    let magnitude: number;
+    let direction: 'LONG' | 'SHORT';
+    let band: 'longshot' | 'favorite';
+
+    if (currentPrice < longshotThreshold) {
+      magnitude = (longshotThreshold - currentPrice) / longshotThreshold;
+      direction = 'LONG';
+      band = 'longshot';
+    } else if (currentPrice > favoriteThreshold) {
+      magnitude = (currentPrice - favoriteThreshold) / (1 - favoriteThreshold);
+      direction = 'SHORT';
+      band = 'favorite';
+    } else {
+      return null;
+    }
+
+    if (magnitude < minStrength) return null;
+
+    const strength = direction === 'LONG' ? magnitude : -magnitude;
+    const confidence = 0.4 + 0.5 * magnitude;
+
+    return this.createOutput(context, direction, strength, confidence, {
+      features: [currentPrice, magnitude],
+      metadata: {
+        currentPrice,
+        band,
+        magnitude,
+        threshold: band === 'longshot' ? longshotThreshold : favoriteThreshold,
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary

First Tier 1 generator from `project_prediction_market_alpha_research.md` Sprint 2. Codifies the favorite-longshot bias documented in prediction-market literature:

- **Longshot band** (price < 0.10): emits LONG. Empirical under-pricing of 3–8%.
- **Favorite band** (price > 0.90): emits SHORT. Empirical over-pricing.
- **Mid-range** (0.10–0.90): null (no clear directional bias in literature).

Magnitude scales linearly with distance from the boundary; confidence is bounded to `[0.4, 0.9]` to play nicely with the combiner's consensus discount.

## Wire-up strategy

The generator is registered in `SignalEngine`, `BacktestService`, and the package `signalRegistry`, and seeds a `signal_weights` row at **weight = 0.0** on server start. This means:

- Predictions flow into `generator_predictions` so Pilar 1 (`EdgeCapacityRefresher`) measures cost-aware t-stat for it on the next nightly cron (2026-05-18 02:30 UTC).
- The combiner output is unaffected until the optimizer ratchets the weight up from positive cost-aware edge evidence. Conservative-by-default: a generator with unproven edge never moves real capital.

## Test plan

- [x] 23 new unit tests in `FavoriteLongshotBiasGenerator.test.ts` (longshot / favorite / mid-range / terminal / parameter / shape).
- [x] `pnpm exec vitest run packages/signals` — 255 / 255 pass.
- [x] `pnpm exec vitest run packages/dashboard` — 389 / 389 pass.
- [x] `pnpm -r exec tsc --noEmit` — 0 errors.
- [ ] After deploy: verify `signal_weights.favorite_longshot_bias` row exists with weight = 0.
- [ ] After ~24h of trading: check `generator_predictions` contains rows with `signal_id = 'favorite_longshot_bias'`.
- [ ] After next Phase 5 cron (02:30 UTC): check `generator_edge` contains rows for the new signal — that confirms the measurement infra picks it up automatically with no schema change.

## Next in Sprint 2

When this lands and measurement confirms predictions are flowing:

1. `resolution_prior_v2` — refined Bayesian prior with time-decay vs SMA (~1 week, separate PR).
2. `liquidity_quality_filter` — exclude markets with > 5% spread or single-LP wash before signal generation.
3. Re-measure cost-aware t-stat across all generators with new signals + filter. If still no positive cell after ~14 days of data → trigger quitting-criteria pivot per the research doc.

## Related

- Research doc: `project_prediction_market_alpha_research.md`
- Phase 5 measurement infra: PR #228 (sampling), #229 (history), #230 (daily-review)
- Quitting criteria: documented in research doc + `project_phase5_aed_design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)