### PR TITLE
fix(signals): correct favorite_longshot_bias direction — it traded into the bias

### DIFF
--- a/packages/signals/src/signals/market-structure/FavoriteLongshotBiasGenerator.test.ts
+++ b/packages/signals/src/signals/market-structure/FavoriteLongshotBiasGenerator.test.ts
@@ -58,22 +58,22 @@ describe('FavoriteLongshotBiasGenerator', () => {
     });
   });
 
-  describe('longshot band (price < longshotThreshold)', () => {
-    it('emits LONG when price is well below longshotThreshold', async () => {
+  describe('longshot band (price < longshotThreshold) — fade the overpriced longshot', () => {
+    it('emits SHORT when price is well below longshotThreshold', async () => {
       const gen = new FavoriteLongshotBiasGenerator();
       const out = await gen.compute(context([0.03]));
       expect(out).not.toBeNull();
-      expect(out!.direction).toBe('LONG');
-      expect(out!.strength).toBeGreaterThan(0);
+      expect(out!.direction).toBe('SHORT');
+      expect(out!.strength).toBeLessThan(0);
     });
 
-    it('strength scales with distance from boundary (deeper longshot = stronger)', async () => {
+    it('strength magnitude scales with distance from boundary (deeper longshot = stronger)', async () => {
       const gen = new FavoriteLongshotBiasGenerator();
       const out01 = await gen.compute(context([0.01]));
       const out08 = await gen.compute(context([0.08]));
       expect(out01).not.toBeNull();
       expect(out08).not.toBeNull();
-      expect(out01!.strength).toBeGreaterThan(out08!.strength);
+      expect(Math.abs(out01!.strength)).toBeGreaterThan(Math.abs(out08!.strength));
     });
 
     it('returns null near the boundary (strength below minStrength)', async () => {
@@ -84,13 +84,13 @@ describe('FavoriteLongshotBiasGenerator', () => {
     });
   });
 
-  describe('favorite band (price > favoriteThreshold)', () => {
-    it('emits SHORT when price is well above favoriteThreshold', async () => {
+  describe('favorite band (price > favoriteThreshold) — back the underpriced favorite', () => {
+    it('emits LONG when price is well above favoriteThreshold', async () => {
       const gen = new FavoriteLongshotBiasGenerator();
       const out = await gen.compute(context([0.97]));
       expect(out).not.toBeNull();
-      expect(out!.direction).toBe('SHORT');
-      expect(out!.strength).toBeLessThan(0);
+      expect(out!.direction).toBe('LONG');
+      expect(out!.strength).toBeGreaterThan(0);
     });
 
     it('strength magnitude scales with distance from boundary (deeper favorite = stronger)', async () => {
@@ -190,14 +190,14 @@ describe('FavoriteLongshotBiasGenerator', () => {
       const gen = new FavoriteLongshotBiasGenerator({ longshotThreshold: 0.20 });
       const out = await gen.compute(context([0.15])); // would be null under default
       expect(out).not.toBeNull();
-      expect(out!.direction).toBe('LONG');
+      expect(out!.direction).toBe('SHORT');
     });
 
     it('respects custom favoriteThreshold', async () => {
       const gen = new FavoriteLongshotBiasGenerator({ favoriteThreshold: 0.80 });
       const out = await gen.compute(context([0.85])); // would be null under default
       expect(out).not.toBeNull();
-      expect(out!.direction).toBe('SHORT');
+      expect(out!.direction).toBe('LONG');
     });
 
     it('respects custom minStrength gate', async () => {

--- a/packages/signals/src/signals/market-structure/FavoriteLongshotBiasGenerator.ts
+++ b/packages/signals/src/signals/market-structure/FavoriteLongshotBiasGenerator.ts
@@ -35,25 +35,32 @@ export const DEFAULT_FAVORITE_LONGSHOT_BIAS_PARAMS: FavoriteLongshotBiasParams =
  * FavoriteLongshotBiasGenerator
  *
  * Codifies the favorite-longshot bias documented in prediction-market
- * literature (Wolfers/Zitzewitz 2004, Manski 2006). Two regimes:
+ * literature (Wolfers/Zitzewitz 2004, Manski 2006). The bias: bettors
+ * systematically OVER-pay for longshots and UNDER-pay for favorites, so
+ * longshots resolve YES *less* often than their price implies and favorites
+ * resolve YES *more* often. The generator exploits the bias by trading
+ * against it. Two regimes:
  *
- *   1. Longshot band (price < longshotThreshold): YES outcomes priced below
- *      ~0.10 historically resolve YES more often than the price implies.
- *      Empirical mispricing is 3–8%. The generator emits LONG.
+ *   1. Longshot band (price < longshotThreshold): the YES outcome is
+ *      over-priced. The generator emits SHORT (fade the longshot).
  *
- *   2. Favorite band (price > favoriteThreshold): YES outcomes priced above
- *      ~0.90 historically resolve YES less often than the price implies
- *      (lottery-aversion + supply imbalance). The generator emits SHORT.
+ *   2. Favorite band (price > favoriteThreshold): the YES outcome is
+ *      under-priced. The generator emits LONG (back the favorite).
  *
  * In the mid-range no clear directional bias exists in the literature, so
  * the generator returns null.
  *
+ * NOTE: until 2026-05-19 this generator emitted the inverted directions
+ * (LONG on longshots, SHORT on favorites) — i.e. it traded *into* the bias.
+ * The cohort-measurement deploy (PR #241) surfaced it: crypto_daily LONG
+ * scored gross −0.78% / t_net −22.70 on n=438. Corrected here.
+ *
  * Mathematical structure:
  *
  *   longshot: magnitude = (longshotThreshold - price) / longshotThreshold
- *             direction = LONG, strength = +magnitude
- *   favorite: magnitude = (price - favoriteThreshold) / (1 - favoriteThreshold)
  *             direction = SHORT, strength = -magnitude
+ *   favorite: magnitude = (price - favoriteThreshold) / (1 - favoriteThreshold)
+ *             direction = LONG, strength = +magnitude
  *   confidence = 0.4 + 0.5 × magnitude  (clamped to [0, 1] by BaseSignal)
  *
  * Output is bounded by `createOutput` to strength ∈ [-1, 1] and
@@ -64,7 +71,7 @@ export class FavoriteLongshotBiasGenerator extends BaseSignal<FavoriteLongshotBi
   readonly signalId = 'favorite_longshot_bias';
   readonly name = 'Favorite-Longshot Bias';
   readonly description =
-    'Exploits the empirical under-pricing of longshots (price < 0.10) and over-pricing of favorites (price > 0.90) in binary prediction markets';
+    'Exploits the empirical over-pricing of longshots (price < 0.10) and under-pricing of favorites (price > 0.90) in binary prediction markets: SHORT longshots, LONG favorites';
 
   protected parameters: FavoriteLongshotBiasParams;
 
@@ -98,12 +105,14 @@ export class FavoriteLongshotBiasGenerator extends BaseSignal<FavoriteLongshotBi
     let band: 'longshot' | 'favorite';
 
     if (currentPrice < longshotThreshold) {
+      // Longshot is over-priced — fade it.
       magnitude = (longshotThreshold - currentPrice) / longshotThreshold;
-      direction = 'LONG';
+      direction = 'SHORT';
       band = 'longshot';
     } else if (currentPrice > favoriteThreshold) {
+      // Favorite is under-priced — back it.
       magnitude = (currentPrice - favoriteThreshold) / (1 - favoriteThreshold);
-      direction = 'SHORT';
+      direction = 'LONG';
       band = 'favorite';
     } else {
       return null;


### PR DESCRIPTION
## Problem

`FavoriteLongshotBiasGenerator` emitted **LONG on longshots** (price < 0.10) and **SHORT on favorites** (price > 0.90) — it backed longshots and faded favorites, the exact inverse of the favorite-longshot bias it is named after.

The documented bias (Wolfers/Zitzewitz 2004, Manski 2006, both cited in the generator's own docstring): bettors over-pay for longshots and under-pay for favorites. Longshots resolve YES *less* often than their price implies; favorites resolve YES *more* often. Exploiting the bias means **SHORT longshots, LONG favorites**. The generator did the opposite — and its docstring/description mis-stated the literature (claimed longshots are under-priced).

## Empirical confirmation

The force-track cohort deploy (PR #241) gave the generator its target markets and the 02:30 cost-aware cron measured it:

```
favorite_longshot_bias  crypto_daily  LONG  n=438  gross -0.78%  t_net -22.70
```

Anti-edge — the generator was trading *into* the bias. The counter direction is +0.78% gross (the corrected direction). Note: at the real ~1.08% round-trip cost the corrected direction still nets approximately -0.30%, so this fix makes the generator *correct*, not profitable — flagged in the Sprint 2 measurement review.

## Change

- Longshot band emits `SHORT` (was `LONG`); favorite band emits `LONG` (was `SHORT`).
- The `strength` sign expression is unchanged (`LONG=+`, `SHORT=-`); the sign now follows the corrected direction.
- Docstring + `description` corrected to state the bias accurately.
- Generator weight stays **0.0** in the combiner — this is a correctness fix, not a trading-behaviour change.

## Tests

`FavoriteLongshotBiasGenerator.test.ts`: 4 direction assertions flipped (longshot→SHORT, favorite→LONG, custom-threshold cases). 23 FLB tests pass; full signals suite 277 passed; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Corrected FavoriteLongshotBiasGenerator signal directions: now emits SHORT for overpriced longshots and LONG for underpriced favorites, aligning with proper market bias exploitation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->