### PR TITLE
fix(signal-engine): thread market.endDate into SignalContext

### DIFF
--- a/packages/dashboard/src/services/SignalEngine.ts
+++ b/packages/dashboard/src/services/SignalEngine.ts
@@ -693,6 +693,13 @@ export class SignalEngine extends EventEmitter {
         tokenIdNo: market.tokenIdNo,
         currentPriceYes: market.currentPrice,
         volume24h: market.volume24h,
+        // Resolution-aware generators (resolution_prior v1+v2) gate firing
+        // on `isReady` requiring endDate. Without this line they're wired
+        // but ineffective — predictions table will show zero rows for them
+        // forever. Verified empirically 2026-05-17 16:45 UTC: 837734
+        // (Georgia primary, TTR 2d) had momentum/ofi/mlofi predictions but
+        // zero RPv1/RPv2 because endDate was undefined here.
+        endDate: market.endDate ?? undefined,
       };
 
       // Fetch latest order book snapshot from DB
@@ -1115,6 +1122,7 @@ export class SignalEngine extends EventEmitter {
       tokenIdYes: market.tokenIdYes,
       tokenIdNo: market.tokenIdNo,
       currentPriceYes: market.currentPrice,
+      endDate: market.endDate ?? undefined,
     };
 
     return {


### PR DESCRIPTION
## The bug

`ResolutionPriorGenerator` (v1, in production for weeks) and `ResolutionPriorV2Generator` (PR #237) both gate `isReady()` on `context.market.endDate`. `SignalEngine.buildSignalContext` built `MarketInfo` **without** an `endDate` field — even though the upstream `ActiveMarket` carries it from `PolymarketService`.

Net effect: both generators returned \`isReady = false\` for every market, so `compute()` was never called and `generator_predictions` got zero rows for them. This is a **pre-existing bug for v1** — surfaced now while validating Sprint 2 generators.

## Empirical pre/post

Pre (verified 2026-05-17 16:45 UTC, after PRs #238 + #239 unblocked the rotator):
```
Market 837734 (Georgia primary, TTR ≈ 2 days, 1839 price bars):
  momentum: 6 predictions, ofi: 6, mlofi: 6
  resolution_prior:    0
  resolution_prior_v2: 0
```

Post (expected): both `resolution_prior` and `resolution_prior_v2` start firing on 837734 within ~60s of deploy. After 24h, Phase 5 cron 02:30 UTC will measure cost-aware t_net for them for the first time.

## Fix

One-line addition to `buildSignalContext` and `buildMockContext`:
```ts
endDate: market.endDate ?? undefined,
```

`MarketInfo.endDate` is already optional per the type definition; the engine just wasn't populating it.

## Test plan

- [x] `pnpm exec vitest run packages/dashboard` — 422/422 pass.
- [x] `pnpm -r exec tsc --noEmit` — 0 errors.
- [ ] After deploy: verify `generator_predictions` accumulates rows with `signal_id IN ('resolution_prior', 'resolution_prior_v2')` for any market with `end_date` set.

## Related

- PR #234 / PR #237 (Sprint 2 generators)
- PR #238 / PR #239 (rotator fix that surfaced this)
- `project_session_2026-05-17_wrap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved an issue where signal generators requiring date information could not operate properly. The system now correctly supplies the necessary end-date information to all signal generators during both standard and test operations, ensuring that date-dependent generators function correctly and deliver accurate outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->