### PR TITLE
fix(rotator): lower default minVolume24h to 500, FORCE_INCLUDE bypasses SQL

### DIFF
--- a/packages/dashboard/src/services/PolymarketService.ts
+++ b/packages/dashboard/src/services/PolymarketService.ts
@@ -41,7 +41,14 @@ const DEFAULT_CONFIG: PolymarketConfig = {
   marketsToFetch: 200,       // Fetch more for diversified selection
   maxMarketsPerCategory: 8,  // Max 8 per category ensures diversity across ~6+ categories
   autoDiscoverMarkets: true,
-  minVolume24h: 1000,
+  // Default lowered from 1000 → 500 on 2026-05-17. The 1000 threshold was
+  // hiding low-volume but resolution-soon markets (e.g. primaries) that the
+  // resolution_prior v1+v2 generators need to fire on. Tune via env
+  // POLYMARKET_MIN_VOLUME_24H.
+  minVolume24h: (() => {
+    const parsed = Number(process.env.POLYMARKET_MIN_VOLUME_24H);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 500;
+  })(),
   minLiquidity: 500,
   // Rate limiting - very conservative to avoid 429s
   requestDelayMs: 1000,         // 1 second between requests (1 req/sec max)
@@ -438,7 +445,12 @@ export class PolymarketService extends EventEmitter {
       const MAX_PRICE = 0.98;
 
       // Only select markets that have recent price_history data (last 24 hours)
-      // This ensures signals are never generated for markets without real price data
+      // This ensures signals are never generated for markets without real price data.
+      // Force-included IDs (FORCE_INCLUDE_MARKET_IDS env) bypass the volume +
+      // price-history filters but still must have a YES token, an active status,
+      // and a sane price range — those are correctness preconditions for the
+      // downstream engine, not selection filters.
+      const forceIds = Array.from(parseForceIncludeIds(process.env.FORCE_INCLUDE_MARKET_IDS));
       const marketsResult = await query<{
         id: string;
         condition_id: string;
@@ -471,16 +483,23 @@ export class PolymarketService extends EventEmitter {
           AND m.clob_token_id_yes IS NOT NULL AND m.clob_token_id_yes != ''
           AND m.current_price_yes > $1
           AND m.current_price_yes < $2
-          AND m.volume_24h >= $3
-          AND EXISTS (
-            SELECT 1 FROM price_history ph
-            WHERE ph.token_id = m.clob_token_id_yes
-              AND ph.time > NOW() - INTERVAL '24 hours'
-            LIMIT 1
+          AND (
+            -- Normal path: above volume threshold AND has recent price history
+            (m.volume_24h >= $3
+              AND EXISTS (
+                SELECT 1 FROM price_history ph
+                WHERE ph.token_id = m.clob_token_id_yes
+                  AND ph.time > NOW() - INTERVAL '24 hours'
+                LIMIT 1
+              ))
+            OR
+            -- Force-include bypass: explicitly allow-listed markets skip the
+            -- volume + price-history filters above.
+            m.id = ANY($5::varchar[])
           )
         ORDER BY m.volume_24h DESC NULLS LAST
         LIMIT $4
-      `, [MIN_PRICE, MAX_PRICE, this.config.minVolume24h, this.config.marketsToFetch]);
+      `, [MIN_PRICE, MAX_PRICE, this.config.minVolume24h, this.config.marketsToFetch, forceIds]);
 
       console.log(`[PolymarketService] Found ${marketsResult.rows.length} markets with recent price data (filtered by price_history)`);
 


### PR DESCRIPTION
## Why

Follow-up to PR #238 after post-deploy empirical verification. The rotator blend was now correct, but the **underlying DB query still returned only 31 candidates out of 71 tracked markets**. Two binding filters in `discoverMarkets`:

1. **`minVolume24h` hardcoded to 1000**: excluded e.g. market 837734 (Georgia Governor primary, TTR ~2 days, vol 877) — exactly the cohort `resolution_prior` v1 + v2 need to fire on.
2. **`FORCE_INCLUDE_MARKET_IDS` env (PR #238) was a silent no-op**: it operated only on the post-query JS list. Markets that fail the SQL filters (volume + price_history) never reached the JS code, so the knob did nothing for the cases that motivated its introduction.

## Changes

1. **`minVolume24h` env-configurable**: defaults to **500** (down from 1000), overridable via `POLYMARKET_MIN_VOLUME_24H`. Setting `0` makes the filter inactive.
2. **SQL force-include bypass**: query now adds `... OR m.id = ANY($5::varchar[])` where `$5` is the parsed force-include list. Explicitly allow-listed IDs skip the volume + price-history checks.

Correctness preconditions retained even for force-include:
- `is_active = true`
- `is_resolved = false`
- `tracking_status != 'cold'`
- `clob_token_id_yes IS NOT NULL AND != ''`
- `current_price_yes ∈ (0.02, 0.98)`

Bypassing those would feed the engine garbage.

## Empirical pre/post

Pre this PR (with PR #238 deployed):
```
[PolymarketService] Found 31 markets with recent price data (filtered by price_history)
```

Predicted post (no env change, just lower default):
```
[PolymarketService] Found 34+ markets...   (≥ +3 from threshold drop)
```

With `FORCE_INCLUDE_MARKET_IDS=837734` (Georgia primary):
```
[PolymarketService] Force-included 1 markets: 837734
```
→ should unblock `resolution_prior` v1 + v2 firing on it within one signal cycle.

## Test plan

- [x] `pnpm exec vitest run packages/dashboard` — 422/422 pass.
- [x] `pnpm -r exec tsc --noEmit` — 0 errors.
- [ ] After deploy: log shows `Found N markets` with N > 31.
- [ ] Optional next: set `FORCE_INCLUDE_MARKET_IDS=837734` in compose, observe predictions for that market id with `signal_id IN ('resolution_prior', 'resolution_prior_v2')` populate within ~60s.

## Related

- PR #238 (rotator blend + force-include JS-level)
- `project_session_2026-05-17_wrap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Market discovery now supports force-including specific markets that may not meet standard filtering criteria.

* **Improvements**
  * Minimum volume threshold for market discovery is now configurable via environment settings, with a default value of 500.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->