### PR TITLE
feat(data-collector): force-track experiment cohort for Sprint 2 measurement

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -74,9 +74,18 @@ services:
       GAMMA_API_URL: https://gamma-api.polymarket.com
       CLOB_API_URL: https://clob.polymarket.com
       DATA_API_URL: https://data-api.polymarket.com
-      MAX_TRACKED_MARKETS: "35"
+      MAX_TRACKED_MARKETS: "45"
       ALLOWED_MARKET_TYPES: "crypto_intraday,crypto_daily,event_financial,event_short"
       MAX_SHADOW_MARKETS: "10"
+      # Force-tracked experiment cohort (Sprint 2 measurement, 2026-05-18).
+      # The volume/score-biased rotator never promotes tail-band markets, so
+      # favorite_longshot_bias / resolution_prior_v2 are starved of their target
+      # markets and cannot accumulate cost-aware edge measurement. These 12
+      # liquid tail-band markets (Yes price 0.03–0.09) are pinned to `active`
+      # tracking. MarketRotator.applyForceInclude() reads this var. Curate /
+      # prune as cohort markets resolve. Same var the dashboard reads for
+      # signal inclusion. Remove when Sprint 2 measurement concludes.
+      FORCE_INCLUDE_MARKET_IDS: "616905,616906,948956,948957,1144471,1654959,1294363,1032269,951180,1652691,1818152,1032270"
       DB_POOL_MAX: "8"
       DB_IDLE_TIMEOUT_MS: "10000"
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
@@ -124,7 +133,14 @@ services:
       DB_IDLE_TIMEOUT_MS: "10000"
       ENABLE_SIGNAL_ENGINE: "true"
       SIGNAL_INTERVAL_MS: "300000"
-      MAX_SIGNAL_MARKETS: "35"
+      # Raised 35→45 (2026-05-18) so the 12-market force-include cohort and the
+      # ~33 merit-selected markets both fit a signal cycle without the cohort
+      # squeezing trading-market coverage.
+      MAX_SIGNAL_MARKETS: "45"
+      # Force-tracked experiment cohort — same list as the data-collector.
+      # MarketSelector pins these to the signal-selection pool so the Sprint 2
+      # generators receive predictions on their target tail-band markets.
+      FORCE_INCLUDE_MARKET_IDS: "616905,616906,948956,948957,1144471,1654959,1294363,1032269,951180,1652691,1818152,1032270"
       ENABLE_OPTIMIZATION: "true"
       OPTIMIZER_URL: "https://polymarket-optimizer-server.onrender.com"
       # Min Sharpe lift required to flip direction_multiplier per market_type.

--- a/packages/data-collector/src/services/MarketRotator.test.ts
+++ b/packages/data-collector/src/services/MarketRotator.test.ts
@@ -6,6 +6,7 @@ import {
   type RotationConfig,
   type MarketRow,
   parseAllowedMarketTypes,
+  parseForceIncludeIds,
 } from './MarketRotator.js';
 
 vi.mock('../database/connection.js', () => ({
@@ -47,6 +48,20 @@ describe('parseAllowedMarketTypes', () => {
       'crypto_intraday',
       'event_short',
     ]);
+  });
+});
+
+describe('parseForceIncludeIds', () => {
+  it('returns empty array when env is undefined', () => {
+    expect(parseForceIncludeIds(undefined)).toEqual([]);
+  });
+
+  it('returns empty array when env is empty string', () => {
+    expect(parseForceIncludeIds('')).toEqual([]);
+  });
+
+  it('parses comma-separated ids, trimming whitespace and dropping empties', () => {
+    expect(parseForceIncludeIds(' 906973, 1652691 ,,')).toEqual(['906973', '1652691']);
   });
 });
 
@@ -774,5 +789,120 @@ describe('MarketRotator', () => {
       expect(updateSqlsSeen[1]).toMatch(/price_history/);
       expect(updateSqlsSeen[1]).toMatch(/INTERVAL '6 hours'/);
     });
