### PR TITLE
feat(optimizer): wire favorite_longshot_bias into Optuna param space

### DIFF
--- a/packages/dashboard/src/services/BacktestService.ts
+++ b/packages/dashboard/src/services/BacktestService.ts
@@ -85,6 +85,7 @@ export interface BacktestRequest {
     mlofiWeight?: number;
     spreadCompressionWeight?: number;
     resolutionPriorWeight?: number;
+    favoriteLongshotBiasWeight?: number;
     minCombinedConfidence?: number;
     minCombinedStrength?: number;
     onlyDirection?: string | null;
@@ -207,6 +208,7 @@ export class BacktestService extends EventEmitter {
         mlofi: cc?.mlofiWeight ?? 0,
         spread_compression: cc?.spreadCompressionWeight ?? 0,
         resolution_prior: cc?.resolutionPriorWeight ?? 0,
+        favorite_longshot_bias: cc?.favoriteLongshotBiasWeight ?? 0,
         wallet_tracking: 0.3,
       };
       const combiner = new WeightedAverageCombiner(weights, cc ? {

--- a/packages/dashboard/src/services/OptimizationScheduler.ts
+++ b/packages/dashboard/src/services/OptimizationScheduler.ts
@@ -60,6 +60,12 @@ export const OPTUNA_PARAM_SPACE: ParameterDef[] = [
   // markets drifting toward NO/YES. Allow full [0, 2] range; OOS gate
   // protects against bad applies.
   { name: 'combiner.resolutionPriorWeight', type: 'float', low: 0.0, high: 2.0 },
+  // Favorite-longshot bias (Sprint 2 2026-05-17). Codifies empirical
+  // mispricing in tail-band markets (price < 0.10 or > 0.90). Bootstrap row
+  // ships at weight 0 so the generator emits predictions for measurement
+  // without affecting the combiner until Optuna has cost-aware t-stat
+  // evidence. [0, 2] range matches other tail-anchored generators.
+  { name: 'combiner.favoriteLongshotBiasWeight', type: 'float', low: 0.0, high: 2.0 },
   // Consensus discount floor (Sub-project B.2, see docs/plans/2026-04-25-signal-consensus-design.md).
   // Combiner-layer confidence multiplier driven by entropy across active generators.
   // 0.0 = full discount on disagreement; 1.0 = no-op. Live default in signal_weights is 0.5.
@@ -121,6 +127,7 @@ export const REFINEMENT_PARAM_SPACE: ParameterDef[] = [
   { name: 'combiner.mlofiWeight', type: 'float', low: 0.0, high: 2.0 },
   { name: 'combiner.spreadCompressionWeight', type: 'float', low: 0.0, high: 2.0 },
   { name: 'combiner.resolutionPriorWeight', type: 'float', low: 0.0, high: 2.0 },
+  { name: 'combiner.favoriteLongshotBiasWeight', type: 'float', low: 0.0, high: 2.0 },
   { name: 'combiner.consensusDiscountFloor', type: 'float', low: 0.0, high: 1.0 },
   { name: 'risk.maxPositionSizePct', type: 'float', low: 3.0, high: 15.0 },
   { name: 'risk.stopLossPct', type: 'float', low: 8.0, high: 30.0 },
@@ -756,6 +763,7 @@ export class OptimizationScheduler {
         mlofiWeight: params['combiner.mlofiWeight'],
         spreadCompressionWeight: params['combiner.spreadCompressionWeight'],
         resolutionPriorWeight: params['combiner.resolutionPriorWeight'],
+        favoriteLongshotBiasWeight: params['combiner.favoriteLongshotBiasWeight'],
         minCombinedConfidence: params['combiner.minCombinedConfidence'],
         minCombinedStrength: params['combiner.minCombinedStrength'],
         onlyDirection: params['combiner.onlyDirection'],
@@ -1183,6 +1191,7 @@ export class OptimizationScheduler {
       'combiner.mlofiWeight': 'mlofi',
       'combiner.spreadCompressionWeight': 'spread_compression',
       'combiner.resolutionPriorWeight': 'resolution_prior',
+      'combiner.favoriteLongshotBiasWeight': 'favorite_longshot_bias',
       // Per-type dm (REFINEMENT_PARAM_SPACE only). Categorical {-1, +1} so the
       // generic clamp below trivially preserves the value. Min-lift gate
       // (OPTIMIZER_DM_FLIP_MIN_LIFT) gates flips when configured.


### PR DESCRIPTION
## Summary

Closes the gap from PR #234: the generator emits predictions and the combiner sees its weight at 0.0, but **Optuna had no path to ratchet up the weight** even with positive cost-aware t-stat evidence. This PR adds `combiner.favoriteLongshotBiasWeight` to both the full and per-type refinement parameter spaces, wires the result-application path, and threads the value through `BacktestService.combinerConfig` so trials can evaluate it as part of the joint search.

## Changes

- `OptimizationScheduler.ts`:
  - `OPTUNA_PARAM_SPACE` and `REFINEMENT_PARAM_SPACE` each get a `combiner.favoriteLongshotBiasWeight: [0, 2]` entry.
  - `WEIGHT_PARAM_MAP` maps it to signal_type `favorite_longshot_bias`.
  - Result-application path passes it to `combinerConfig`.
- `BacktestService.ts`:
  - `BacktestRequest.combinerConfig.favoriteLongshotBiasWeight?: number` type.
  - Default weights table reads `cc?.favoriteLongshotBiasWeight ?? 0`.

## Test plan

- [x] `pnpm exec vitest run packages/dashboard/src/services/OptimizationScheduler` — 79 pass.
- [x] `pnpm -r exec tsc --noEmit` — 0 errors.
- [ ] After deploy: next Optuna cycle (~6h) suggests a `combiner.favoriteLongshotBiasWeight` value; verify by inspecting trial params.
- [ ] After ~1 week of edge data: if `generator_edge` shows positive t_net for the signal, verify optimizer ratchets `signal_weights.favorite_longshot_bias.weight` above 0.

## Related

- PR #234 — generator + bootstrap
- `project_session_2026-05-17_wrap.md` — Sprint 2 plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `favoriteLongshotBiasWeight` parameter to backtest and optimization configurations. This new configurable parameter enables users to fine-tune the favorite longshot bias signal contribution in strategy backtesting and optimization workflows. The weight supports values ranging from 0.0 to 2.0, with a default value of 0 when unset, and integrates seamlessly with existing signal combination processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->