### PR TITLE
fix(daily-review): make daily issue creation non-negotiable

### DIFF
--- a/scripts/daily-review-prompt.md
+++ b/scripts/daily-review-prompt.md
@@ -311,6 +311,18 @@ Cross-check with `optimization_runs` and dashboard logs to confirm the EdgeCapac
 
 ### 3a. GitHub Issue
 
+**This step is NON-NEGOTIABLE. Every run MUST create exactly one daily-review issue, no exceptions.**
+
+Creating the issue is NOT conditional on findings. Do NOT skip it because:
+- the system looks healthy ("all containers up, no alerts") — a healthy run still gets a healthy issue;
+- there is "nothing actionable" or "no PR to open" — the issue is the audit trail, not a bug report;
+- a prior issue covers the same problem — note that in the new issue, do not skip it;
+- the analysis was short — a short issue is fine, a missing one is a failed run.
+
+A run that ends without a `gh issue create` call is a **FAILED run** — the workflow's
+verify step will file a degraded auto-stub in its place and emit a `::warning::`.
+The issue is the FIRST output: create it before opening any PR.
+
 Create a GitHub Issue with label "daily-review". Do NOT close it afterward:
 
 ```bash
@@ -318,6 +330,9 @@ ISSUE_URL=$(gh issue create --title "TITLE" --body-file report.md --label "daily
 ISSUE_NUMBER=${ISSUE_URL##*/}
 echo "Created issue #$ISSUE_NUMBER"
 ```
+
+If `gh issue create` fails (label missing, transient error), fix the cause and retry —
+do not proceed to Step 4 or exit until the issue exists.
 
 The issue should have:
 - **Executive Summary** (1 paragraph): Overall health assessment


### PR DESCRIPTION
## Problem

Claude's daily-review session skipped `gh issue create` **three days running** (2026-05-16, 2026-05-18, 2026-05-19) — a judgment call that the system looked healthy or had "nothing actionable". The gather succeeded each time (real account data was present), so it was a behavioural skip, not an infra failure.

PR #242's auto-stub now catches the miss and preserves the audit trail, but the auto-stub is a raw data dump — the actual qualitative review (root-cause analysis, trending, fix verification) is lost whenever the stub fires.

## Change

`scripts/daily-review-prompt.md` Step 3a now states the mandate explicitly:

- The issue is **unconditional** — a healthy run still gets a healthy issue.
- "Nothing actionable" / "no PR to open" is **not** grounds to skip — the issue is the audit trail, not a bug report.
- A prior issue covering the same problem is not grounds to skip — note it in the new issue.
- A run ending without `gh issue create` is a **failed run**.
- The issue is the first output, before any PR; if `gh issue create` fails, fix and retry rather than exiting.

This is the "hard mandate" complement to PR #242's safety-net: #242 guarantees the audit trail exists; this PR aims to restore the actual analysis so the stub stops being needed.

## Notes

Prompt-only change, no code. Effect is observable on the next daily run (08:00 UTC) — if Claude still skips, the gap is deeper than prompt wording and the auto-stub remains the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)