+  });
+});
+
+// ── FORCE_INCLUDE_MARKET_IDS — force-tracked experiment cohort ──────
+//
+// The data-collector's volume/score-biased rotation never promotes
+// tail-band or near-resolution markets (low market_score, low volume),
+// so the Sprint 2 generators (favorite_longshot_bias, resolution_prior_v2)
+// are starved of their target markets and cannot accumulate the sample
+// size needed for cost-aware edge measurement. FORCE_INCLUDE_MARKET_IDS
+// pins a curated cohort to `active` regardless of score — a measurement
+// instrument, decoupled from the merit-based rotator.
+describe('FORCE_INCLUDE_MARKET_IDS — force-tracked experiment cohort', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('constructor reads FORCE_INCLUDE_MARKET_IDS env into the force-include set', () => {
+    vi.stubEnv('FORCE_INCLUDE_MARKET_IDS', '906973,1652691');
+    const r = new MarketRotator();
+    expect(r.getForceIncludeIds().sort()).toEqual(['1652691', '906973']);
+  });
+
+  it('getForceIncludeIds is empty when env unset', () => {
+    const r = new MarketRotator();
+    expect(r.getForceIncludeIds()).toEqual([]);
+  });
+
+  describe('demotion exemption', () => {
+    it('does NOT demote a force-included active market even with extreme price', () => {
+      vi.stubEnv('FORCE_INCLUDE_MARKET_IDS', 'cohort-1');
+      const r = new MarketRotator(DEFAULT_CONFIG);
+      const active = [
+        makeMarket({ id: 'cohort-1', market_score: 0.10, tracking_status: 'active', current_price_yes: 0.03, has_open_positions: false }),
+        makeMarket({ id: 'normal-extreme', market_score: 0.10, tracking_status: 'active', current_price_yes: 0.03, has_open_positions: false }),
+      ];
+      const result = r.selectDemotions(active, []);
+      const ids = result.map(m => m.id);
+      expect(ids).not.toContain('cohort-1');
+      expect(ids).toContain('normal-extreme');
+    });
+
+    it('does NOT demote a force-included active market with low score below hysteresis', () => {
+      vi.stubEnv('FORCE_INCLUDE_MARKET_IDS', 'cohort-1');
+      const r = new MarketRotator(DEFAULT_CONFIG);
+      const active = [
+        makeMarket({ id: 'cohort-1', market_score: 0.05, tracking_status: 'active', current_price_yes: 0.50, has_open_positions: false }),
+      ];
+      const candidates = [makeMarket({ id: 'cand', market_score: 0.90, tracking_status: 'cold' })];
+      const result = r.selectDemotions(active, candidates);
+      expect(result).toHaveLength(0);
+    });
+
+    it('does NOT demote a force-included warming market even if stale and extreme', () => {
+      vi.stubEnv('FORCE_INCLUDE_MARKET_IDS', 'cohort-1');
+      const r = new MarketRotator(DEFAULT_CONFIG);
+      const warming = [
+        makeMarket({ id: 'cohort-1', tracking_status: 'warming', current_price_yes: 0.02, bars_24h: 0, tracking_status_changed_at: new Date(Date.now() - 12 * 3600_000) }),
+      ];
+      const result = r.selectWarmingDemotions(warming);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('applyForceInclude', () => {
+    it('issues an UPDATE promoting non-active, valid force-included markets to active', async () => {
+      vi.stubEnv('FORCE_INCLUDE_MARKET_IDS', '906973,1652691');
+      const r = new MarketRotator(DEFAULT_CONFIG);
+
+      let sql: string | null = null;
+      let params: unknown[] | null = null;
+      mockedQuery.mockImplementation(async (q: string, p?: unknown[]) => {
+        sql = q;
+        params = p ?? null;
+        return { rows: [], command: 'UPDATE', rowCount: 2, oid: 0, fields: [] };
+      });
+
+      const promoted = await r.applyForceInclude();
+
+      expect(promoted).toBe(2);
+      expect(sql).toMatch(/UPDATE markets/);
+      expect(sql).toMatch(/tracking_status = 'active'/);
+      expect(sql).toMatch(/id = ANY\(\$1::text\[\]\)/);
+      expect(sql).toMatch(/is_resolved = false/);
+      expect(sql).toMatch(/end_date IS NULL OR end_date > NOW/);
+      expect(params).toEqual([['906973', '1652691']]);
+    });
+
+    it('issues NO query when the force-include set is empty', async () => {
+      const r = new MarketRotator(DEFAULT_CONFIG);
+      const promoted = await r.applyForceInclude();
+      expect(promoted).toBe(0);
+      expect(mockedQuery).not.toHaveBeenCalled();
+    });
+  });
+
+  it('rotateAll runs applyForceInclude — force-include UPDATE present after the two evictions', async () => {
+    vi.stubEnv('FORCE_INCLUDE_MARKET_IDS', '906973');
+    const r = new MarketRotator();
+    const updateSqls: string[] = [];
+    mockedQuery.mockImplementation(async (sql: string) => {
+      if (typeof sql === 'string' && sql.trimStart().startsWith('UPDATE')) {
+        updateSqls.push(sql.trim());
+      }
+      return { rows: [], command: 'SELECT', rowCount: 0, oid: 0, fields: [] };
+    });
+
+    await r.rotateAll();
+
+    // 2 evictions + 1 force-include
+    expect(updateSqls).toHaveLength(3);
+    expect(
+      updateSqls.some(s => /id = ANY\(\$1::text\[\]\)/.test(s) && /tracking_status = 'active'/.test(s))
+    ).toBe(true);
   });
 });

--- a/packages/data-collector/src/services/MarketRotator.ts
+++ b/packages/data-collector/src/services/MarketRotator.ts
@@ -19,6 +19,23 @@ export function parseAllowedMarketTypes(raw: string | undefined): string[] {
     .filter(Boolean);
 }
 
+/**
+ * Parse the FORCE_INCLUDE_MARKET_IDS env value into a clean array of market IDs.
+ * Empty / undefined / whitespace-only entries are dropped.
+ * These IDs are pinned to `active` tracking regardless of score/volume — a
+ * measurement instrument for generators whose target markets (tail-band,
+ * near-resolution) the merit-based rotator would never surface on its own.
+ * Same env var the dashboard's MarketSelector reads, so a single compose entry
+ * drives both data collection (here) and signal inclusion (dashboard).
+ */
+export function parseForceIncludeIds(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map(id => id.trim())
+    .filter(Boolean);
+}
+
 export interface RotationConfig {
   maxTracked: number;              // 40 (from MAX_TRACKED_MARKETS env)
   maxRotationsPerHour: number;     // 5
@@ -69,6 +86,9 @@ export class MarketRotator {
   private liveConfig: RotationConfig;
   private shadowConfig: RotationConfig;
   private allowedTypes: string[];
+  // Curated market IDs pinned to `active` regardless of score/volume.
+  // Exempt from all demotion paths; promoted by applyForceInclude().
+  private forceIncludeIds: Set<string>;
   // The "active" config used by helper methods that read this.config.
   // Mutated by rotate(lane) — safe because rotateAll runs lanes sequentially.
   private config: RotationConfig;
@@ -84,6 +104,7 @@ export class MarketRotator {
       ...shadowConfig,
     };
     this.allowedTypes = parseAllowedMarketTypes(process.env.ALLOWED_MARKET_TYPES);
+    this.forceIncludeIds = new Set(parseForceIncludeIds(process.env.FORCE_INCLUDE_MARKET_IDS));
     // Default to live config so any helper called without going through rotate()
     // (e.g. existing tests of selectDemotions/selectPromotions) keep behaving as
     // they did pre-refactor.
@@ -96,6 +117,10 @@ export class MarketRotator {
 
   getShadowMaxTracked(): number {
     return this.shadowConfig.maxTracked;
+  }
+
+  getForceIncludeIds(): string[] {
+    return [...this.forceIncludeIds];
   }
 
   /**
@@ -145,8 +170,12 @@ export class MarketRotator {
    * capped at maxRotationsPerHour.
    */
   selectDemotions(active: MarketRow[], candidates: MarketRow[]): MarketRow[] {
+    // Force-included markets are pinned to active — never demote them, even
+    // when extreme-priced (their whole purpose is tail-band measurement).
     // Extreme-price markets are force-demoted even without candidates
-    const extremeEligible = active.filter(m => !m.has_open_positions && this.isExtremePrice(m));
+    const extremeEligible = active.filter(
+      m => !m.has_open_positions && !this.forceIncludeIds.has(m.id) && this.isExtremePrice(m),
+    );
 
     if (candidates.length === 0) {
       return extremeEligible
@@ -159,7 +188,12 @@ export class MarketRotator {
     const threshold = bestCandidateScore * this.config.hysteresisRatio;
 
     const eligible = active
-      .filter(m => !m.has_open_positions && (this.isExtremePrice(m) || m.market_score < threshold))
+      .filter(
+        m =>
+          !m.has_open_positions &&
+          !this.forceIncludeIds.has(m.id) &&
+          (this.isExtremePrice(m) || m.market_score < threshold),
+      )
       .sort((a, b) => a.market_score - b.market_score); // worst first
 
     return eligible.slice(0, this.config.maxRotationsPerHour);
@@ -193,6 +227,8 @@ export class MarketRotator {
 
     return warming.filter(m => {
       if (m.has_open_positions) return false;
+      // Force-included markets are pinned — never demote, even if stale/extreme.
+      if (this.forceIncludeIds.has(m.id)) return false;
 
       // Criterion 1: extreme price
       if (this.isExtremePrice(m)) return true;
@@ -414,6 +450,42 @@ export class MarketRotator {
   }
 
   /**
+   * Promote the FORCE_INCLUDE_MARKET_IDS cohort to `active` tracking.
+   *
+   * The merit-based rotator ranks cold candidates by market_score, which is
+   * volume/tradeability-biased: tail-band and near-resolution markets score low
+   * and are never promoted. That starves the Sprint 2 generators
+   * (favorite_longshot_bias, resolution_prior_v2) of their target markets, so
+   * they cannot accumulate the sample size needed for cost-aware edge
+   * measurement. This bypass pins a curated cohort to `active` directly.
+   *
+   * Only valid markets are promoted — active, not resolved, not past end_date.
+   * Already-active markets and the eviction step keep resolved cohort markets
+   * from being re-promoted. No-op when the env var is unset.
+   *
+   * @returns number of markets transitioned to `active`.
+   */
+  async applyForceInclude(): Promise<number> {
+    if (this.forceIncludeIds.size === 0) return 0;
+
+    const ids = [...this.forceIncludeIds];
+    const res = await query(
+      `UPDATE markets SET tracking_status = 'active', tracking_status_changed_at = NOW()
+       WHERE id = ANY($1::text[])
+         AND tracking_status <> 'active'
+         AND is_active = true AND is_resolved = false
+         AND (end_date IS NULL OR end_date > NOW())`,
+      [ids],
+    );
+
+    const promoted = res.rowCount ?? 0;
+    if (promoted > 0) {
+      logger.info({ promoted, forceIncludeIds: ids }, 'Force-included markets promoted to active');
+    }
+    return promoted;
+  }
+
+  /**
    * Run rotation for both lanes sequentially. Live lane operates on
    * ALLOWED_MARKET_TYPES; shadow lane operates on the complement (plus NULL).
    * Sequential because parallelism here yields no measurable benefit and would
@@ -443,6 +515,10 @@ export class MarketRotator {
              AND ph.time > NOW() - INTERVAL '24 hours'
          )`,
     );
+    // Pin the force-include cohort to `active` after eviction (so resolved
+    // cohort markets are not re-promoted) and before the lanes run (so the
+    // demotion logic sees them as active and the exemption applies).
+    await this.applyForceInclude();
     const live = await this.rotate('live');
     const shadow = await this.rotate('shadow');
     return { live, shadow };


### PR DESCRIPTION
## Problem

The Sprint 2 generators (`favorite_longshot_bias`, `resolution_prior_v2`) cannot be empirically measured. Diagnosis from the 2026-05-18 auto-review analysis:

- The catalog holds **5,435 tail-band markets** (Yes price <0.10 or >0.90 — `favorite_longshot_bias` territory), but only **1** has `tracking_status='active'`.
- `favorite_longshot_bias` emitted just **6 predictions in 24h**, then stopped — far below the `n≥100` the cost-aware edge cron needs.
- Root cause: `MarketRotator` ranks cold candidates by `market_score`, which is volume/tradeability-biased. Tail-band markets score low (the tradeability dimension penalises extreme prices) so they are never promoted out of `cold`.

The `FORCE_INCLUDE_MARKET_IDS` env var (PR #238/#239) only reaches the dashboard's `MarketSelector` — it never affected the data-collector's `tracking_status` promotion, so force-included markets got no price data.

## Change

- `MarketRotator` reads `FORCE_INCLUDE_MARKET_IDS` (same var the dashboard already consumes — one compose entry drives both data collection and signal inclusion).
- New `applyForceInclude()` pins the cohort to `active` via a direct UPDATE, restricted to valid markets (`is_active`, not resolved, not past `end_date`).
- The cohort is exempt from every demotion path: `selectDemotions` (extreme-price + hysteresis) and `selectWarmingDemotions` (stale/extreme).
- `applyForceInclude()` runs in `rotateAll()` **after** eviction (resolved cohort markets are not re-promoted) and **before** the lanes (demotion exemption applies).

### compose
- 12-market liquid tail-band cohort (Yes price 0.03–0.09, liquidity 43k–110k), curated from the catalog.
- `MAX_TRACKED_MARKETS` 35→45 (data-collector) and `MAX_SIGNAL_MARKETS` 35→45 (dashboard) so the cohort and merit-selected markets coexist.

## Scope notes

- `resolution_prior_v2` is **supply-blocked** — there are currently 0 near-resolution mid-price markets in tradeable types, so it cannot be measured regardless of this change. Tracked separately; not addressed here.
- This is a **measurement instrument**, not a strategy change. Cohort weights stay at 0.0 — the generators emit predictions only; the combiner is unaffected.
- Post-deploy: monitor data-collector (200M limit) and dashboard (150M limit) memory — tracked-market count rises from ~70 to ~85.

## Tests

`MarketRotator.test.ts`: 11 new tests (parse, constructor, demotion exemptions, `applyForceInclude` SQL/no-op, `rotateAll` wiring). Full data-collector suite: 288 passed. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented market force-include functionality allowing administrators to designate specific markets for permanent active status, ensuring continuous availability and protection from standard rotation and market removal processes
  * Increased platform capacity to track and generate market signals for up to 45 markets across the system, expanding from the previous 35-market limitation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->