### PR TITLE
feat(filter): MarketLiquidityFilter — exclude wide-spread markets pre-signals

### DIFF
--- a/packages/dashboard/src/services/MarketLiquidityFilter.test.ts
+++ b/packages/dashboard/src/services/MarketLiquidityFilter.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  filterMarketsByLiquidity,
+  parseLiquidityFilterEnv,
+  DEFAULT_LIQUIDITY_FILTER_PARAMS,
+  type MarketWithSpread,
+} from './MarketLiquidityFilter.js';
+
+describe('filterMarketsByLiquidity', () => {
+  describe('default thresholds (5% spread)', () => {
+    it('keeps markets below threshold', () => {
+      const markets: MarketWithSpread[] = [
+        { marketId: 'a', spreadPct: 0.02 },
+        { marketId: 'b', spreadPct: 0.04 },
+      ];
+      const { kept, filtered } = filterMarketsByLiquidity(markets, DEFAULT_LIQUIDITY_FILTER_PARAMS);
+      expect(kept.map(m => m.marketId)).toEqual(['a', 'b']);
+      expect(filtered).toEqual([]);
+    });
+
+    it('filters out markets at or above threshold (strict >)', () => {
+      const markets: MarketWithSpread[] = [
+        { marketId: 'a', spreadPct: 0.05 },  // exactly threshold — KEEP (>= boundary not strict)
+        { marketId: 'b', spreadPct: 0.0501 },
+        { marketId: 'c', spreadPct: 0.20 },
+      ];
+      const { kept, filtered } = filterMarketsByLiquidity(markets, { maxSpreadPct: 0.05, filterMissing: false });
+      expect(kept.map(m => m.marketId)).toEqual(['a']);
+      expect(filtered.map(m => m.marketId)).toEqual(['b', 'c']);
+    });
+  });
+
+  describe('missing orderbook data', () => {
+    it('keeps markets without spread data by default (filterMissing=false)', () => {
+      const markets: MarketWithSpread[] = [
+        { marketId: 'a', spreadPct: 0.02 },
+        { marketId: 'b' },  // no orderbook data
+      ];
+      const { kept, filtered } = filterMarketsByLiquidity(markets, { maxSpreadPct: 0.05, filterMissing: false });
+      expect(kept.map(m => m.marketId)).toEqual(['a', 'b']);
+      expect(filtered).toEqual([]);
+    });
+
+    it('filters markets without spread data when filterMissing=true', () => {
+      const markets: MarketWithSpread[] = [
+        { marketId: 'a', spreadPct: 0.02 },
+        { marketId: 'b' },
+      ];
+      const { kept, filtered } = filterMarketsByLiquidity(markets, { maxSpreadPct: 0.05, filterMissing: true });
+      expect(kept.map(m => m.marketId)).toEqual(['a']);
+      expect(filtered.map(m => m.marketId)).toEqual(['b']);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty list', () => {
+      const { kept, filtered } = filterMarketsByLiquidity([], DEFAULT_LIQUIDITY_FILTER_PARAMS);
+      expect(kept).toEqual([]);
+      expect(filtered).toEqual([]);
+    });
+
+    it('handles negative spreads as missing data (data corruption)', () => {
+      const markets: MarketWithSpread[] = [
+        { marketId: 'a', spreadPct: -0.01 },
+      ];
+      const { kept, filtered } = filterMarketsByLiquidity(markets, { maxSpreadPct: 0.05, filterMissing: false });
+      // Negative spread = data corruption. Conservative: treat as missing → keep when filterMissing=false.
+      expect(kept.map(m => m.marketId)).toEqual(['a']);
+      expect(filtered).toEqual([]);
+    });
+
+    it('handles NaN spreads as missing data', () => {
+      const markets: MarketWithSpread[] = [
+        { marketId: 'a', spreadPct: NaN },
+      ];
+      const { kept } = filterMarketsByLiquidity(markets, { maxSpreadPct: 0.05, filterMissing: false });
+      expect(kept.map(m => m.marketId)).toEqual(['a']);
+    });
+  });
+
+  describe('threshold parameter respected', () => {
+    it('uses a relaxed 10% threshold', () => {
+      const markets: MarketWithSpread[] = [
+        { marketId: 'a', spreadPct: 0.06 },  // would be filtered at 5%
+        { marketId: 'b', spreadPct: 0.11 },
+      ];
+      const { kept, filtered } = filterMarketsByLiquidity(markets, { maxSpreadPct: 0.10, filterMissing: false });
+      expect(kept.map(m => m.marketId)).toEqual(['a']);
+      expect(filtered.map(m => m.marketId)).toEqual(['b']);
+    });
+
+    it('with maxSpreadPct=Infinity, nothing is filtered by spread', () => {
+      const markets: MarketWithSpread[] = [
+        { marketId: 'a', spreadPct: 0.50 },
+      ];
+      const { kept, filtered } = filterMarketsByLiquidity(markets, { maxSpreadPct: Infinity, filterMissing: false });
+      expect(kept.map(m => m.marketId)).toEqual(['a']);
+      expect(filtered).toEqual([]);
+    });
+  });
+});
+
+describe('parseLiquidityFilterEnv', () => {
+  it('returns disabled when env var unset', () => {
+    const result = parseLiquidityFilterEnv(undefined);
+    expect(result.enabled).toBe(false);
+  });
+
+  it('returns disabled when env var is "false"', () => {
+    expect(parseLiquidityFilterEnv('false').enabled).toBe(false);
+    expect(parseLiquidityFilterEnv('0').enabled).toBe(false);
+    expect(parseLiquidityFilterEnv('').enabled).toBe(false);
+  });
+
+  it('returns enabled with defaults when env var is "true"', () => {
+    const result = parseLiquidityFilterEnv('true');
+    expect(result.enabled).toBe(true);
+    expect(result.params).toEqual(DEFAULT_LIQUIDITY_FILTER_PARAMS);
+  });
+
+  it('accepts numeric threshold form: "0.07"', () => {
+    const result = parseLiquidityFilterEnv('0.07');
+    expect(result.enabled).toBe(true);
+    expect(result.params.maxSpreadPct).toBe(0.07);
+  });
+
+  it('ignores invalid numeric values, falls back to disabled', () => {
+    const result = parseLiquidityFilterEnv('abc');
+    expect(result.enabled).toBe(false);
+  });
+
+  it('clamps absurd thresholds to a sensible bound', () => {
+    // > 1.0 means "100% spread allowed" — clearly a typo. Cap at 1.0.
+    const result = parseLiquidityFilterEnv('2.0');
+    expect(result.enabled).toBe(true);
+    expect(result.params.maxSpreadPct).toBeLessThanOrEqual(1.0);
+  });
+});

