### PR TITLE
fix(rotator): blend volume+market_score, add FORCE_INCLUDE_MARKET_IDS env

### DIFF
--- a/packages/dashboard/src/services/MarketSelector.test.ts
+++ b/packages/dashboard/src/services/MarketSelector.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseForceIncludeIds,
+  parseVolumeWeight,
+  rankMarketsByVolumeScoreBlend,
+  DEFAULT_VOLUME_WEIGHT,
+  type RankableMarket,
+} from './MarketSelector.js';
+
+describe('parseForceIncludeIds', () => {
+  it('returns empty set when env is unset', () => {
+    expect(parseForceIncludeIds(undefined).size).toBe(0);
+  });
+
+  it('returns empty set for empty string', () => {
+    expect(parseForceIncludeIds('').size).toBe(0);
+  });
+
+  it('parses single id', () => {
+    const ids = parseForceIncludeIds('abc');
+    expect(ids.has('abc')).toBe(true);
+    expect(ids.size).toBe(1);
+  });
+
+  it('parses comma-separated ids', () => {
+    const ids = parseForceIncludeIds('abc,def,ghi');
+    expect(ids.size).toBe(3);
+    expect(ids.has('abc')).toBe(true);
+    expect(ids.has('def')).toBe(true);
+    expect(ids.has('ghi')).toBe(true);
+  });
+
+  it('trims whitespace around ids', () => {
+    const ids = parseForceIncludeIds('  abc  ,   def , ghi  ');
+    expect(ids.size).toBe(3);
+    expect(ids.has('abc')).toBe(true);
+  });
+
+  it('ignores empty entries from trailing commas', () => {
+    const ids = parseForceIncludeIds('abc,,def,');
+    expect(ids.size).toBe(2);
+  });
+});
+
+describe('parseVolumeWeight', () => {
+  it('returns default when env unset', () => {
+    expect(parseVolumeWeight(undefined)).toBe(DEFAULT_VOLUME_WEIGHT);
+  });
+
+  it('parses valid number in [0, 1]', () => {
+    expect(parseVolumeWeight('0.3')).toBeCloseTo(0.3);
+    expect(parseVolumeWeight('0.0')).toBe(0);
+    expect(parseVolumeWeight('1.0')).toBe(1);
+  });
+
+  it('clamps below 0 to 0', () => {
+    expect(parseVolumeWeight('-0.5')).toBe(0);
+  });
+
+  it('clamps above 1 to 1', () => {
+    expect(parseVolumeWeight('1.5')).toBe(1);
+    expect(parseVolumeWeight('10')).toBe(1);
+  });
+
+  it('returns default on non-numeric input (typo-safe)', () => {
+    expect(parseVolumeWeight('abc')).toBe(DEFAULT_VOLUME_WEIGHT);
+    expect(parseVolumeWeight('')).toBe(DEFAULT_VOLUME_WEIGHT);
+  });
+});
+
+describe('rankMarketsByVolumeScoreBlend', () => {
+  const make = (id: string, volume: number, marketScore?: number): RankableMarket => ({
+    id, volume, marketScore,
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(rankMarketsByVolumeScoreBlend([], 0.5)).toEqual([]);
+  });
+
+  it('weight=1 sorts purely by volume desc', () => {
+    const m = [make('a', 100, 0.1), make('b', 300, 0.9), make('c', 200, 0.5)];
+    const ranked = rankMarketsByVolumeScoreBlend(m, 1);
+    expect(ranked.map(r => r.market.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('weight=0 sorts purely by marketScore desc (missing scores go last)', () => {
+    const m = [make('a', 999, 0.1), make('b', 1, 0.9), make('c', 500, undefined)];
+    const ranked = rankMarketsByVolumeScoreBlend(m, 0);
+    expect(ranked[0].market.id).toBe('b');
+    expect(ranked[1].market.id).toBe('a');
+    expect(ranked[2].market.id).toBe('c');  // missing score → last
+  });
+
+  it('weight=0.5 blends both: a high-volume-low-score and high-score-low-volume both rank high', () => {
+    // Volume rank:  big_vol=1, med=2, low_vol_high_score=3, small=4
+    // Score rank:   low_vol_high_score=1, big_vol=2, med=3, small=4
+    // Blended:      big_vol=1.5, low_vol_high_score=2.0, med=2.5, small=4.0
+    const m = [
+      make('big_vol', 1000, 0.5),
+      make('med', 500, 0.3),
+      make('low_vol_high_score', 100, 0.95),
+      make('small', 50, 0.1),
+    ];
+    const ranked = rankMarketsByVolumeScoreBlend(m, 0.5);
+    expect(ranked[0].market.id).toBe('big_vol');
+    expect(ranked[1].market.id).toBe('low_vol_high_score');
+    expect(ranked[2].market.id).toBe('med');
+    expect(ranked[3].market.id).toBe('small');
+  });
+
+  it('attaches diagnostic info: blendedRank, volumeRank, scoreRank', () => {
+    const m = [make('a', 100, 0.5), make('b', 200, 0.9)];
+    const ranked = rankMarketsByVolumeScoreBlend(m, 0.5);
+    expect(ranked[0].blendedRank).toBeDefined();
+    expect(ranked[0].volumeRank).toBeDefined();
+    expect(ranked[0].scoreRank).toBeDefined();
+    expect(ranked[0].blendedRank).toBeLessThanOrEqual(ranked[1].blendedRank);
+  });
+
+  it('handles ties in volume deterministically', () => {
+    const m = [make('a', 100, 0.5), make('b', 100, 0.5)];
+    const ranked = rankMarketsByVolumeScoreBlend(m, 0.5);
+    // Both should be present, order is determined by sort stability + input order
+    expect(ranked).toHaveLength(2);
+    expect(new Set(ranked.map(r => r.market.id))).toEqual(new Set(['a', 'b']));
+  });
+
+  it('missing marketScore on all markets — score rank determined by input order, blend still works', () => {
+    // Volume rank: b=1, c=2, a=3 (sorted by volume desc).
+    // Score rank: all -Infinity → stable sort keeps input order a=1, b=2, c=3.
+    // Blended @0.5: a=(3+1)/2/3=0.667  b=(1+2)/2/3=0.5  c=(2+3)/2/3=0.833.
+    // Best (lowest blended) → b; then a; then c.
+    const m = [make('a', 100), make('b', 300), make('c', 200)];
+    const ranked = rankMarketsByVolumeScoreBlend(m, 0.5);
+    expect(ranked[0].market.id).toBe('b');
+    expect(ranked[1].market.id).toBe('a');
+    expect(ranked[2].market.id).toBe('c');
+  });
+});

--- a/packages/dashboard/src/services/MarketSelector.ts
+++ b/packages/dashboard/src/services/MarketSelector.ts
@@ -1,0 +1,122 @@
+/**
+ * MarketSelector — pure helpers for ranking + force-include during the
+ * PolymarketService.selectDiversifiedMarkets step.
+ *
+ * The historical selector ordered markets by `volume` descending and grouped
+ * by category. That picked up high-action markets but systematically excluded
+ * markets in the cohorts that several generators (resolution_prior v1+v2,
+ * favorite_longshot_bias) need to fire on — those tend to have lower volume
+ * but high `MarketScorer.score`. This module replaces the pure-volume sort
+ * with a rank-based blend of volume and `market_score`, plus an opt-in
+ * `FORCE_INCLUDE_MARKET_IDS` env knob for controlled experiments.
+ *
+ * Pure: no DB / env access from `rankMarketsByVolumeScoreBlend`. Env access
+ * is isolated to the parse helpers so the wiring can be tested with explicit
+ * inputs.
+ */
+
+export interface RankableMarket {
+  id: string;
+  volume: number;
+  /** `markets.market_score`. Optional — populated when PolymarketService
+   *  fetches it from the DB. Absent markets sink to the bottom of the score
+   *  ranking but remain selectable via the volume rank. */
+  marketScore?: number;
+}
+
+/** Default ratio of volume vs market_score in the blended rank. 0.5 means
+ *  equal weight. Configurable via `MARKET_SELECTION_VOLUME_WEIGHT` env. */
+export const DEFAULT_VOLUME_WEIGHT = 0.5;
+
+/**
+ * Parse `FORCE_INCLUDE_MARKET_IDS` env var into a Set of market IDs.
+ *
+ * Comma-separated, whitespace-tolerant. Empty / unset → empty set (no-op).
+ * Markets in the returned set will be added to the active set regardless of
+ * volume / score / diversification rules. Useful for diagnostic experiments
+ * ("force the longshot 1323366 in so we can validate that
+ * favorite_longshot_bias actually fires on it end-to-end").
+ */
+export function parseForceIncludeIds(raw: string | undefined): Set<string> {
+  if (!raw) return new Set();
+  return new Set(
+    raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+}
+
+/**
+ * Parse `MARKET_SELECTION_VOLUME_WEIGHT` env var (a number in [0, 1]).
+ *
+ * `1` reproduces the legacy pure-volume behaviour. `0` selects purely by
+ * market_score. Default (`0.5`) gives equal weight, the recommended
+ * starting point. Invalid input falls back to default to avoid silent
+ * misconfiguration.
+ */
+export function parseVolumeWeight(raw: string | undefined): number {
+  if (raw === undefined || raw === '') return DEFAULT_VOLUME_WEIGHT;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return DEFAULT_VOLUME_WEIGHT;
+  return Math.max(0, Math.min(1, parsed));
+}
+
+export interface RankedMarket<T extends RankableMarket> {
+  market: T;
+  /** Normalised rank in `[1/N, 1]`; lower is better. */
+  blendedRank: number;
+  /** 1-indexed rank by volume (1 = highest volume). */
+  volumeRank: number;
+  /** 1-indexed rank by market_score (1 = highest). Markets without a score
+   *  share the bottom rank — counted once per missing-score entry. */
+  scoreRank: number;
+}
+
+/**
+ * Rank a list of markets by a convex combination of volume rank and
+ * market_score rank. Returns markets sorted ascending by blended rank
+ * (best first).
+ *
+ * Why rank-based and not value-based: one whale market with 100× the
+ * volume of the rest would dominate any value-based blend. Ranks compress
+ * everything into `[1, N]` so a high-score-low-volume market and a
+ * high-volume-mediocre-score market can both surface.
+ */
+export function rankMarketsByVolumeScoreBlend<T extends RankableMarket>(
+  markets: T[],
+  volumeWeight: number,
+): RankedMarket<T>[] {
+  if (markets.length === 0) return [];
+
+  const N = markets.length;
+  const w = Math.max(0, Math.min(1, volumeWeight));
+
+  // Volume rank: 1 = highest volume. Stable sort preserves input order on ties.
+  const byVolume = [...markets].sort((a, b) => b.volume - a.volume);
+  const volumeRankMap = new Map<string, number>();
+  byVolume.forEach((m, i) => volumeRankMap.set(m.id, i + 1));
+
+  // Score rank: 1 = highest score. Markets without a score get pushed to the
+  // bottom — they share the same effective rank N. This way a market with
+  // missing score is comparable but never beats a scored market on the
+  // score axis.
+  const byScore = [...markets].sort((a, b) => {
+    const aScore = a.marketScore ?? -Infinity;
+    const bScore = b.marketScore ?? -Infinity;
+    return bScore - aScore;
+  });
+  const scoreRankMap = new Map<string, number>();
+  byScore.forEach((m, i) => scoreRankMap.set(m.id, i + 1));
+
+  const ranked = markets.map((market) => {
+    const volumeRank = volumeRankMap.get(market.id)!;
+    const scoreRank = scoreRankMap.get(market.id)!;
+    // Normalise to [1/N, 1]; lower is better.
+    const blendedRank = (w * volumeRank + (1 - w) * scoreRank) / N;
+    return { market, blendedRank, volumeRank, scoreRank };
+  });
+
+  ranked.sort((a, b) => a.blendedRank - b.blendedRank);
+  return ranked;
+}

--- a/packages/dashboard/src/services/PolymarketService.ts
+++ b/packages/dashboard/src/services/PolymarketService.ts
@@ -10,6 +10,11 @@ import { isDatabaseConfigured, query } from '../database/index.js';
 import { getSignalEngine } from './SignalEngine.js';
 import { getDataCollectorService, type PriceData } from './DataCollectorService.js';
 import { applyLiquidityFilter } from './MarketLiquidityFilterBridge.js';
+import {
+  parseForceIncludeIds,
+  parseVolumeWeight,
+  rankMarketsByVolumeScoreBlend,
+} from './MarketSelector.js';
 
 export interface PolymarketConfig {
   apiUrl: string;
@@ -64,6 +69,9 @@ export interface PolymarketMarket {
   category: string;  // Primary category for diversification
   marketType?: string;  // crypto_intraday, crypto_daily, event_short, event_long
   trackingStatus?: string;
+  /** `markets.market_score` — populated when fetched from DB. Drives the
+   *  blended ranking inside selectDiversifiedMarkets (volume + score). */
+  marketScore?: number;
 }
 
 export interface PolymarketPrice {
@@ -346,10 +354,30 @@ export class PolymarketService extends EventEmitter {
    * Ensures no single category dominates the selection
    */
   private selectDiversifiedMarkets(allMarkets: PolymarketMarket[]): PolymarketMarket[] {
-    // Group markets by category
-    const byCategory = new Map<string, PolymarketMarket[]>();
+    const maxPerCategory = this.config.maxMarketsPerCategory;
+    const maxTotal = this.config.maxMarketsToTrack;
 
-    for (const market of allMarkets) {
+    const forceIds = parseForceIncludeIds(process.env.FORCE_INCLUDE_MARKET_IDS);
+    const volumeWeight = parseVolumeWeight(process.env.MARKET_SELECTION_VOLUME_WEIGHT);
+
+    // Step 1: pin force-included markets at the top, regardless of volume/score.
+    const forced = allMarkets.filter(m => forceIds.has(m.id));
+    const missingForced = [...forceIds].filter(id => !forced.some(m => m.id === id));
+    if (forced.length > 0) {
+      console.log(`[PolymarketService] Force-included ${forced.length} markets: ${forced.map(m => m.id).join(',')}`);
+    }
+    if (missingForced.length > 0) {
+      console.log(`[PolymarketService] Force-include IDs not in candidate set (skipped): ${missingForced.join(',')}`);
+    }
+
+    // Step 2: rank the non-forced pool by blended volume + market_score.
+    const candidates = allMarkets.filter(m => !forceIds.has(m.id));
+    const ranked = rankMarketsByVolumeScoreBlend(candidates, volumeWeight);
+    const rankMap = new Map(ranked.map(r => [r.market.id, r.blendedRank]));
+
+    // Step 3: diversify by category, taking the highest-ranked first.
+    const byCategory = new Map<string, PolymarketMarket[]>();
+    for (const { market } of ranked) {
       const cat = market.category;
       if (!byCategory.has(cat)) {
         byCategory.set(cat, []);
@@ -357,42 +385,38 @@ export class PolymarketService extends EventEmitter {
       byCategory.get(cat)!.push(market);
     }
 
-    // Sort each category by volume (highest first)
-    for (const markets of byCategory.values()) {
-      markets.sort((a, b) => b.volume - a.volume);
-    }
-
-    const selected: PolymarketMarket[] = [];
-    const maxPerCategory = this.config.maxMarketsPerCategory;
-    const maxTotal = this.config.maxMarketsToTrack;
-
-    // First pass: take up to maxPerCategory from each category
+    const selected: PolymarketMarket[] = [...forced];
     for (const [category, markets] of byCategory) {
       const toTake = Math.min(maxPerCategory, markets.length);
       selected.push(...markets.slice(0, toTake));
       console.log(`[PolymarketService] Category '${category}': ${toTake}/${markets.length} markets selected`);
     }
 
-    // If we have less than maxTotal, fill with remaining high-volume markets
+    // Step 4: fill remaining slots with the next best by blended rank.
     if (selected.length < maxTotal) {
       const selectedIds = new Set(selected.map(m => m.id));
-      const remaining = allMarkets
-        .filter(m => !selectedIds.has(m.id))
-        .sort((a, b) => b.volume - a.volume);
+      const remaining = ranked
+        .map(r => r.market)
+        .filter(m => !selectedIds.has(m.id));
 
       const needed = maxTotal - selected.length;
       selected.push(...remaining.slice(0, needed));
 
       if (remaining.length > 0) {
-        console.log(`[PolymarketService] Added ${Math.min(needed, remaining.length)} additional high-volume markets`);
+        console.log(`[PolymarketService] Added ${Math.min(needed, remaining.length)} additional ranked markets (volumeWeight=${volumeWeight})`);
       }
     }
 
-    // If we have more than maxTotal, trim (shouldn't happen with proper config)
+    // Step 5: trim if we overshoot. Force-included markets are preserved;
+    // non-forced trimming preserves blended-rank order.
     if (selected.length > maxTotal) {
-      // Sort by volume and keep top N
-      selected.sort((a, b) => b.volume - a.volume);
-      selected.length = maxTotal;
+      const forcedKeep = selected.filter(m => forceIds.has(m.id));
+      const nonForced = selected
+        .filter(m => !forceIds.has(m.id))
+        .sort((a, b) => (rankMap.get(a.id) ?? Infinity) - (rankMap.get(b.id) ?? Infinity));
+      const overflow = selected.length - maxTotal;
+      console.log(`[PolymarketService] Trimming ${overflow} markets to enforce maxMarketsToTrack=${maxTotal}`);
+      return [...forcedKeep, ...nonForced.slice(0, Math.max(0, maxTotal - forcedKeep.length))];
     }
 
     return selected;
@@ -430,6 +454,7 @@ export class PolymarketService extends EventEmitter {
         is_active: boolean;
         market_type: string | null;
         tracking_status: string | null;
+        market_score: string | null;
       }>(`
         SELECT
           m.id, m.condition_id, m.question, m.category,
@@ -437,7 +462,8 @@ export class PolymarketService extends EventEmitter {
           m.current_price_yes, m.current_price_no,
           m.volume_24h, m.liquidity, m.end_date, m.is_active,
           m.market_type,
-          m.tracking_status
+          m.tracking_status,
+          m.market_score
         FROM markets m
         WHERE m.is_active = true
           AND m.is_resolved = false
@@ -495,6 +521,7 @@ export class PolymarketService extends EventEmitter {
           category: m.category || category,
           marketType: m.market_type || undefined,
           trackingStatus: m.tracking_status || undefined,
+          marketScore: m.market_score != null ? parseFloat(m.market_score) : undefined,
         };
 
         candidateMarkets.push(market);


### PR DESCRIPTION
## The bug

`PolymarketService.selectDiversifiedMarkets` ordered markets by `m.volume` descending. Discovered 2026-05-17 14:48 UTC post-PR #237 deploy:

```
Predictions last 1h, by signal:
  momentum:        677     ✓
  ofi:             660     ✓
  mlofi:           469     ✓
  cross_market_corr: 113
  mean_reversion:   96
  news_sentiment:   58
  spread_compression: 3

  resolution_prior:        0   ← v1, structurally exists, exists in active set, never fires
  resolution_prior_v2:     0   ← brand-new (PR #237)
  favorite_longshot_bias:  0   ← brand-new (PR #234)
```

Of the 31 active markets selected by volume out of 71 tracked: 0 have `TTR ≤ 7d`, 0 have `current_price_yes < 0.10` or `> 0.90`. The 3 generators that need those cohorts had **zero data to fire on**. The empirical Phase 5 measurement cron (02:30 UTC) would have produced no new t_net data for them.

## The fix

Rank-based convex blend of volume rank and `markets.market_score` rank:

```
blendedRank = w × volumeRank + (1 − w) × scoreRank
```

- `w = 1` → legacy pure-volume behaviour (reversible via env).
- `w = 0` → pure score-based selection.
- `w = 0.5` (default) → equal weight.

Configurable via `MARKET_SELECTION_VOLUME_WEIGHT`. Defaults to 0.5 — picks up the high-score-but-low-volume cohorts (longshots, near-resolution primaries) while keeping the volume-heavy markets that are still in the top half of the joint ranking.

## The knob

`FORCE_INCLUDE_MARKET_IDS=id1,id2,id3` — comma-separated allowlist that bypasses the selector entirely (still counts against the `maxMarketsToTrack` budget). Intended for diagnostic experiments — pin specific markets to verify a generator fires end-to-end without waiting for the rotator to converge.

Example use case: tomorrow, set `FORCE_INCLUDE_MARKET_IDS=837734,1323366` to pin the Georgia primary and Ukraine ceasefire markets. If `resolution_prior_v2` and `favorite_longshot_bias` then emit predictions on them, we have empirical confirmation that the generators work end-to-end. Without the force-include, we'd have to wait for the rotator to organically select these markets, which may never happen given their low volume.

## Changes

- New: `MarketSelector.ts` (122 LoC) — pure helpers + types.
- New: `MarketSelector.test.ts` (139 LoC) — 18 unit tests covering parse edge-cases, rank blend boundaries, missing scores, ties.
- `PolymarketService.ts`:
  - Adds `marketScore?: number` to `PolymarketMarket` interface.
  - Adds `m.market_score` to the discoverMarkets SQL.
  - Rewrites `selectDiversifiedMarkets` to use force-include + blended ranking.

## Defaults

Both env knobs default to no-op-equivalent for safety:
- `MARKET_SELECTION_VOLUME_WEIGHT=0.5` (unset) — gentle shift from pure-volume.
- `FORCE_INCLUDE_MARKET_IDS=` (unset) — no forced markets.

Legacy behaviour is reachable with `MARKET_SELECTION_VOLUME_WEIGHT=1`.

## Test plan

- [x] 18 new unit tests pass.
- [x] `pnpm exec vitest run packages/dashboard` — 422/422 pass.
- [x] `pnpm -r exec tsc --noEmit` — 0 errors.
- [ ] After deploy: verify SignalEngine `marketCount` is still ≤ 50 (no overrun).
- [ ] After 1 cycle (~60 s post deploy): verify at least one of the 3 dormant generators starts emitting predictions.
- [ ] Optional next step (separate PR or compose edit): set `FORCE_INCLUDE_MARKET_IDS=837734,1323366` in `docker-compose.gcp.yml` to validate end-to-end firing of RPv2 + FLB.

## Related

- PR #234 (favorite_longshot_bias)
- PR #237 (resolution_prior_v2)
- `project_session_2026-05-17_wrap.md` — the original finding writeup

🤖 Generated with [Claude Code](https://claude.com/claude-code)