--- a/packages/dashboard/src/services/MarketLiquidityFilter.ts
+++ b/packages/dashboard/src/services/MarketLiquidityFilter.ts
@@ -1,0 +1,163 @@
+import { query } from '../database/index.js';
+
+/**
+ * MarketLiquidityFilter
+ *
+ * Filters markets by orderbook spread before signal generation. Empirical
+ * snapshot 2026-05-17: 30 of 54 tracked markets had spread > 5% of mid;
+ * 22 had > 10%; 18 had > 20%. On a 1% generator edge, a 5% round-trip
+ * spread cost is fatal — the trade is dead before it opens. The filter
+ * gives generators (and the optimizer measuring them) a chance to operate
+ * on markets where their predicted edge is not immediately consumed by
+ * friction.
+ *
+ * Default OFF behind ENABLE_LIQUIDITY_FILTER env. When enabled, the filter
+ * still always logs what WOULD be filtered so operators can see the impact
+ * before the gate hardens.
+ */
+
+export interface MarketWithSpread {
+  marketId: string;
+  /**
+   * (best_ask - best_bid) / mid_price. Undefined / NaN / negative all mean
+   * "no usable orderbook data" — the filter treats them per filterMissing
+   * policy rather than as bad spreads.
+   */
+  spreadPct?: number;
+}
+
+export interface LiquidityFilterParams {
+  /** Strict upper bound on accepted spread, as fraction of mid. */
+  maxSpreadPct: number;
+  /**
+   * When `true`, markets without orderbook data are filtered (assume the
+   * worst). When `false`, they pass through unchanged. Default `false` is
+   * conservative — we don't want to silently drop markets just because the
+   * data-collector hasn't snapshotted them yet.
+   */
+  filterMissing: boolean;
+}
+
+export const DEFAULT_LIQUIDITY_FILTER_PARAMS: LiquidityFilterParams = {
+  maxSpreadPct: 0.05,
+  filterMissing: false,
+};
+
+const SPREAD_CAP = 1.0;
+
+/**
+ * Pure: split a market list into kept/filtered by spread quality.
+ *
+ * Markets are filtered when `spreadPct > maxSpreadPct`. Equality is kept
+ * (cheap markets right at the threshold survive; only strictly-worse get
+ * dropped). Missing or invalid spread data is routed by `filterMissing`.
+ */
+export function filterMarketsByLiquidity(
+  markets: MarketWithSpread[],
+  params: LiquidityFilterParams,
+): { kept: MarketWithSpread[]; filtered: MarketWithSpread[] } {
+  const kept: MarketWithSpread[] = [];
+  const filtered: MarketWithSpread[] = [];
+
+  for (const market of markets) {
+    const spread = market.spreadPct;
+    const isUsable =
+      spread !== undefined &&
+      typeof spread === 'number' &&
+      !Number.isNaN(spread) &&
+      spread >= 0;
+
+    if (!isUsable) {
+      if (params.filterMissing) {
+        filtered.push(market);
+      } else {
+        kept.push(market);
+      }
+      continue;
+    }
+
+    if (spread > params.maxSpreadPct) {
+      filtered.push(market);
+    } else {
+      kept.push(market);
+    }
+  }
+
+  return { kept, filtered };
+}
+
+export interface LiquidityFilterEnvParse {
+  enabled: boolean;
+  params: LiquidityFilterParams;
+}
+
+/**
+ * Parse the ENABLE_LIQUIDITY_FILTER env value into a config.
+ *
+ * Accepted forms:
+ *   - unset / "" / "false" / "0"      → disabled
+ *   - "true" / "1"                     → enabled with defaults
+ *   - "<number>" (e.g. "0.07")        → enabled with that threshold; clamped to [0, 1]
+ *
+ * Invalid values fall back to disabled so a typo never silently changes the
+ * filter behaviour.
+ */
+export function parseLiquidityFilterEnv(raw: string | undefined): LiquidityFilterEnvParse {
+  if (raw === undefined) return { enabled: false, params: DEFAULT_LIQUIDITY_FILTER_PARAMS };
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === '' || trimmed === 'false' || trimmed === '0') {
+    return { enabled: false, params: DEFAULT_LIQUIDITY_FILTER_PARAMS };
+  }
+  if (trimmed === 'true' || trimmed === '1') {
+    return { enabled: true, params: DEFAULT_LIQUIDITY_FILTER_PARAMS };
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return { enabled: false, params: DEFAULT_LIQUIDITY_FILTER_PARAMS };
+  }
+  const clamped = Math.min(SPREAD_CAP, parsed);
+  return {
+    enabled: true,
+    params: { ...DEFAULT_LIQUIDITY_FILTER_PARAMS, maxSpreadPct: clamped },
+  };
+}
+
+/**
+ * Load the latest spread per market from orderbook_snapshots. Returns a Map
+ * of marketId → spreadPct (relative to mid). Markets without recent (last
+ * `withinMinutes` minutes) book snapshots are absent from the Map.
+ *
+ * Uses a single DISTINCT ON query so it scales linearly with the tracked
+ * set. The query is bounded by `withinMinutes` because a 6-hour-old book
+ * is not what trading will execute against now.
+ */
+export async function loadMarketSpreads(
+  marketIds: string[],
+  options: { withinMinutes?: number } = {},
+): Promise<Map<string, number>> {
+  const withinMinutes = options.withinMinutes ?? 30;
+  if (marketIds.length === 0) return new Map();
+
+  const result = await query<{ market_id: string; spread_pct: string }>(
+    `SELECT DISTINCT ON (market_id)
+       market_id,
+       (spread / NULLIF(mid_price, 0))::text AS spread_pct
+     FROM orderbook_snapshots
+     WHERE market_id = ANY($1::varchar[])
+       AND time > NOW() - ($2::int || ' minutes')::interval
+       AND spread IS NOT NULL
+       AND mid_price IS NOT NULL
+       AND mid_price > 0
+     ORDER BY market_id, time DESC`,
+    [marketIds, withinMinutes],
+  );
+
+  const map = new Map<string, number>();
+  for (const row of result.rows) {
+    const value = parseFloat(row.spread_pct);
+    if (Number.isFinite(value) && value >= 0) {
+      map.set(row.market_id, value);
+    }
+  }
+  return map;
+}

--- a/packages/dashboard/src/services/MarketLiquidityFilterBridge.ts
+++ b/packages/dashboard/src/services/MarketLiquidityFilterBridge.ts
@@ -1,0 +1,42 @@
+import {
+  filterMarketsByLiquidity,
+  loadMarketSpreads,
+  parseLiquidityFilterEnv,
+} from './MarketLiquidityFilter.js';
+
+/**
+ * Bridge between PolymarketService and the (pure + DB-bound) liquidity
+ * filter. Reads the ENABLE_LIQUIDITY_FILTER env var, loads spreads for the
+ * given markets when enabled, and returns a filtered copy of the input.
+ *
+ * No-op (returns the input unchanged) when the env var is unset, "false",
+ * or invalid. Always logs the filter outcome so operators can see impact
+ * before tightening the gate.
+ *
+ * Generic over the market shape — only `id` is required. Keeps the pure
+ * filter agnostic to `ActiveMarket` and other consumer-specific types.
+ */
+export async function applyLiquidityFilter<T extends { id: string }>(
+  markets: T[],
+): Promise<T[]> {
+  const envParse = parseLiquidityFilterEnv(process.env.ENABLE_LIQUIDITY_FILTER);
+  if (!envParse.enabled || markets.length === 0) {
+    return markets;
+  }
+
+  const spreads = await loadMarketSpreads(markets.map((m) => m.id));
+  const withSpread = markets.map((m) => ({
+    marketId: m.id,
+    spreadPct: spreads.get(m.id),
+  }));
+  const { kept, filtered } = filterMarketsByLiquidity(withSpread, envParse.params);
+  const keptIds = new Set(kept.map((m) => m.marketId));
+
+  console.log(
+    `[LiquidityFilter] threshold=${envParse.params.maxSpreadPct} kept=${kept.length} filtered=${filtered.length} (missing_data=${
+      withSpread.filter((m) => m.spreadPct === undefined).length
+    })`,
+  );
+
+  return markets.filter((m) => keptIds.has(m.id));
+}

--- a/packages/dashboard/src/services/PolymarketService.ts
+++ b/packages/dashboard/src/services/PolymarketService.ts
@@ -9,6 +9,7 @@ import { EventEmitter } from 'events';
 import { isDatabaseConfigured, query } from '../database/index.js';
 import { getSignalEngine } from './SignalEngine.js';
 import { getDataCollectorService, type PriceData } from './DataCollectorService.js';
+import { applyLiquidityFilter } from './MarketLiquidityFilterBridge.js';
 
 export interface PolymarketConfig {
   apiUrl: string;
@@ -528,7 +529,7 @@ export class PolymarketService extends EventEmitter {
       console.log(`[PolymarketService] Selected ${selectedMarkets.length} diversified markets`);
 
       // Update SignalEngine with discovered markets
-      this.updateSignalEngineMarkets(selectedMarkets);
+      await this.updateSignalEngineMarkets(selectedMarkets);
 
       this.emit('markets:discovered', selectedMarkets);
       return selectedMarkets;
@@ -687,11 +688,11 @@ export class PolymarketService extends EventEmitter {
   /**
    * Update SignalEngine with current markets
    */
-  private updateSignalEngineMarkets(markets: PolymarketMarket[]): void {
+  private async updateSignalEngineMarkets(markets: PolymarketMarket[]): Promise<void> {
     try {
       const engine = getSignalEngine();
 
-      const activeMarkets = markets
+      const baseActiveMarkets = markets
         .filter(m => m.isActive)
         .slice(0, this.config.maxMarketsToTrack)
         .map(m => ({
@@ -707,6 +708,8 @@ export class PolymarketService extends EventEmitter {
           endDate: m.endDate ?? null,
           trackingStatus: m.trackingStatus,
         }));
+
+      const activeMarkets = await applyLiquidityFilter(baseActiveMarkets);
 
       engine.setActiveMarkets(activeMarkets);
       console.log(`[PolymarketService] Updated SignalEngine with ${activeMarkets.length} markets`);


### PR DESCRIPTION
## Summary

Empirical 2026-05-17 snapshot (last hour of orderbooks on the VM):

| Threshold | Markets above | % of universe |
|----------|--------------:|--------------:|
| spread > 5% | 30 / 54 | 55% |
| spread > 10% | 22 / 54 | 41% |
| spread > 20% | 18 / 54 | 33% |

On a 1% generator edge, a 5% round-trip spread is fatal. This PR adds the filter infrastructure so the generators (and the optimizer measuring them under Phase 5) can operate on markets where their predicted edge is not immediately consumed by friction.

## Changes

- **Pure**: `filterMarketsByLiquidity(markets, params)` in `MarketLiquidityFilter.ts`. 15 unit tests for threshold boundaries, missing data handling, edge cases.
- **DB**: `loadMarketSpreads(marketIds)` — single `DISTINCT ON` query over `orderbook_snapshots`, time-bounded to 30 min so stale books don't leak through.
- **Env**: `parseLiquidityFilterEnv` accepts `true`, `false`, or a numeric threshold like `0.07`. Clamped to `[0, 1]`; invalid values fall back to disabled (typo-safe).
- **Bridge**: `MarketLiquidityFilterBridge.applyLiquidityFilter` is the integration point. Wired into `PolymarketService.updateSignalEngineMarkets` — no-op when the env var is unset (default).

## Activation

Set in `docker-compose.gcp.yml`:
```yaml
ENABLE_LIQUIDITY_FILTER: \"true\"        # uses default 5% threshold
# or
ENABLE_LIQUIDITY_FILTER: \"0.07\"        # 7% custom threshold
```

The filter always logs its outcome — `[LiquidityFilter] threshold=0.05 kept=24 filtered=30 (missing_data=0)` — so operators can see impact before tightening the gate.

## Test plan

- [x] 15 unit tests in `MarketLiquidityFilter.test.ts` — all pass.
- [x] `pnpm exec vitest run packages/dashboard` — 404/404 pass.
- [x] `pnpm -r exec tsc --noEmit` — 0 errors.
- [ ] After deploy (still OFF by default): no behaviour change, no new logs.
- [ ] Stretch: enable in compose with a conservative threshold (10%), observe daily for spreads-vs-edge tradeoff before tightening to 5%.

## Not in scope

- Volume filter (Tier 2)
- Single-LP wash detection via top-3 trader concentration (Tier 3)
- Adjusting MarketRotator scoring to penalize wide spreads (separate concern)

Future work documented in `project_prediction_market_alpha_research.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)