### PR TITLE
chore: repo cleanup — gitignore build artifacts, track real files

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,14 @@
+# CodeRabbit Configuration
+# https://docs.coderabbit.ai/configuration
+language: en-US
+
+reviews:
+  profile: assertive
+  auto_review:
+    enabled: true
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+
+chat:
+  auto_reply: true

--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,31 @@ timescaledb_data/
 
 # Claude Code local settings (may contain credentials)
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 .worktrees/
-.worktrees/
+
+# Compiled TypeScript artifacts — source is .ts; tsc emits these in place
+*.js.map
+*.d.ts.map
+packages/**/src/**/*.js
+packages/**/src/**/*.d.ts
+tests/**/*.js
+tests/**/*.d.ts
+scripts/**/*.d.ts
+scripts/train-rl-model.js
+scripts/trigger-scorer-optimization.js
+vitest.config.js
+vitest.config.d.ts
+
+# Playwright artifacts
+test-results/
+playwright-report/
+
+# Scratch / throwaway files
+tmp-*
+*.stackdump
+review-history.json
+vercel-check.png
+
+# Wrong package manager — this project uses pnpm (pnpm-lock.yaml)
+package-lock.json

--- a/docs/plans/2026-03-10-comprehensive-fix-design.md
+++ b/docs/plans/2026-03-10-comprehensive-fix-design.md
@@ -1,0 +1,219 @@
+# Comprehensive Fix Design — 2026-03-10
+
+## Context
+
+Daily trade review ([Issue #4](https://github.com/JaviMaligno/polymarket-trader/issues/4)) surfaced multiple critical issues. System is headed for real-money trading, so fixes must be robust.
+
+### Issues Identified
+
+1. **Unexplained capital loss (-$2,674.78)** — Historical bug where `paperPositionsRepo.close()` was DELETE. Positions deleted without crediting capital back.
+2. **$0 PnL on most closed trades** — Positions churning on event markets with no price movement. Also, StopLossService and PositionCleanupService don't deduct fees from PnL.
+3. **Signal generation stopped (0 signals/hour)** — Bayesian confidence cap crushes confidence to ~0% on snapshot data. Thresholds (0.60/0.45) too high.
+4. **Optimization decorative** — Optuna server uses in-memory dict, Render restarts kill state → 404. Even when optimization completes, weights never written to `signal_weights` table.
+5. **TimescaleDB at 218% CPU** — Causes query timeouts in RiskManager, dashboard marked "unhealthy".
+6. **6.38% win rate** — Misleading: 38 of 47 trades recorded as $0 PnL (not classified as W or L).
+
+---
+
+## Design
+
+### 1. Consolidated Position Closing Service
+
+**Problem:** Three services close positions with inconsistent PnL/fee logic:
+- `AutoSignalExecutor.closePosition()` — correct (deducts fees)
+- `StopLossService.closePosition()` — bug (ignores fees)
+- `PositionCleanupService.closePosition()` — bug (sets fee=0)
+
+**Design:** Single `PositionClosingService` with one `close()` method.
+
+```
+PositionClosingService.close(position, exitPrice, reason)
+  ├─ Compute exit value: exitPrice * shares
+  ├─ Compute fee: exitValue * FEE_RATE
+  ├─ Compute PnL: exitValue - entryValue - fee
+  ├─ BEGIN transaction
+  │   ├─ UPDATE paper_positions (closed_at, realized_pnl, size=0)
+  │   ├─ UPDATE paper_account (capital += exitValue - fee, pnl += netPnl, fees += fee)
+  │   └─ INSERT paper_trades (record with reason: 'signal'|'stop_loss'|'take_profit'|'time_exit'|'cleanup')
+  └─ COMMIT
+```
+
+**Properties:**
+- Single transaction — no partial state if DB fails mid-close (critical for real money)
+- Reason tracking via `reason` parameter
+- Price validation — rejects close if exit price is null/stale beyond configurable threshold
+- Idempotent — if position already closed (size=0), returns early
+
+AutoSignalExecutor, StopLossService, and PositionCleanupService all delegate to this service.
+
+### 2. Optuna PostgreSQL Migration
+
+**Problem:** Optuna server on Render stores sessions in Python dict. Restart = state loss = 404.
+
+**Design:** Replace in-memory dict with Optuna's native PostgreSQL backend (existing TimescaleDB).
+
+**Changes to `services/optimizer-server/app/main.py`:**
+- Remove `optimizers: Dict[str, OptunaOptimizer] = {}`
+- Each endpoint uses `DATABASE_URL` from environment
+- `POST /optimizer/create` → `optuna.create_study(storage=DATABASE_URL, study_name=name)`
+- `POST /optimizer/suggest` → `optuna.load_study(storage=DATABASE_URL, study_name=id)` then `study.ask()`
+- `POST /optimizer/report` → `study.tell(trial, score)`
+- `GET /optimizer/{id}/best` → `study.best_params`
+- `DELETE /optimizer/{id}` → `optuna.delete_study(storage=DATABASE_URL, study_name=id)`
+
+**What Optuna auto-creates in PostgreSQL:**
+- `optuna_studies`, `optuna_trials`, `optuna_trial_params`, `optuna_trial_values`
+- Lightweight: ~100 rows per 15-iteration run
+
+**API contract unchanged** — dashboard's `OptunaClient` needs zero changes. Same endpoints, same shapes. Only server-side storage changes.
+
+**Cleanup:** Dashboard already calls `DELETE /optimizer/{id}` after each run, which now calls `optuna.delete_study()`.
+
+### 3. Wire Optimization Weights to Signal Engine
+
+**Problem:** OptimizationScheduler computes optimal signal weights but only extracts `minEdge`/`minConfidence`. Weight parameters are computed, scored, and discarded. `signal_weights` table never updated.
+
+**Changes to `OptimizationScheduler.updateStrategy()`:**
+```
+After saving to optimization_runs:
+  ├─ Extract weight params from best_params:
+  │   combiner.momentumWeight → momentum
+  │   combiner.meanReversionWeight → mean_reversion
+  │   (map all 5 generators)
+  ├─ For each weight:
+  │   signalWeightsRepo.update(signalType, { weight: value })
+  └─ Log: "Applied optimized weights: {momentum: 0.35, ...}"
+```
+
+**Changes to `server.ts` startup:**
+```
+After loading best_params from optimization_runs:
+  ├─ Extract thresholds (already done)
+  └─ Extract signal weights and pass to SignalEngine constructor
+```
+
+**No changes to SignalEngine** — already syncs from `signal_weights` table every 5 minutes.
+
+**Safety:** Reject weights outside [0.05, 0.95]. Log warning if weight changes >50%.
+
+### 4. Bayesian Confidence Cap + Threshold Tuning
+
+**Problem:** Bayesian cap counts "informative bars" (price changed). Snapshot data = same price repeated = 0 informative bars = confidence crushed to ~0%. Thresholds 0.60/0.45 filter everything out.
+
+**Changes:**
+
+**A. Adjust informative bar definition:**
+A bar is informative if:
+- Source is `'trade'` (real market activity), OR
+- Source is `'snapshot'` AND price differs from market's initial listing price by >$0.01
+
+This prevents fresh inactive markets from generating overconfident signals while allowing established stable markets to pass.
+
+**B. Lower default thresholds to documented values:**
+- `minCombinedConfidence`: 0.60 → 0.43
+- `minCombinedStrength`: 0.45 → 0.27
+
+(CLAUDE.md documents these as the intended config. They were raised at some point.)
+
+**C. Add floor to Bayesian cap:**
+Minimum confidence cap of 0.15 — even with zero informative bars, a very strong signal can still pass. Prevents total silence.
+
+### 5. TimescaleDB CPU Investigation
+
+**Problem:** 218% CPU on 0.25 vCPU. Causes query timeouts, dashboard unhealthy. Adding Optuna tables could worsen.
+
+**Design:** Diagnostic script run on VM, then apply findings.
+
+**Diagnostics:**
+1. `pg_stat_activity` → active queries, long-running ones
+2. `pg_stat_user_tables` → seq scans vs index scans on price_history
+3. Continuous aggregate jobs → refresh frequency
+4. Table sizes → price_history row count and bloat
+5. Missing indexes → full table scans
+6. Connection count vs `max_connections=50`
+
+**Likely culprits:**
+1. Continuous aggregate refresh over large time ranges
+2. price_history bloat (snapshots add 11,520 rows/day)
+3. Missing index on token_id + time
+4. Too many concurrent queries from signal generation
+
+**Mitigations (applied based on findings):**
+- Data retention policy: `add_retention_policy('price_history', INTERVAL '30 days')`
+- Tune continuous aggregate refresh interval
+- Add missing indexes
+- Reduce `MAX_SIGNAL_MARKETS` if needed
+
+### 6. Account Reconciliation
+
+**Problem:** $2,674.78 unexplained capital loss from historical DELETE bug.
+
+**Design:** One-time script (not automated).
+
+```
+1. Sum paper_trades where side='BUY': total_spent
+2. Sum paper_trades where side='SELL': total_received
+3. expected_capital = initial_capital - total_spent + total_received
+4. Diff with paper_account.current_capital = unexplained loss
+5. Find orphaned BUYs (no matching SELL, no open position) = DELETE victims
+6. Report: expected vs actual, orphaned buys, recommended adjustment
+```
+
+**Adjustment (manual approval):**
+```sql
+UPDATE paper_account
+SET current_capital = current_capital + adjustment,
+    available_capital = available_capital + adjustment
+WHERE id = 1;
+```
+
+Runs once, reviewed manually, then applied. Going forward, the PositionClosingService prevents this class of bug.
+
+---
+
+## Implementation Plan
+
+```
+Phase 1 (Diagnose — no code changes)
+  ├─ TimescaleDB CPU investigation script
+  └─ Account reconciliation script
+
+Phase 2 (Core fixes)
+  ├─ 2A: PositionClosingService (consolidate close logic)
+  │       Must be first — StopLoss and Cleanup depend on it
+  ├─ 2B: Bayesian cap + threshold tuning
+  │       Independent of 2A, can parallel
+  └─ 2C: Apply Phase 1 findings (retention, indexes, etc.)
+
+Phase 3 (Optimization pipeline)
+  ├─ 3A: Optuna PostgreSQL migration
+  └─ 3B: Wire weights to signal_weights table
+       Depends on 3A
+
+Phase 4 (Validate)
+  ├─ Account reconciliation adjustment
+  ├─ Deploy all to VM
+  └─ Monitor 24h: signals, PnL accuracy, optimization, DB CPU
+```
+
+Phases 1+2 overlap. Phase 3 independent of Phase 2 (can parallel with worktrees).
+
+**Scope:** ~7 files modified, 1 new service, 2 scripts, 1 Python server update. No new infra.
+
+---
+
+## Files Affected
+
+| File | Change |
+|------|--------|
+| `packages/dashboard/src/services/PositionClosingService.ts` | **NEW** — consolidated close logic |
+| `packages/dashboard/src/services/AutoSignalExecutor.ts` | Delegate close to PositionClosingService |
+| `packages/dashboard/src/services/StopLossService.ts` | Delegate close to PositionClosingService |
+| `packages/dashboard/src/services/PositionCleanupService.ts` | Delegate close to PositionClosingService |
+| `packages/dashboard/src/services/SignalEngine.ts` | Bayesian cap adjustments, threshold defaults |
+| `packages/dashboard/src/services/OptimizationScheduler.ts` | Write weights to signal_weights table |
+| `packages/dashboard/src/server.ts` | Load optimized weights on startup |
+| `services/optimizer-server/app/main.py` | PostgreSQL-backed Optuna storage |
+| `services/optimizer-server/requirements.txt` | Add `psycopg2-binary` |
+| `scripts/diagnose-db-cpu.js` | **NEW** — TimescaleDB diagnostic script |
+| `scripts/reconcile-account.js` | **NEW** — account reconciliation script |

--- a/docs/plans/2026-03-10-comprehensive-fix-plan.md
+++ b/docs/plans/2026-03-10-comprehensive-fix-plan.md
@@ -1,0 +1,1982 @@
+# Comprehensive Fix Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix all critical issues from the daily trade review: PnL accounting bugs, broken optimization pipeline, signal generation silence, and DB performance.
+
+**Architecture:** Six independent work items across 4 phases. Phase 1 (diagnostics) runs first. Phase 2 (core fixes) and Phase 3 (optimization) can run in parallel. Phase 4 validates everything.
+
+**Tech Stack:** TypeScript (Vitest for tests), Python (FastAPI + Optuna), PostgreSQL/TimescaleDB, Node.js scripts
+
+**Design doc:** `docs/plans/2026-03-10-comprehensive-fix-design.md`
+
+---
+
+## Phase 1: Diagnostics
+
+### Task 1: TimescaleDB CPU Diagnostic Script
+
+**Files:**
+- Create: `scripts/diagnose-db-cpu.js`
+
+**Step 1: Write the diagnostic script**
+
+```javascript
+#!/usr/bin/env node
+/**
+ * TimescaleDB CPU Diagnostic Script
+ * Run on VM or locally with DATABASE_URL pointing to TimescaleDB.
+ * Identifies: long queries, seq scans, table bloat, connection count,
+ * continuous aggregate jobs, missing indexes.
+ */
+const { Pool } = require('pg');
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0' ? { rejectUnauthorized: false } : undefined,
+});
+
+async function run() {
+  console.log('=== TimescaleDB CPU Diagnostics ===\n');
+
+  // 1. Active queries
+  console.log('--- Active Queries ---');
+  const active = await pool.query(`
+    SELECT pid, state, query_start, NOW() - query_start AS duration,
+           LEFT(query, 120) AS query_preview
+    FROM pg_stat_activity
+    WHERE state != 'idle' AND pid != pg_backend_pid()
+    ORDER BY query_start ASC
+  `);
+  console.table(active.rows);
+
+  // 2. Long-running queries (>5s)
+  console.log('\n--- Long-Running Queries (>5s) ---');
+  const longRunning = await pool.query(`
+    SELECT pid, state, NOW() - query_start AS duration,
+           LEFT(query, 200) AS query_preview
+    FROM pg_stat_activity
+    WHERE state != 'idle' AND NOW() - query_start > INTERVAL '5 seconds'
+      AND pid != pg_backend_pid()
+  `);
+  console.table(longRunning.rows);
+
+  // 3. Table sizes
+  console.log('\n--- Table Sizes ---');
+  const sizes = await pool.query(`
+    SELECT schemaname, tablename,
+           pg_size_pretty(pg_total_relation_size(schemaname || '.' || tablename)) AS total_size,
+           pg_total_relation_size(schemaname || '.' || tablename) AS size_bytes
+    FROM pg_tables
+    WHERE schemaname = 'public'
+    ORDER BY pg_total_relation_size(schemaname || '.' || tablename) DESC
+    LIMIT 15
+  `);
+  console.table(sizes.rows);
+
+  // 4. Seq scans vs index scans on big tables
+  console.log('\n--- Seq Scans vs Index Scans (top tables) ---');
+  const scans = await pool.query(`
+    SELECT relname, seq_scan, idx_scan,
+           CASE WHEN seq_scan + idx_scan > 0
+             THEN ROUND(100.0 * seq_scan / (seq_scan + idx_scan), 1)
+             ELSE 0 END AS seq_scan_pct,
+           seq_tup_read, idx_tup_fetch,
+           n_live_tup
+    FROM pg_stat_user_tables
+    ORDER BY seq_tup_read DESC
+    LIMIT 10
+  `);
+  console.table(scans.rows);
+
+  // 5. Missing indexes (high seq scan tables with many rows)
+  console.log('\n--- Potentially Missing Indexes ---');
+  const missing = await pool.query(`
+    SELECT relname, seq_scan, seq_tup_read, n_live_tup
+    FROM pg_stat_user_tables
+    WHERE seq_scan > 100 AND n_live_tup > 10000
+    ORDER BY seq_tup_read DESC
+    LIMIT 5
+  `);
+  console.table(missing.rows);
+
+  // 6. Existing indexes on price_history
+  console.log('\n--- Indexes on price_history ---');
+  const indexes = await pool.query(`
+    SELECT indexname, indexdef
+    FROM pg_indexes
+    WHERE tablename = 'price_history'
+  `);
+  console.table(indexes.rows);
+
+  // 7. price_history row count and date range
+  console.log('\n--- price_history Stats ---');
+  const phStats = await pool.query(`
+    SELECT COUNT(*) AS row_count,
+           MIN(time) AS oldest,
+           MAX(time) AS newest,
+           COUNT(DISTINCT token_id) AS unique_tokens
+    FROM price_history
+  `);
+  console.table(phStats.rows);
+
+  // 8. Connection count
+  console.log('\n--- Connection Count ---');
+  const conns = await pool.query(`
+    SELECT state, COUNT(*) AS count
+    FROM pg_stat_activity
+    GROUP BY state
+  `);
+  console.table(conns.rows);
+
+  // 9. Continuous aggregate / background jobs
+  console.log('\n--- TimescaleDB Background Jobs ---');
+  try {
+    const jobs = await pool.query(`
+      SELECT job_id, application_name, schedule_interval,
+             last_run_status, last_run_started_at, last_run_duration,
+             next_start
+      FROM timescaledb_information.jobs
+      WHERE application_name NOT LIKE 'Telemetry%'
+      ORDER BY next_start ASC
+    `);
+    console.table(jobs.rows);
+  } catch (e) {
+    console.log('Could not query TimescaleDB jobs:', e.message);
+  }
+
+  // 10. Retention policies
+  console.log('\n--- Retention Policies ---');
+  try {
+    const retention = await pool.query(`
+      SELECT j.hypertable_name, j.schedule_interval,
+             c.config
+      FROM timescaledb_information.jobs j
+      JOIN timescaledb_information.job_stats s ON j.job_id = s.job_id
+      LEFT JOIN _timescaledb_config.bgw_job c ON j.job_id = c.id
+      WHERE j.proc_name = 'policy_retention'
+    `);
+    console.table(retention.rows);
+  } catch (e) {
+    console.log('No retention policies found or query failed:', e.message);
+  }
+
+  await pool.end();
+  console.log('\n=== Diagnostics Complete ===');
+}
+
+run().catch(err => { console.error(err); process.exit(1); });
+```
+
+**Step 2: Run on VM and save output**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  'docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading' \
+  < scripts/diagnose-db-cpu.js
+```
+
+Or locally:
+```bash
+NODE_TLS_REJECT_UNAUTHORIZED=0 DATABASE_URL="postgres://..." node scripts/diagnose-db-cpu.js
+```
+
+Expected: Table output showing bottlenecks. Look for: high seq_scan_pct on price_history, large row counts, missing indexes, frequent background jobs.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/diagnose-db-cpu.js
+git commit -m "feat: add TimescaleDB CPU diagnostic script"
+```
+
+---
+
+### Task 2: Account Reconciliation Script
+
+**Files:**
+- Create: `scripts/reconcile-account.js`
+
+**Step 1: Write the reconciliation script**
+
+```javascript
+#!/usr/bin/env node
+/**
+ * Account Reconciliation Script
+ * Identifies unexplained capital differences by comparing trade records
+ * with current account balance. Finds orphaned BUY trades (DELETE bug victims).
+ */
+const { Pool } = require('pg');
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0' ? { rejectUnauthorized: false } : undefined,
+});
+
+async function run() {
+  console.log('=== Account Reconciliation ===\n');
+
+  // 1. Current account state
+  const account = await pool.query(`
+    SELECT current_capital, available_capital, initial_capital,
+           total_realized_pnl, total_fees_paid, total_trades,
+           winning_trades, losing_trades
+    FROM paper_account WHERE id = 1
+  `);
+  const acct = account.rows[0];
+  console.log('--- Current Account ---');
+  console.table([acct]);
+
+  // 2. Sum all trades
+  const buys = await pool.query(`
+    SELECT COUNT(*) AS count, COALESCE(SUM(value_usd), 0) AS total_value,
+           COALESCE(SUM(fee), 0) AS total_fees
+    FROM paper_trades WHERE side = 'buy'
+  `);
+  const sells = await pool.query(`
+    SELECT COUNT(*) AS count, COALESCE(SUM(value_usd), 0) AS total_value,
+           COALESCE(SUM(fee), 0) AS total_fees
+    FROM paper_trades WHERE side = 'sell'
+  `);
+
+  const buyTotal = parseFloat(buys.rows[0].total_value);
+  const sellTotal = parseFloat(sells.rows[0].total_value);
+  const totalFees = parseFloat(buys.rows[0].total_fees) + parseFloat(sells.rows[0].total_fees);
+
+  console.log('\n--- Trade Totals ---');
+  console.log(`BUY trades:  ${buys.rows[0].count} | Total: $${buyTotal.toFixed(2)} | Fees: $${parseFloat(buys.rows[0].total_fees).toFixed(2)}`);
+  console.log(`SELL trades: ${sells.rows[0].count} | Total: $${sellTotal.toFixed(2)} | Fees: $${parseFloat(sells.rows[0].total_fees).toFixed(2)}`);
+  console.log(`Total fees from trades: $${totalFees.toFixed(2)}`);
+
+  // 3. Expected capital
+  const initial = parseFloat(acct.initial_capital);
+  const expectedCapital = initial - buyTotal + sellTotal - totalFees;
+  const actualCapital = parseFloat(acct.current_capital);
+  const diff = actualCapital - expectedCapital;
+
+  console.log('\n--- Reconciliation ---');
+  console.log(`Initial capital:  $${initial.toFixed(2)}`);
+  console.log(`- Total bought:   $${buyTotal.toFixed(2)}`);
+  console.log(`+ Total sold:     $${sellTotal.toFixed(2)}`);
+  console.log(`- Total fees:     $${totalFees.toFixed(2)}`);
+  console.log(`= Expected:       $${expectedCapital.toFixed(2)}`);
+  console.log(`  Actual:         $${actualCapital.toFixed(2)}`);
+  console.log(`  Difference:     $${diff.toFixed(2)}`);
+
+  // 4. Open positions (capital tied up)
+  const openPositions = await pool.query(`
+    SELECT COUNT(*) AS count,
+           COALESCE(SUM(size * avg_entry_price), 0) AS capital_locked
+    FROM paper_positions
+    WHERE closed_at IS NULL AND size > 0
+  `);
+  console.log(`\nOpen positions: ${openPositions.rows[0].count} | Capital locked: $${parseFloat(openPositions.rows[0].capital_locked).toFixed(2)}`);
+
+  // 5. Orphaned BUYs: buy trades with no matching sell and no open position
+  const orphaned = await pool.query(`
+    SELECT bt.market_id, bt.token_id, bt.time, bt.value_usd, bt.executed_size, bt.executed_price
+    FROM paper_trades bt
+    WHERE bt.side = 'buy'
+      AND NOT EXISTS (
+        SELECT 1 FROM paper_trades st
+        WHERE st.market_id = bt.market_id AND st.token_id = bt.token_id
+          AND st.side = 'sell' AND st.time > bt.time
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM paper_positions pp
+        WHERE pp.market_id = bt.market_id AND pp.token_id = bt.token_id
+          AND pp.closed_at IS NULL AND pp.size > 0
+      )
+    ORDER BY bt.time DESC
+  `);
+
+  console.log(`\n--- Orphaned BUYs (no matching SELL, no open position) ---`);
+  console.log(`Count: ${orphaned.rows.length}`);
+  let orphanedValue = 0;
+  for (const row of orphaned.rows) {
+    orphanedValue += parseFloat(row.value_usd);
+    console.log(`  ${row.time} | ${row.market_id.substring(0, 30)}... | $${parseFloat(row.value_usd).toFixed(2)}`);
+  }
+  console.log(`Total orphaned value: $${orphanedValue.toFixed(2)}`);
+
+  // 6. Recommendation
+  const adjustment = expectedCapital - actualCapital;
+  console.log('\n--- Recommendation ---');
+  if (Math.abs(adjustment) > 1) {
+    console.log(`Adjust capital by $${adjustment.toFixed(2)} to match trade records.`);
+    console.log(`SQL (review before running):`);
+    console.log(`  UPDATE paper_account SET`);
+    console.log(`    current_capital = current_capital + ${adjustment.toFixed(2)},`);
+    console.log(`    available_capital = available_capital + ${adjustment.toFixed(2)}`);
+    console.log(`  WHERE id = 1;`);
+  } else {
+    console.log('Account is reconciled within $1. No adjustment needed.');
+  }
+
+  await pool.end();
+}
+
+run().catch(err => { console.error(err); process.exit(1); });
+```
+
+**Step 2: Run locally**
+
+```bash
+NODE_TLS_REJECT_UNAUTHORIZED=0 DATABASE_URL="postgres://..." node scripts/reconcile-account.js
+```
+
+Expected: Report showing the $2,674.78 gap and the orphaned BUY trades that caused it.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/reconcile-account.js
+git commit -m "feat: add account reconciliation script"
+```
+
+---
+
+## Phase 2: Core Fixes
+
+### Task 3: PositionClosingService
+
+**Files:**
+- Create: `packages/dashboard/src/services/PositionClosingService.ts`
+- Create: `packages/dashboard/src/services/PositionClosingService.test.ts`
+- Modify: `packages/dashboard/src/services/StopLossService.ts:354-416`
+- Modify: `packages/dashboard/src/services/PositionCleanupService.ts:231-280`
+- Modify: `packages/dashboard/src/services/AutoSignalExecutor.ts:447-584`
+
+**Step 1: Write the failing test**
+
+Create `packages/dashboard/src/services/PositionClosingService.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the database module before importing the service
+vi.mock('../database/index.js', () => ({
+  query: vi.fn(),
+  transaction: vi.fn(),
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+vi.mock('../database/repositories.js', () => ({
+  paperTradesRepo: {
+    create: vi.fn(),
+  },
+}));
+
+import { PositionClosingService, ClosePositionParams } from './PositionClosingService.js';
+import { query, transaction } from '../database/index.js';
+import { paperTradesRepo } from '../database/repositories.js';
+
+describe('PositionClosingService', () => {
+  let service: PositionClosingService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new PositionClosingService({ feeRate: 0.001 });
+
+    // Default: transaction executes the callback with a mock client
+    const mockClient = { query: vi.fn() };
+    vi.mocked(transaction).mockImplementation(async (cb) => cb(mockClient as any));
+    vi.mocked(paperTradesRepo.create).mockResolvedValue({ id: 'trade-1' } as any);
+  });
+
+  it('computes PnL correctly for a profitable LONG close', async () => {
+    const params: ClosePositionParams = {
+      positionId: 1,
+      marketId: 'market-1',
+      tokenId: 'token-yes',
+      side: 'long',
+      size: 100,
+      entryPrice: 0.40,
+      exitPrice: 0.60,
+      reason: 'signal',
+    };
+
+    const result = await service.close(params);
+
+    // exitValue = 100 * 0.60 = 60
+    // fee = 60 * 0.001 = 0.06
+    // netPnl = (0.60 - 0.40) * 100 - 0.06 = 19.94
+    expect(result.netPnl).toBeCloseTo(19.94, 2);
+    expect(result.fee).toBeCloseTo(0.06, 4);
+    expect(result.executed).toBe(true);
+  });
+
+  it('computes PnL correctly for a losing SHORT close', async () => {
+    const params: ClosePositionParams = {
+      positionId: 2,
+      marketId: 'market-2',
+      tokenId: 'token-no',
+      side: 'short',
+      size: 50,
+      entryPrice: 0.80,
+      exitPrice: 0.70,
+      reason: 'stop_loss',
+    };
+
+    const result = await service.close(params);
+
+    // exitValue = 50 * 0.70 = 35
+    // fee = 35 * 0.001 = 0.035
+    // netPnl = (0.70 - 0.80) * 50 - 0.035 = -5.035
+    expect(result.netPnl).toBeCloseTo(-5.035, 3);
+    expect(result.fee).toBeCloseTo(0.035, 4);
+    expect(result.executed).toBe(true);
+  });
+
+  it('deducts fees from capital update (proceeds - fee)', async () => {
+    const mockClient = {
+      query: vi.fn(),
+    };
+    vi.mocked(transaction).mockImplementation(async (cb) => cb(mockClient as any));
+
+    await service.close({
+      positionId: 1,
+      marketId: 'm1',
+      tokenId: 't1',
+      side: 'long',
+      size: 100,
+      entryPrice: 0.50,
+      exitPrice: 0.60,
+      reason: 'signal',
+    });
+
+    // Check the paper_account UPDATE was called with proceeds - fee
+    const accountUpdate = mockClient.query.mock.calls.find(
+      (call: any[]) => typeof call[0] === 'string' && call[0].includes('paper_account')
+    );
+    expect(accountUpdate).toBeDefined();
+    const params = accountUpdate![1];
+    // proceeds - fee = (100 * 0.60) - (60 * 0.001) = 59.94
+    expect(params[0]).toBeCloseTo(59.94, 2);
+    // fee = 0.06
+    expect(params[1]).toBeCloseTo(0.06, 4);
+  });
+
+  it('returns early without error for already-closed position (idempotent)', async () => {
+    const mockClient = {
+      query: vi.fn().mockResolvedValueOnce({ rowCount: 0 }), // position update returns 0 rows
+    };
+    vi.mocked(transaction).mockImplementation(async (cb) => cb(mockClient as any));
+
+    const result = await service.close({
+      positionId: 99,
+      marketId: 'm1',
+      tokenId: 't1',
+      side: 'long',
+      size: 100,
+      entryPrice: 0.50,
+      exitPrice: 0.60,
+      reason: 'signal',
+    });
+
+    expect(result.executed).toBe(false);
+    expect(result.reason).toContain('already closed');
+  });
+
+  it('records trade with correct reason/signal_type', async () => {
+    await service.close({
+      positionId: 1,
+      marketId: 'm1',
+      tokenId: 't1',
+      side: 'long',
+      size: 100,
+      entryPrice: 0.50,
+      exitPrice: 0.60,
+      reason: 'take_profit',
+    });
+
+    expect(paperTradesRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signal_type: 'take_profit',
+        side: 'sell',
+        fee: expect.closeTo(0.06, 4),
+      })
+    );
+  });
+
+  it('rejects close when exitPrice is null', async () => {
+    const result = await service.close({
+      positionId: 1,
+      marketId: 'm1',
+      tokenId: 't1',
+      side: 'long',
+      size: 100,
+      entryPrice: 0.50,
+      exitPrice: NaN,
+      reason: 'signal',
+    });
+
+    expect(result.executed).toBe(false);
+    expect(result.reason).toContain('invalid exit price');
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run packages/dashboard/src/services/PositionClosingService.test.ts
+```
+
+Expected: FAIL — module `./PositionClosingService.js` not found.
+
+**Step 3: Write the PositionClosingService implementation**
+
+Create `packages/dashboard/src/services/PositionClosingService.ts`:
+
+```typescript
+import { transaction } from '../database/index.js';
+import { paperTradesRepo } from '../database/repositories.js';
+import type { PoolClient } from 'pg';
+
+export type CloseReason = 'signal' | 'stop_loss' | 'take_profit' | 'time_exit' | 'cleanup_inactive' | 'cleanup_resolved';
+
+export interface ClosePositionParams {
+  positionId: number;
+  marketId: string;
+  tokenId: string;
+  side: 'long' | 'short';
+  size: number;
+  entryPrice: number;
+  exitPrice: number;
+  reason: CloseReason;
+  signalId?: string;
+  predictionId?: string;
+}
+
+export interface ClosePositionResult {
+  executed: boolean;
+  netPnl: number;
+  fee: number;
+  reason?: string;
+  tradeId?: string;
+}
+
+export interface PositionClosingConfig {
+  feeRate: number;
+}
+
+const DEFAULT_CONFIG: PositionClosingConfig = {
+  feeRate: 0.001,
+};
+
+/**
+ * Centralized service for closing paper trading positions.
+ * Single source of truth for PnL computation, fee handling, and account updates.
+ * All position closes go through this service to ensure consistent accounting.
+ */
+export class PositionClosingService {
+  private config: PositionClosingConfig;
+
+  constructor(config?: Partial<PositionClosingConfig>) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  async close(params: ClosePositionParams): Promise<ClosePositionResult> {
+    const { positionId, marketId, tokenId, side, size, entryPrice, exitPrice, reason } = params;
+
+    // Validate exit price
+    if (!exitPrice || isNaN(exitPrice) || exitPrice < 0) {
+      return { executed: false, netPnl: 0, fee: 0, reason: 'invalid exit price' };
+    }
+
+    // Compute financials
+    const exitValue = size * exitPrice;
+    const fee = exitValue * this.config.feeRate;
+    const grossPnl = (exitPrice - entryPrice) * size;
+    const netPnl = grossPnl - fee;
+    const proceeds = exitValue - fee;
+
+    try {
+      const result = await transaction(async (client: PoolClient) => {
+        // 1. Close the position (UPDATE with WHERE closed_at IS NULL for idempotency)
+        const posResult = await client.query(
+          `UPDATE paper_positions SET
+            closed_at = NOW(),
+            realized_pnl = $1,
+            current_price = $2,
+            size = 0
+          WHERE id = $3 AND closed_at IS NULL`,
+          [netPnl, exitPrice, positionId]
+        );
+
+        if (posResult.rowCount === 0) {
+          return { executed: false, reason: 'already closed or not found' };
+        }
+
+        // 2. Update paper account
+        await client.query(
+          `UPDATE paper_account SET
+            current_capital = current_capital + $1,
+            available_capital = available_capital + $1,
+            total_fees_paid = total_fees_paid + $2,
+            total_trades = total_trades + 1,
+            total_realized_pnl = total_realized_pnl + $3,
+            winning_trades = winning_trades + CASE WHEN $3 > 0 THEN 1 ELSE 0 END,
+            losing_trades = losing_trades + CASE WHEN $3 < 0 THEN 1 ELSE 0 END,
+            updated_at = NOW()
+          WHERE id = 1`,
+          [proceeds, fee, netPnl]
+        );
+
+        return { executed: true };
+      });
+
+      if (!result.executed) {
+        return { executed: false, netPnl: 0, fee: 0, reason: result.reason };
+      }
+
+      // 3. Record trade (outside transaction — non-critical)
+      let tradeId: string | undefined;
+      try {
+        const trade = await paperTradesRepo.create({
+          time: new Date(),
+          market_id: marketId,
+          token_id: tokenId,
+          side: 'sell',
+          requested_size: size,
+          executed_size: size,
+          requested_price: exitPrice,
+          executed_price: exitPrice,
+          fee,
+          value_usd: exitValue,
+          signal_id: params.predictionId,
+          signal_type: reason,
+          order_type: 'market',
+          fill_type: 'full',
+        });
+        tradeId = trade.id;
+      } catch (error) {
+        console.error('[PositionClosingService] Failed to record trade (position already closed):', error);
+      }
+
+      return { executed: true, netPnl, fee, tradeId };
+
+    } catch (error) {
+      console.error('[PositionClosingService] Transaction failed:', error);
+      return { executed: false, netPnl: 0, fee: 0, reason: `transaction failed: ${error}` };
+    }
+  }
+}
+
+// Singleton
+let instance: PositionClosingService | null = null;
+
+export function getPositionClosingService(): PositionClosingService {
+  if (!instance) {
+    const feeRate = parseFloat(process.env.TRADING_FEE_RATE || '0.001');
+    instance = new PositionClosingService({ feeRate });
+  }
+  return instance;
+}
+```
+
+**Step 4: Run tests and verify they pass**
+
+```bash
+npx vitest run packages/dashboard/src/services/PositionClosingService.test.ts
+```
+
+Expected: All 5 tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/src/services/PositionClosingService.ts packages/dashboard/src/services/PositionClosingService.test.ts
+git commit -m "feat: add PositionClosingService with consolidated close logic and tests"
+```
+
+---
+
+### Task 4: Wire StopLossService to PositionClosingService
+
+**Files:**
+- Modify: `packages/dashboard/src/services/StopLossService.ts:354-416`
+
+**Step 1: Replace closePosition() in StopLossService**
+
+In `packages/dashboard/src/services/StopLossService.ts`, add import at top:
+
+```typescript
+import { getPositionClosingService } from './PositionClosingService.js';
+```
+
+Replace the `closePosition()` method (lines 354-416) with:
+
+```typescript
+  private async closePosition(
+    positionId: number,
+    marketId: string,
+    tokenId: string,
+    size: number,
+    entryPrice: number,
+    exitPrice: number,
+    reason: 'stop_loss' | 'take_profit' | 'time_exit'
+  ): Promise<{ pnl: number }> {
+    const result = await getPositionClosingService().close({
+      positionId,
+      marketId,
+      tokenId,
+      side: 'long', // StopLoss determines side from position, but close logic handles both
+      size,
+      entryPrice,
+      exitPrice,
+      reason,
+    });
+
+    if (result.executed) {
+      this.emit('position:closed', {
+        marketId,
+        reason,
+        entryPrice,
+        exitPrice,
+        pnl: result.netPnl,
+        pnlPct: ((exitPrice - entryPrice) / entryPrice) * 100,
+      });
+    }
+
+    return { pnl: result.netPnl };
+  }
+```
+
+**Note:** The `side` parameter needs to come from the actual position. Check if StopLossService has access to position.side in the caller. If the caller passes position data, extract `side` from there. If not, we may need to add it to the method signature. Check the callers of `closePosition` in StopLossService to determine.
+
+**Step 2: Check callers pass the right side**
+
+Read lines 150-353 of StopLossService.ts to find how `closePosition` is called and whether position.side is available. The caller likely has the full position object — pass `position.side` through.
+
+If the caller has `position.side`, update the method signature to accept it:
+
+```typescript
+  private async closePosition(
+    positionId: number,
+    marketId: string,
+    tokenId: string,
+    side: 'long' | 'short',
+    size: number,
+    entryPrice: number,
+    exitPrice: number,
+    reason: 'stop_loss' | 'take_profit' | 'time_exit'
+  ): Promise<{ pnl: number }> {
+```
+
+And update callers to pass `position.side`.
+
+**Step 3: Run full test suite**
+
+```bash
+npx vitest run
+```
+
+Expected: All existing tests still pass.
+
+**Step 4: Commit**
+
+```bash
+git add packages/dashboard/src/services/StopLossService.ts
+git commit -m "fix: wire StopLossService to PositionClosingService for correct fee handling"
+```
+
+---
+
+### Task 5: Wire PositionCleanupService to PositionClosingService
+
+**Files:**
+- Modify: `packages/dashboard/src/services/PositionCleanupService.ts:231-280`
+
+**Step 1: Replace closePosition() in PositionCleanupService**
+
+Add import at top:
+
+```typescript
+import { getPositionClosingService } from './PositionClosingService.js';
+```
+
+Replace the `closePosition()` method (lines 231-280) with:
+
+```typescript
+  private async closePosition(
+    positionId: number,
+    marketId: string,
+    tokenId: string,
+    side: 'long' | 'short',
+    size: number,
+    exitPrice: number,
+    pnl: number, // kept for API compat but recalculated internally
+    reason: 'inactive' | 'resolved'
+  ): Promise<void> {
+    const entryPrice = exitPrice - (pnl / size); // reverse-engineer entry price
+
+    await getPositionClosingService().close({
+      positionId,
+      marketId,
+      tokenId,
+      side,
+      size,
+      entryPrice,
+      exitPrice,
+      reason: reason === 'inactive' ? 'cleanup_inactive' : 'cleanup_resolved',
+    });
+  }
+```
+
+**Note:** The current PositionCleanupService receives `pnl` as a parameter (pre-computed by caller). We need entry price for the new service. Check caller to see if `avg_entry_price` is available — it likely is since the position object has it. If so, change the caller to pass `entryPrice` directly instead of `pnl`, and simplify:
+
+```typescript
+  private async closePosition(
+    positionId: number,
+    marketId: string,
+    tokenId: string,
+    side: 'long' | 'short',
+    size: number,
+    entryPrice: number,
+    exitPrice: number,
+    reason: 'inactive' | 'resolved'
+  ): Promise<void> {
+    await getPositionClosingService().close({
+      positionId,
+      marketId,
+      tokenId,
+      side,
+      size,
+      entryPrice,
+      exitPrice,
+      reason: reason === 'inactive' ? 'cleanup_inactive' : 'cleanup_resolved',
+    });
+  }
+```
+
+Update callers accordingly.
+
+**Step 2: Run tests**
+
+```bash
+npx vitest run
+```
+
+**Step 3: Commit**
+
+```bash
+git add packages/dashboard/src/services/PositionCleanupService.ts
+git commit -m "fix: wire PositionCleanupService to PositionClosingService for correct fee handling"
+```
+
+---
+
+### Task 6: Wire AutoSignalExecutor to PositionClosingService
+
+**Files:**
+- Modify: `packages/dashboard/src/services/AutoSignalExecutor.ts:447-584`
+
+**Step 1: Refactor AutoSignalExecutor.closePosition()**
+
+Add import at top:
+
+```typescript
+import { getPositionClosingService } from './PositionClosingService.js';
+```
+
+Replace the closePosition() method (lines 447-584). Keep the price lookup logic (lines 453-480) since it's specific to signal-based exits, but delegate the actual close to PositionClosingService:
+
+```typescript
+  private async closePosition(position: PaperPosition, signal: SignalResult): Promise<SignalProcessResult> {
+    const shares = Number(position.size);
+    const entryPrice = Number(position.avg_entry_price);
+
+    // Get exit price from price_history (same logic as before)
+    let exitPrice = signal.price;
+    try {
+      const isShort = position.side === 'short';
+      const priceResult = await query<{ close: string; price_age_seconds: string }>(
+        `SELECT ph.close, EXTRACT(EPOCH FROM (NOW() - ph.time)) as price_age_seconds
+         FROM markets m
+         JOIN LATERAL (
+           SELECT close, time FROM price_history
+           WHERE token_id = m.clob_token_id_yes
+           ORDER BY time DESC LIMIT 1
+         ) ph ON true
+         WHERE m.id = $1 OR m.condition_id = $1
+         LIMIT 1`,
+        [position.market_id]
+      );
+      if (priceResult.rows[0]) {
+        const yesPrice = parseFloat(priceResult.rows[0].close);
+        const latestPrice = isShort ? 1 - yesPrice : yesPrice;
+        if (latestPrice > 0 && !isNaN(latestPrice)) {
+          exitPrice = latestPrice;
+        }
+      }
+    } catch (error) {
+      console.warn('[AutoExecutor] Failed to get price_history price for exit, using signal price:', error);
+    }
+
+    // Record signal prediction
+    let prediction: SignalPrediction | null = null;
+    try {
+      prediction = await signalPredictionsRepo.create({
+        time: new Date(),
+        market_id: signal.marketId,
+        signal_type: signal.signalId,
+        direction: signal.direction,
+        strength: signal.strength,
+        confidence: signal.confidence,
+        price_at_signal: signal.price,
+        metadata: { ...signal.metadata, action: 'close' },
+      });
+    } catch (error) {
+      console.error('Failed to record prediction:', error);
+    }
+
+    // Delegate close to centralized service
+    const closeResult = await getPositionClosingService().close({
+      positionId: (position as any).id,
+      marketId: signal.marketId,
+      tokenId: position.token_id,
+      side: position.side,
+      size: shares,
+      entryPrice,
+      exitPrice,
+      reason: 'signal',
+      signalId: signal.signalId,
+      predictionId: prediction?.id,
+    });
+
+    if (!closeResult.executed) {
+      return { executed: false, reason: closeResult.reason || 'Close failed' };
+    }
+
+    // Track the trade
+    this.recentTrades.push({ marketId: signal.marketId, timestamp: Date.now() });
+    this.dailyTradeCount++;
+    this.cleanupOldTrades();
+
+    const pnlStr = closeResult.netPnl >= 0 ? `+$${closeResult.netPnl.toFixed(2)}` : `-$${Math.abs(closeResult.netPnl).toFixed(2)}`;
+    this.emit('trade:executed', {
+      signal,
+      tradeId: closeResult.tradeId,
+      prediction,
+      shares,
+      value: shares * exitPrice,
+      action: 'close',
+      pnl: closeResult.netPnl,
+    });
+
+    console.log(`[AutoExecutor] CLOSED: SELL ${shares} shares of ${signal.marketId.substring(0, 20)}... @ $${exitPrice.toFixed(4)} | P&L: ${pnlStr}`);
+
+    return {
+      executed: true,
+      tradeId: closeResult.tradeId,
+      predictionId: prediction?.id,
+      action: 'close',
+      pnl: closeResult.netPnl,
+    };
+  }
+```
+
+**Step 2: Run tests**
+
+```bash
+npx vitest run
+```
+
+**Step 3: Commit**
+
+```bash
+git add packages/dashboard/src/services/AutoSignalExecutor.ts
+git commit -m "refactor: wire AutoSignalExecutor to PositionClosingService"
+```
+
+---
+
+### Task 7: Bayesian Confidence Cap Fix
+
+**Files:**
+- Modify: `packages/dashboard/src/services/SignalEngine.ts:721-746` (Bayesian cap)
+- Modify: `packages/dashboard/src/services/SignalEngine.ts:55-62` (default config)
+- Modify: `packages/dashboard/src/server.ts:81-121` (startup thresholds)
+
+**Step 1: Write test for new Bayesian cap behavior**
+
+Create `packages/dashboard/src/services/SignalEngine.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Test the Bayesian confidence cap logic in isolation.
+ * We extract the pure function to test it without starting the full SignalEngine.
+ */
+
+// Replicate the computation logic for testing
+function computeBayesianConfidenceCap(
+  priceBars: { close: number; source?: string }[],
+  minCap: number = 0.15
+): number {
+  const totalBars = priceBars.length;
+  if (totalBars === 0) return 0;
+
+  let informativeBars = 0;
+  for (let i = 1; i < priceBars.length; i++) {
+    const priceChanged = Math.abs(priceBars[i].close - priceBars[i - 1].close) > 1e-8;
+    const isRealTrade = priceBars[i].source === 'trade';
+
+    if (priceChanged || isRealTrade) {
+      informativeBars++;
+    }
+  }
+
+  const alpha0 = 1;
+  const beta0 = 1;
+  const alpha = alpha0 + informativeBars;
+  const beta = beta0 + (totalBars - informativeBars);
+
+  const priorVar = (alpha0 * beta0) / ((alpha0 + beta0) ** 2 * (alpha0 + beta0 + 1));
+  const posteriorVar = (alpha * beta) / ((alpha + beta) ** 2 * (alpha + beta + 1));
+
+  const cap = 1 - (posteriorVar / priorVar);
+  return Math.max(minCap, Math.min(1, cap));
+}
+
+describe('Bayesian Confidence Cap', () => {
+  it('returns minCap for all-identical snapshot prices', () => {
+    const bars = Array.from({ length: 20 }, () => ({ close: 0.5, source: 'snapshot' }));
+    const cap = computeBayesianConfidenceCap(bars);
+    expect(cap).toBe(0.15); // floor, not 0
+  });
+
+  it('returns high cap when prices change frequently', () => {
+    const bars = Array.from({ length: 20 }, (_, i) => ({
+      close: 0.5 + i * 0.01,
+      source: 'trade',
+    }));
+    const cap = computeBayesianConfidenceCap(bars);
+    expect(cap).toBeGreaterThan(0.8);
+  });
+
+  it('counts trade-sourced bars as informative even if price unchanged', () => {
+    const bars = Array.from({ length: 10 }, () => ({ close: 0.5, source: 'trade' }));
+    const cap = computeBayesianConfidenceCap(bars);
+    expect(cap).toBeGreaterThan(0.15); // trades count as informative
+  });
+
+  it('returns 0 for empty bars', () => {
+    expect(computeBayesianConfidenceCap([])).toBe(0);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run packages/dashboard/src/services/SignalEngine.test.ts
+```
+
+Expected: Should pass (pure function test). This establishes the expected behavior.
+
+**Step 3: Update SignalEngine.ts — Bayesian cap method**
+
+Modify lines 721-746 in `packages/dashboard/src/services/SignalEngine.ts`:
+
+```typescript
+  private computeBayesianConfidenceCap(priceBars: { close: number; source?: string }[]): number {
+    const totalBars = priceBars.length;
+    if (totalBars === 0) return 0;
+
+    const MIN_CAP = 0.15; // Floor: even with no informative bars, allow strong signals through
+
+    // Count informative bars:
+    // - Price changed from previous bar, OR
+    // - Bar came from a real trade (not snapshot)
+    let informativeBars = 0;
+    for (let i = 1; i < priceBars.length; i++) {
+      const priceChanged = Math.abs(priceBars[i].close - priceBars[i - 1].close) > 1e-8;
+      const isRealTrade = (priceBars[i] as any).source === 'trade';
+
+      if (priceChanged || isRealTrade) {
+        informativeBars++;
+      }
+    }
+
+    // Beta-Binomial: prior Beta(alpha0, beta0) = Beta(1, 1) = uniform
+    const alpha0 = 1;
+    const beta0 = 1;
+    const alpha = alpha0 + informativeBars;
+    const beta = beta0 + (totalBars - informativeBars);
+
+    // Variance of Beta distribution: ab / ((a+b)^2 * (a+b+1))
+    const priorVar = (alpha0 * beta0) / ((alpha0 + beta0) ** 2 * (alpha0 + beta0 + 1));
+    const posteriorVar = (alpha * beta) / ((alpha + beta) ** 2 * (alpha + beta + 1));
+
+    // Confidence = reduction in uncertainty, with floor
+    const cap = 1 - (posteriorVar / priorVar);
+    return Math.max(MIN_CAP, Math.min(1, cap));
+  }
+```
+
+**Step 4: Update default thresholds in SignalEngine config**
+
+Modify lines 55-62 in `SignalEngine.ts`:
+
+```typescript
+  minCombinedConfidence: 0.43,   // Default: moderate confidence (optimizer can tune)
+  minCombinedStrength: 0.27,     // Default: moderate strength (optimizer can tune)
+```
+
+**Step 5: Update server.ts to lower minimum thresholds**
+
+Modify lines 82-83 in `server.ts`:
+
+```typescript
+      const MIN_CONFIDENCE = 0.43;  // Minimum confidence threshold
+      const MIN_STRENGTH = 0.27;    // Minimum strength threshold
+```
+
+**Step 6: Verify price bars include source field**
+
+Check that `buildSignalContext()` in SignalEngine.ts includes the `source` column when querying price_history. If not, add it to the SELECT. The query likely looks like:
+
+```sql
+SELECT time, open, high, low, close, volume FROM price_history WHERE ...
+```
+
+Add `source` to the SELECT:
+
+```sql
+SELECT time, open, high, low, close, volume, source FROM price_history WHERE ...
+```
+
+**Step 7: Run tests**
+
+```bash
+npx vitest run
+```
+
+**Step 8: Commit**
+
+```bash
+git add packages/dashboard/src/services/SignalEngine.ts packages/dashboard/src/services/SignalEngine.test.ts packages/dashboard/src/server.ts
+git commit -m "fix: adjust Bayesian cap for snapshot data, lower default thresholds to 0.43/0.27"
+```
+
+---
+
+## Phase 3: Optimization Pipeline
+
+### Task 8: Optuna PostgreSQL Migration
+
+**Files:**
+- Modify: `services/optimizer-server/app/optuna_optimizer.py`
+- Modify: `services/optimizer-server/app/main.py`
+- Modify: `services/optimizer-server/requirements.txt`
+
+**Step 1: Add psycopg2-binary to requirements**
+
+In `services/optimizer-server/requirements.txt`, add:
+
+```
+psycopg2-binary==2.9.9
+```
+
+**Step 2: Rewrite optuna_optimizer.py for PostgreSQL storage**
+
+Replace `services/optimizer-server/app/optuna_optimizer.py` with:
+
+```python
+"""
+Optuna-based optimizer with PostgreSQL persistence.
+
+Studies persist across server restarts via Optuna's native RDB backend.
+"""
+
+import os
+import optuna
+from optuna.samplers import TPESampler, CmaEsSampler, RandomSampler, GridSampler
+from typing import Dict, List, Optional, Any
+from dataclasses import dataclass
+import logging
+import numpy as np
+
+# Suppress Optuna's verbose logging
+optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+logger = logging.getLogger(__name__)
+
+
+def get_storage_url() -> str:
+    """Get PostgreSQL storage URL from environment."""
+    url = os.environ.get("DATABASE_URL", "")
+    if not url:
+        raise RuntimeError("DATABASE_URL environment variable is required")
+    return url
+
+
+@dataclass
+class ParameterDefinition:
+    """Definition of a single parameter to optimize"""
+    name: str
+    param_type: str  # 'float', 'int', 'categorical'
+    low: Optional[float] = None
+    high: Optional[float] = None
+    choices: Optional[List[Any]] = None
+    log: bool = False  # use log scale
+
+
+class OptunaOptimizer:
+    """
+    Wrapper around Optuna study with PostgreSQL persistence.
+
+    Studies are stored in PostgreSQL, so they survive server restarts.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        parameters: List[ParameterDefinition],
+        direction: str = "maximize",
+        sampler: str = "tpe",
+        n_startup_trials: int = 10,
+        seed: Optional[int] = None,
+        storage: Optional[str] = None
+    ):
+        self.name = name
+        self.parameters = {p.name: p for p in parameters}
+        self.direction = direction
+        self._storage = storage or get_storage_url()
+
+        # Create sampler
+        if sampler == "tpe":
+            sampler_obj = TPESampler(
+                n_startup_trials=n_startup_trials,
+                seed=seed
+            )
+        elif sampler == "cmaes":
+            sampler_obj = CmaEsSampler(seed=seed)
+        elif sampler == "random":
+            sampler_obj = RandomSampler(seed=seed)
+        elif sampler == "grid":
+            search_space = self._build_grid_search_space()
+            sampler_obj = GridSampler(search_space)
+        else:
+            raise ValueError(f"Unknown sampler: {sampler}")
+
+        # Create study with PostgreSQL storage
+        self.study = optuna.create_study(
+            study_name=name,
+            direction=direction,
+            sampler=sampler_obj,
+            storage=self._storage,
+            load_if_exists=False  # New study for each optimization run
+        )
+
+        # Track running trials (in-memory, acceptable to lose on restart
+        # since the dashboard will create a new optimizer session)
+        self._running_trials: Dict[int, optuna.trial.Trial] = {}
+        self._trial_metrics: Dict[int, Dict[str, float]] = {}
+
+    @classmethod
+    def load(cls, name: str, storage: Optional[str] = None) -> 'OptunaOptimizer':
+        """Load an existing study from PostgreSQL."""
+        storage_url = storage or get_storage_url()
+        study = optuna.load_study(study_name=name, storage=storage_url)
+
+        instance = cls.__new__(cls)
+        instance.name = name
+        instance.study = study
+        instance._storage = storage_url
+        instance.parameters = {}
+        instance._running_trials = {}
+        instance._trial_metrics = {}
+        instance.direction = study.direction.name.lower()
+        return instance
+
+    def _build_grid_search_space(self) -> Dict[str, List[Any]]:
+        """Build search space for grid sampler"""
+        search_space = {}
+        for name, param in self.parameters.items():
+            if param.param_type == "categorical":
+                search_space[name] = param.choices
+            elif param.param_type == "int":
+                n_points = min(10, int(param.high - param.low + 1))
+                search_space[name] = list(range(int(param.low), int(param.high) + 1,
+                    max(1, int((param.high - param.low) / n_points))))
+            elif param.param_type == "float":
+                if param.log:
+                    search_space[name] = list(np.logspace(
+                        np.log10(param.low), np.log10(param.high), 10
+                    ))
+                else:
+                    search_space[name] = list(np.linspace(param.low, param.high, 10))
+        return search_space
+
+    def suggest(self, n_suggestions: int = 1) -> List[Dict[str, Any]]:
+        """Get parameter suggestions for the next trials."""
+        suggestions = []
+
+        for _ in range(n_suggestions):
+            trial = self.study.ask()
+
+            params = {}
+            for name, param in self.parameters.items():
+                if param.param_type == "float":
+                    params[name] = trial.suggest_float(
+                        name, param.low, param.high, log=param.log
+                    )
+                elif param.param_type == "int":
+                    params[name] = trial.suggest_int(
+                        name, int(param.low), int(param.high), log=param.log
+                    )
+                elif param.param_type == "categorical":
+                    params[name] = trial.suggest_categorical(name, param.choices)
+
+            self._running_trials[trial.number] = trial
+
+            suggestions.append({
+                "trial_id": trial.number,
+                "params": params
+            })
+
+        return suggestions
+
+    def report(
+        self,
+        trial_id: int,
+        score: float,
+        metrics: Optional[Dict[str, float]] = None
+    ):
+        """Report the result of a trial."""
+        if trial_id not in self._running_trials:
+            raise ValueError(f"Unknown trial_id: {trial_id}")
+
+        trial = self._running_trials[trial_id]
+
+        if metrics:
+            for key, value in metrics.items():
+                trial.set_user_attr(key, value)
+            self._trial_metrics[trial_id] = metrics
+
+        self.study.tell(trial, score)
+        del self._running_trials[trial_id]
+
+    def get_best(self) -> Optional[Dict[str, Any]]:
+        """Get the best parameters found so far"""
+        if self.n_complete_trials == 0:
+            return None
+
+        best_trial = self.study.best_trial
+        return {
+            "params": best_trial.params,
+            "score": best_trial.value,
+            "trial_id": best_trial.number,
+            "metrics": self._trial_metrics.get(best_trial.number, {})
+        }
+
+    def get_optimization_history(self) -> List[Dict[str, Any]]:
+        """Get the optimization history"""
+        history = []
+        for trial in self.study.trials:
+            if trial.state == optuna.trial.TrialState.COMPLETE:
+                history.append({
+                    "trial_id": trial.number,
+                    "params": trial.params,
+                    "score": trial.value,
+                    "metrics": self._trial_metrics.get(trial.number, {})
+                })
+        return history
+
+    def get_param_importances(self) -> Dict[str, float]:
+        """Get parameter importance scores"""
+        if self.n_complete_trials < 10:
+            return {}
+
+        try:
+            importances = optuna.importance.get_param_importances(self.study)
+            return dict(importances)
+        except Exception as e:
+            logger.warning(f"Could not compute parameter importances: {e}")
+            return {}
+
+    @property
+    def n_trials(self) -> int:
+        return len(self.study.trials)
+
+    @property
+    def n_complete_trials(self) -> int:
+        return len([t for t in self.study.trials
+                   if t.state == optuna.trial.TrialState.COMPLETE])
+
+    @property
+    def n_running_trials(self) -> int:
+        return len(self._running_trials)
+
+    @staticmethod
+    def delete_study(name: str, storage: Optional[str] = None):
+        """Delete a study from PostgreSQL storage."""
+        storage_url = storage or get_storage_url()
+        try:
+            optuna.delete_study(study_name=name, storage=storage_url)
+        except KeyError:
+            pass  # Study doesn't exist, that's fine
+
+
+# Keep predefined parameter spaces unchanged
+def get_default_parameter_space() -> List[ParameterDefinition]:
+    return [
+        ParameterDefinition("combiner.minCombinedConfidence", "float", 0.1, 0.7),
+        ParameterDefinition("combiner.minCombinedStrength", "float", 0.1, 0.7),
+        ParameterDefinition("combiner.onlyDirection", "categorical", choices=[None, "LONG", "SHORT"]),
+        ParameterDefinition("combiner.momentumWeight", "float", 0.0, 3.0),
+        ParameterDefinition("combiner.meanReversionWeight", "float", 0.0, 3.0),
+        ParameterDefinition("combiner.conflictResolution", "categorical", choices=["weighted", "strongest", "majority"]),
+        ParameterDefinition("combiner.timeDecayFactor", "float", 0.5, 1.0),
+        ParameterDefinition("combiner.maxSignalAgeMinutes", "int", 5, 60),
+        ParameterDefinition("risk.maxPositionSizePct", "float", 1.0, 25.0),
+        ParameterDefinition("risk.maxExposurePct", "float", 20.0, 100.0),
+        ParameterDefinition("risk.stopLossPct", "float", 5.0, 40.0),
+        ParameterDefinition("risk.takeProfitPct", "float", 10.0, 150.0),
+        ParameterDefinition("risk.maxPositions", "int", 3, 30),
+        ParameterDefinition("risk.maxDrawdownPct", "float", 10.0, 40.0),
+        ParameterDefinition("risk.minCashBufferPct", "float", 5.0, 30.0),
+        ParameterDefinition("sizing.method", "categorical", choices=["fixed", "kelly", "volatility_adjusted"]),
+        ParameterDefinition("sizing.kellyFraction", "float", 0.1, 0.5),
+        ParameterDefinition("sizing.volatilityLookback", "int", 10, 50),
+        ParameterDefinition("momentum.rsiPeriod", "int", 5, 28),
+        ParameterDefinition("momentum.rsiOverbought", "float", 60.0, 90.0),
+        ParameterDefinition("momentum.rsiOversold", "float", 10.0, 40.0),
+        ParameterDefinition("momentum.macdFast", "int", 6, 18),
+        ParameterDefinition("momentum.macdSlow", "int", 18, 35),
+        ParameterDefinition("momentum.macdSignal", "int", 5, 15),
+        ParameterDefinition("momentum.trendLookback", "int", 10, 50),
+        ParameterDefinition("momentum.minTrendStrength", "float", 0.0, 0.3),
+        ParameterDefinition("meanReversion.bollingerPeriod", "int", 10, 40),
+        ParameterDefinition("meanReversion.bollingerStdDev", "float", 1.0, 4.0),
+        ParameterDefinition("meanReversion.zScorePeriod", "int", 5, 40),
+        ParameterDefinition("meanReversion.zScoreThreshold", "float", 1.0, 4.0),
+        ParameterDefinition("meanReversion.meanType", "categorical", choices=["sma", "ema", "wma"]),
+        ParameterDefinition("marketFilters.minVolume24h", "float", 100.0, 10000.0, log=True),
+        ParameterDefinition("marketFilters.minLiquidity", "float", 1000.0, 50000.0, log=True),
+        ParameterDefinition("marketFilters.priceRangeMin", "float", 0.02, 0.15),
+        ParameterDefinition("marketFilters.priceRangeMax", "float", 0.85, 0.98),
+        ParameterDefinition("marketFilters.minDaysToExpiry", "int", 1, 14),
+        ParameterDefinition("timing.tradingHoursStart", "int", 0, 12),
+        ParameterDefinition("timing.tradingHoursEnd", "int", 12, 24),
+        ParameterDefinition("timing.avoidWeekends", "categorical", choices=[True, False]),
+        ParameterDefinition("timing.minBarsBetweenTrades", "int", 1, 24),
+        ParameterDefinition("execution.slippageModel", "categorical", choices=["fixed", "proportional", "orderbook"]),
+        ParameterDefinition("execution.fixedSlippageBps", "int", 10, 100),
+        ParameterDefinition("execution.maxSlippagePct", "float", 0.5, 3.0),
+    ]
+
+
+def get_minimal_parameter_space() -> List[ParameterDefinition]:
+    return [
+        ParameterDefinition("combiner.minCombinedConfidence", "float", 0.1, 0.6),
+        ParameterDefinition("combiner.minCombinedStrength", "float", 0.1, 0.6),
+        ParameterDefinition("combiner.onlyDirection", "categorical", choices=[None, "LONG", "SHORT"]),
+        ParameterDefinition("risk.maxPositionSizePct", "float", 2.0, 20.0),
+        ParameterDefinition("risk.maxPositions", "int", 3, 20),
+        ParameterDefinition("momentum.rsiPeriod", "int", 7, 21),
+        ParameterDefinition("meanReversion.bollingerPeriod", "int", 15, 30),
+        ParameterDefinition("meanReversion.zScoreThreshold", "float", 1.5, 3.0),
+    ]
+```
+
+**Step 3: Rewrite main.py to use study names instead of in-memory dict**
+
+Replace `services/optimizer-server/app/main.py`:
+
+```python
+"""
+Polymarket Strategy Optimizer Server
+
+FastAPI server that provides Bayesian optimization via Optuna
+with PostgreSQL persistence for the TypeScript trading system.
+"""
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from typing import Dict, List, Optional, Any
+import uuid
+from datetime import datetime
+
+from .optuna_optimizer import OptunaOptimizer, ParameterDefinition
+
+app = FastAPI(
+    title="Polymarket Strategy Optimizer",
+    description="Bayesian optimization service with PostgreSQL persistence",
+    version="2.0.0"
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Track active optimizer names (for suggest/report with in-memory running trials)
+# The actual study data is in PostgreSQL — this just maps IDs to loaded instances
+_active_optimizers: Dict[str, OptunaOptimizer] = {}
+
+
+# ============================================
+# Request/Response Models (unchanged API contract)
+# ============================================
+
+class ParameterBounds(BaseModel):
+    name: str
+    type: str
+    low: Optional[float] = None
+    high: Optional[float] = None
+    choices: Optional[List[Any]] = None
+    log: bool = False
+
+class CreateOptimizerRequest(BaseModel):
+    name: str
+    parameters: List[ParameterBounds]
+    direction: str = "maximize"
+    sampler: str = "tpe"
+    n_startup_trials: int = 10
+
+class CreateOptimizerResponse(BaseModel):
+    optimizer_id: str
+    name: str
+    parameter_names: List[str]
+    created_at: str
+
+class SuggestRequest(BaseModel):
+    optimizer_id: str
+    n_suggestions: int = 1
+
+class SuggestResponse(BaseModel):
+    trial_ids: List[int]
+    suggestions: List[Dict[str, Any]]
+
+class ReportRequest(BaseModel):
+    optimizer_id: str
+    trial_id: int
+    score: float
+    metrics: Optional[Dict[str, float]] = None
+
+class ReportResponse(BaseModel):
+    recorded: bool
+    best_score: Optional[float]
+    best_params: Optional[Dict[str, Any]]
+    n_trials: int
+
+class BestParamsResponse(BaseModel):
+    best_params: Optional[Dict[str, Any]]
+    best_score: Optional[float]
+    n_trials: int
+    optimization_history: List[Dict[str, Any]]
+
+class OptimizerStatusResponse(BaseModel):
+    optimizer_id: str
+    name: str
+    n_trials: int
+    n_complete: int
+    n_running: int
+    best_score: Optional[float]
+    best_params: Optional[Dict[str, Any]]
+
+
+# ============================================
+# Helpers
+# ============================================
+
+def _get_optimizer(optimizer_id: str) -> OptunaOptimizer:
+    """Get optimizer from active cache, or try to reload from DB."""
+    if optimizer_id in _active_optimizers:
+        return _active_optimizers[optimizer_id]
+
+    # Try loading from PostgreSQL (study_name = optimizer_id)
+    try:
+        optimizer = OptunaOptimizer.load(optimizer_id)
+        _active_optimizers[optimizer_id] = optimizer
+        return optimizer
+    except Exception:
+        raise HTTPException(status_code=404, detail="Optimizer not found")
+
+
+# ============================================
+# Endpoints
+# ============================================
+
+@app.get("/health")
+async def health_check():
+    return {"status": "healthy", "timestamp": datetime.utcnow().isoformat()}
+
+
+@app.post("/optimizer/create", response_model=CreateOptimizerResponse)
+async def create_optimizer(request: CreateOptimizerRequest):
+    """Create a new optimization session with PostgreSQL-backed study."""
+    # Use a unique study name as the optimizer_id
+    optimizer_id = f"{request.name}-{uuid.uuid4().hex[:8]}"
+
+    param_defs = []
+    for p in request.parameters:
+        param_def = ParameterDefinition(
+            name=p.name,
+            param_type=p.type,
+            low=p.low,
+            high=p.high,
+            choices=p.choices,
+            log=p.log
+        )
+        param_defs.append(param_def)
+
+    optimizer = OptunaOptimizer(
+        name=optimizer_id,
+        parameters=param_defs,
+        direction=request.direction,
+        sampler=request.sampler,
+        n_startup_trials=request.n_startup_trials
+    )
+
+    _active_optimizers[optimizer_id] = optimizer
+
+    return CreateOptimizerResponse(
+        optimizer_id=optimizer_id,
+        name=request.name,
+        parameter_names=[p.name for p in request.parameters],
+        created_at=datetime.utcnow().isoformat()
+    )
+
+
+@app.post("/optimizer/suggest", response_model=SuggestResponse)
+async def suggest_params(request: SuggestRequest):
+    optimizer = _get_optimizer(request.optimizer_id)
+    suggestions = optimizer.suggest(request.n_suggestions)
+
+    return SuggestResponse(
+        trial_ids=[s["trial_id"] for s in suggestions],
+        suggestions=[s["params"] for s in suggestions]
+    )
+
+
+@app.post("/optimizer/report", response_model=ReportResponse)
+async def report_result(request: ReportRequest):
+    optimizer = _get_optimizer(request.optimizer_id)
+    optimizer.report(request.trial_id, request.score, request.metrics)
+
+    best = optimizer.get_best()
+
+    return ReportResponse(
+        recorded=True,
+        best_score=best["score"] if best else None,
+        best_params=best["params"] if best else None,
+        n_trials=optimizer.n_complete_trials
+    )
+
+
+@app.get("/optimizer/{optimizer_id}/best", response_model=BestParamsResponse)
+async def get_best_params(optimizer_id: str):
+    optimizer = _get_optimizer(optimizer_id)
+    best = optimizer.get_best()
+    history = optimizer.get_optimization_history()
+
+    return BestParamsResponse(
+        best_params=best["params"] if best else None,
+        best_score=best["score"] if best else None,
+        n_trials=optimizer.n_complete_trials,
+        optimization_history=history
+    )
+
+
+@app.get("/optimizer/{optimizer_id}/status", response_model=OptimizerStatusResponse)
+async def get_optimizer_status(optimizer_id: str):
+    optimizer = _get_optimizer(optimizer_id)
+    best = optimizer.get_best()
+
+    return OptimizerStatusResponse(
+        optimizer_id=optimizer_id,
+        name=optimizer.name,
+        n_trials=optimizer.n_trials,
+        n_complete=optimizer.n_complete_trials,
+        n_running=optimizer.n_running_trials,
+        best_score=best["score"] if best else None,
+        best_params=best["params"] if best else None
+    )
+
+
+@app.delete("/optimizer/{optimizer_id}")
+async def delete_optimizer(optimizer_id: str):
+    # Remove from active cache
+    _active_optimizers.pop(optimizer_id, None)
+
+    # Delete study from PostgreSQL
+    OptunaOptimizer.delete_study(optimizer_id)
+
+    return {"deleted": True}
+
+
+@app.get("/optimizers")
+async def list_optimizers():
+    result = []
+    for opt_id, optimizer in _active_optimizers.items():
+        best = optimizer.get_best()
+        result.append({
+            "optimizer_id": opt_id,
+            "name": optimizer.name,
+            "n_trials": optimizer.n_complete_trials,
+            "best_score": best["score"] if best else None
+        })
+    return {"optimizers": result}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+```
+
+**Step 4: Deploy to Render**
+
+Add `DATABASE_URL` environment variable to the Render service, pointing to TimescaleDB on the GCP VM. The URL format:
+
+```
+postgresql://polymarket:polymarket_prod@<VM_EXTERNAL_IP>:5432/polymarket_trading
+```
+
+**Note:** TimescaleDB must accept external connections. If it only listens on Docker network, you'll need to either:
+- Expose port 5432 on the VM (add firewall rule, only allow Render IPs)
+- Or use an SSH tunnel
+
+If external access isn't feasible, an alternative is to deploy the optimizer on the GCP VM itself as a Docker container alongside TimescaleDB.
+
+**Step 5: Commit**
+
+```bash
+git add services/optimizer-server/
+git commit -m "feat: migrate Optuna to PostgreSQL-backed storage for restart resilience"
+```
+
+---
+
+### Task 9: Wire Optimization Weights to signal_weights Table
+
+**Files:**
+- Modify: `packages/dashboard/src/services/OptimizationScheduler.ts:637-740`
+- Modify: `packages/dashboard/src/server.ts:81-121`
+
+**Step 1: Add weight application to updateStrategy()**
+
+In `OptimizationScheduler.ts`, after line 678 (the DB save), add the weight extraction and application:
+
+```typescript
+    // Apply optimized signal weights to database
+    const WEIGHT_PARAM_MAP: Record<string, string> = {
+      'combiner.momentumWeight': 'momentum',
+      'combiner.meanReversionWeight': 'mean_reversion',
+    };
+
+    const MIN_WEIGHT = 0.05;
+    const MAX_WEIGHT = 0.95;
+
+    for (const [paramKey, signalType] of Object.entries(WEIGHT_PARAM_MAP)) {
+      const rawWeight = result.params[paramKey];
+      if (rawWeight !== undefined && rawWeight !== null) {
+        const weight = Math.max(MIN_WEIGHT, Math.min(MAX_WEIGHT, Number(rawWeight)));
+
+        try {
+          await signalWeightsRepo.update(signalType, weight, `optimization-${new Date().toISOString().slice(0, 10)}`);
+          console.log(`[OptimizationScheduler] Updated signal weight: ${signalType} = ${weight.toFixed(4)}`);
+        } catch (err) {
+          console.error(`[OptimizationScheduler] Failed to update weight ${signalType}:`, err);
+        }
+      }
+    }
+```
+
+Add import at top if not already present:
+
+```typescript
+import { signalWeightsRepo } from '../database/repositories.js';
+```
+
+**Step 2: Update server.ts to load signal weights from best_params on startup**
+
+After the existing threshold loading in `server.ts` (around line 105), add:
+
+```typescript
+          // Also load optimized signal weights
+          const weightMap: Record<string, string> = {
+            'combiner.momentumWeight': 'momentum',
+            'combiner.meanReversionWeight': 'mean_reversion',
+          };
+          for (const [paramKey, signalType] of Object.entries(weightMap)) {
+            const w = params[paramKey];
+            if (w !== undefined) {
+              try {
+                await signalWeightsRepo.update(signalType, Number(w), 'startup-load');
+                console.log(`Loaded optimized weight: ${signalType} = ${w}`);
+              } catch (err) {
+                console.warn(`Failed to load weight ${signalType}:`, err);
+              }
+            }
+          }
+```
+
+Add import:
+```typescript
+import { signalWeightsRepo } from './database/repositories.js';
+```
+
+**Step 3: Run tests**
+
+```bash
+npx vitest run
+```
+
+**Step 4: Commit**
+
+```bash
+git add packages/dashboard/src/services/OptimizationScheduler.ts packages/dashboard/src/server.ts
+git commit -m "feat: wire optimization weights to signal_weights table"
+```
+
+---
+
+## Phase 4: Validate
+
+### Task 10: Apply DB Mitigations (Based on Phase 1 Findings)
+
+This task depends on the output of Task 1 (TimescaleDB diagnostics). Based on findings, apply one or more of:
+
+**If price_history has no retention policy:**
+
+```sql
+-- Add 30-day retention (run via psql on VM)
+SELECT add_retention_policy('price_history', INTERVAL '30 days');
+```
+
+**If price_history missing indexes:**
+
+```sql
+-- Composite index for signal engine queries
+CREATE INDEX IF NOT EXISTS idx_price_history_token_time
+  ON price_history (token_id, time DESC);
+```
+
+**If continuous aggregate refresh is too frequent:**
+
+```sql
+-- Check current policy
+SELECT * FROM timescaledb_information.jobs WHERE proc_name LIKE '%refresh%';
+
+-- Reduce frequency if needed (example)
+SELECT alter_job(<job_id>, schedule_interval => INTERVAL '30 minutes');
+```
+
+**If too many connections:**
+
+Reduce `DB_POOL_MAX` in docker-compose.gcp.yml from 5 to 3 per service.
+
+**Step 1: Run diagnostics, analyze output, apply fixes**
+
+**Step 2: Commit any migration SQL files or docker-compose changes**
+
+```bash
+git commit -m "fix: apply TimescaleDB performance mitigations"
+```
+
+---
+
+### Task 11: Account Reconciliation (Run and Apply)
+
+**Step 1: Run the reconciliation script from Task 2**
+
+```bash
+NODE_TLS_REJECT_UNAUTHORIZED=0 DATABASE_URL="..." node scripts/reconcile-account.js
+```
+
+**Step 2: Review the output**
+
+Verify the orphaned BUYs match the expected ~$2,674.78 gap.
+
+**Step 3: Apply the adjustment (after review)**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  'docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c "
+    UPDATE paper_account SET
+      current_capital = current_capital + <ADJUSTMENT>,
+      available_capital = available_capital + <ADJUSTMENT>
+    WHERE id = 1;
+  "'
+```
+
+---
+
+### Task 12: Deploy and Monitor
+
+**Step 1: Push changes and let CI/CD build images**
+
+```bash
+git push origin main
+```
+
+**Step 2: Deploy to VM**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- '
+  cd /opt/polymarket-trader &&
+  docker compose -f docker-compose.gcp.yml pull &&
+  docker compose -f docker-compose.gcp.yml up -d --remove-orphans
+'
+```
+
+**Step 3: Monitor for 24h**
+
+Check these after deploy:
+```bash
+# Signals being generated
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  'docker compose -f docker-compose.gcp.yml logs --tail=50 dashboard-api | grep -E "(signals generated|Signal|CLOSED|OPENED)"'
+
+# DB CPU
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  'docker stats --no-stream'
+
+# Account health
+NODE_TLS_REJECT_UNAUTHORIZED=0 DATABASE_URL="..." node scripts/check-status.js
+```
+
+**Step 4: Verify optimization runs successfully**
+
+Wait for next scheduled optimization (every 6h) and check:
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  'docker compose -f docker-compose.gcp.yml logs --tail=100 dashboard-api | grep -i optim'
+```
+
+Expected: No more "Optimizer not found" 404 errors. Weights should update in signal_weights table.
+
+---
+
+## Summary
+
+| Task | Phase | Estimated Steps | Key File |
+|------|-------|----------------|----------|
+| 1. DB Diagnostics | 1 | 3 | `scripts/diagnose-db-cpu.js` |
+| 2. Account Reconciliation | 1 | 3 | `scripts/reconcile-account.js` |
+| 3. PositionClosingService | 2 | 5 | `packages/dashboard/src/services/PositionClosingService.ts` |
+| 4. Wire StopLossService | 2 | 4 | `packages/dashboard/src/services/StopLossService.ts` |
+| 5. Wire PositionCleanupService | 2 | 3 | `packages/dashboard/src/services/PositionCleanupService.ts` |
+| 6. Wire AutoSignalExecutor | 2 | 3 | `packages/dashboard/src/services/AutoSignalExecutor.ts` |
+| 7. Bayesian Cap Fix | 2 | 8 | `packages/dashboard/src/services/SignalEngine.ts` |
+| 8. Optuna PostgreSQL | 3 | 5 | `services/optimizer-server/app/main.py` |
+| 9. Wire Weights | 3 | 4 | `packages/dashboard/src/services/OptimizationScheduler.ts` |
+| 10. DB Mitigations | 4 | 2 | SQL on VM |
+| 11. Account Fix | 4 | 3 | SQL on VM |
+| 12. Deploy & Monitor | 4 | 4 | CI/CD |
+
+**Parallel execution opportunities:**
+- Tasks 1+2 (both diagnostic scripts)
+- Tasks 3-6 and Task 7 (position closing vs signal engine — independent)
+- Tasks 8+9 and Tasks 3-7 (optimization vs core fixes — different codepaths)

--- a/docs/plans/2026-03-11-phase2-risk-fixes-design.md
+++ b/docs/plans/2026-03-11-phase2-risk-fixes-design.md
@@ -1,0 +1,203 @@
+# Phase 2: Risk & Protection Fixes — 2026-03-11
+
+## Context
+
+After Phase 1 (PR #6) fixed PnL accounting, signal generation, and optimization pipeline, GitHub issues #5 and #7 surfaced 6 remaining problems. Ordered by severity.
+
+---
+
+## 1. CRITICAL: trading_config Table Missing — CircuitBreaker Non-Functional
+
+**Problem:** `CircuitBreakerService` writes to `trading_config` table, but the table was never created. INSERT fails silently → circuit breaker never halts trading, even during cascading losses.
+
+**Design:**
+
+Add `CREATE TABLE IF NOT EXISTS` at CircuitBreakerService startup:
+
+```sql
+CREATE TABLE IF NOT EXISTS trading_config (
+  key VARCHAR(255) PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+Plus in-memory fallback: `this.isHalted: boolean` flag. When DB write fails, set the flag. `shouldHalt()` checks flag OR DB. This way even a DB outage can't bypass the breaker.
+
+**Scope:** ~15 lines in `CircuitBreakerService.ts`.
+
+---
+
+## 2. CRITICAL: No Stop-Loss Re-Entry Cooldown
+
+**Problem:** After StopLossService closes a position (e.g., Chelsea EPL at -15%), the next signal cycle finds no open position → opens a new one → stopped out again. Observed 30+ re-entries on same market.
+
+**Design:**
+
+In-memory cooldown map in `AutoSignalExecutor`:
+
+```typescript
+private stoppedOutMarkets: Map<string, number> = new Map(); // marketId → timestamp
+
+// On position close event (from PositionClosingService):
+if (reason === 'stop_loss') {
+  this.stoppedOutMarkets.set(marketId, Date.now());
+}
+
+// In processSignal(), before opening:
+const stoppedAt = this.stoppedOutMarkets.get(signal.marketId);
+if (stoppedAt && Date.now() - stoppedAt < STOP_LOSS_COOLDOWN_MS) {
+  logger.info(`Cooldown active for ${signal.marketId}, skipping`);
+  return;
+}
+```
+
+**Constants:**
+- `STOP_LOSS_COOLDOWN_MS = 4 * 60 * 60 * 1000` (4 hours)
+
+**In-memory is acceptable** — cooldown loss on restart means at most one extra re-entry before the map rebuilds. Not worth DB persistence for this.
+
+**Scope:** ~15 lines in `AutoSignalExecutor.ts`.
+
+---
+
+## 3. HIGH: No Per-Market Position Concentration Limit
+
+**Problem:** System can open unlimited positions on the same market. Combined with issue #2, this concentrates risk on a single losing market.
+
+**Design:**
+
+Check in `AutoSignalExecutor.processSignal()` before opening:
+
+```typescript
+const openOnMarket = positions.filter(
+  p => p.market_id === signal.marketId && p.size > 0
+).length;
+if (openOnMarket >= MAX_POSITIONS_PER_MARKET) {
+  logger.info(`Market ${signal.marketId} at position limit (${openOnMarket})`);
+  return;
+}
+```
+
+**Constants:**
+- `MAX_POSITIONS_PER_MARKET = 2`
+
+**Scope:** ~5 lines in `AutoSignalExecutor.ts`.
+
+---
+
+## 4. HIGH: RiskManager Defaults to ALLOW on Failure
+
+**Problem:** `RiskManager.canOpenPosition()` (line 446-449) catches DB errors and returns `{ allowed: true }`. During DB outage, all risk checks are bypassed — positions open unchecked.
+
+**Design:**
+
+Change catch blocks to BLOCK:
+
+```typescript
+// canOpenPosition() catch block:
+catch (error) {
+  logger.error('Risk check failed, BLOCKING trade:', error);
+  return { allowed: false, reason: 'risk_check_failed' };
+}
+
+// checkRisk() catch block — return degraded status:
+catch (error) {
+  logger.error('checkRisk failed, returning degraded:', error);
+  return { status: 'degraded', allowed: false };
+}
+```
+
+**Trade-off:** DB hiccup = no trades until recovery. Correct for real money — missing an opportunity beats opening unchecked positions.
+
+**Scope:** ~4 lines changed in `RiskManager.ts`.
+
+---
+
+## 5. MEDIUM: Sports/Rapid-Resolution Market Protection
+
+**Problem:** Sports markets resolve within hours. Our technical indicators (RSI, Bollinger, MACD) aren't designed for binary-resolution markets. Mean reversion is nonsensical on a market trending toward 0 or 1.
+
+**Design:**
+
+When market resolves within 24 hours, apply stricter controls instead of blocking entirely:
+
+```typescript
+const market = await this.getMarketDetails(signal.marketId);
+if (market.end_date_iso) {
+  const hoursToResolution = (new Date(market.end_date_iso).getTime() - Date.now()) / 3600000;
+
+  if (hoursToResolution < NEAR_RESOLUTION_HOURS) {
+    // Block mean-reversion signals — nonsensical near resolution
+    if (signal.signalType === 'mean_reversion') return;
+
+    // Require higher confidence
+    if (signal.confidence < MIN_CONFIDENCE_NEAR_RESOLUTION) return;
+
+    // Flag for half position size
+    signal.nearResolution = true;
+  }
+}
+```
+
+**Constants:**
+- `NEAR_RESOLUTION_HOURS = 24`
+- `MIN_CONFIDENCE_NEAR_RESOLUTION = 0.65` (~1.5x normal threshold)
+- Position size `* 0.5` when `nearResolution === true`
+- Stop-loss on near-resolution market → permanent cooldown (no re-entry, via Section 2 mechanism)
+
+**`end_date_iso` null** → passes filter (open-ended market, no imminent resolution risk).
+
+**Scope:** ~20 lines in `processSignal()`, ~3 lines in sizing logic.
+
+---
+
+## 6. LOW: 50/50 Market Filtering
+
+**Problem:** Markets at 0.45-0.55 are coin flips. Technical indicators produce noise signals, and fees (~2% roundtrip) make expected value negative.
+
+**Design:**
+
+Add filter alongside existing extreme-price filter in `SignalEngine.generateSignals()`:
+
+```typescript
+if (price > 0.45 && price < 0.55) {
+  logger.debug(`Skipping 50/50 market ${marketId} (price=${price})`);
+  continue;
+}
+```
+
+**Constants:**
+- `FIFTY_FIFTY_BAND = [0.45, 0.55]`
+
+**Scope:** 3 lines in `SignalEngine.ts`.
+
+---
+
+## Files Affected
+
+| File | Change |
+|------|--------|
+| `packages/dashboard/src/services/CircuitBreakerService.ts` | Create `trading_config` table at init + in-memory fallback |
+| `packages/dashboard/src/services/AutoSignalExecutor.ts` | Stop-loss cooldown map, per-market limit, near-resolution controls |
+| `packages/dashboard/src/services/RiskManager.ts` | Default to BLOCK on failure |
+| `packages/dashboard/src/services/SignalEngine.ts` | 50/50 market filter |
+
+**Total: 4 files modified, 0 new files. ~60 lines added.**
+
+---
+
+## Roadmap: Dedicated Pre-Resolution Signal Model
+
+The near-resolution controls (Section 5) and 50/50 filter (Section 6) are stopgaps. Both assume our current technical indicators can't handle these market types — which is correct today.
+
+**Next phase:** Build a dedicated signal generator for markets approaching resolution:
+
+- **Data sources:** External odds (bookmaker APIs), news sentiment, social volume, historical resolution patterns
+- **Model type:** Not technical indicators. Probability estimation from fundamental data.
+- **When it's ready:**
+  - Near-resolution markets (Section 5) would use this model instead of momentum-only with high confidence threshold
+  - 50/50 markets (Section 6) could be unblocked if the model has fundamental edge — the 50/50 filter would only apply to technical signals, not fundamental ones
+- **Trigger:** After Phase 2 is stable and generating consistent positive PnL with current signal types
+
+This should be the immediate priority after Phase 2 stabilizes.

--- a/docs/plans/2026-03-11-phase2-risk-fixes-plan.md
+++ b/docs/plans/2026-03-11-phase2-risk-fixes-plan.md
@@ -1,0 +1,959 @@
+# Phase 2: Risk & Protection Fixes — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix 6 risk/protection issues (trading_config missing, stop-loss re-entry, per-market limit, RiskManager fail-open, near-resolution markets, 50/50 filtering) to make the system safe for real-money trading.
+
+**Architecture:** All fixes are in-process changes to existing services. No new files except tests. PositionClosingService gains EventEmitter to enable cross-service communication for stop-loss cooldown. All changes are backward-compatible.
+
+**Tech Stack:** TypeScript, Vitest, PostgreSQL, EventEmitter pattern
+
+**Test runner:** `cd packages/dashboard && npx vitest run <file> --reporter=verbose`
+
+**Build check:** `cd packages/dashboard && npx tsc --noEmit`
+
+---
+
+### Task 1: CircuitBreakerService — Create trading_config Table + In-Memory Fallback
+
+**Files:**
+- Modify: `packages/dashboard/src/services/CircuitBreakerService.ts`
+- Create: `packages/dashboard/src/services/CircuitBreakerService.test.ts`
+
+**Context:**
+- `haltTrading()` (line 313) and `resumeTrading()` (line 333) INSERT/UPDATE `trading_config` table
+- RiskManager also writes to `trading_config` (line 319-327)
+- Table never created → INSERTs fail silently → circuit breaker non-functional
+- Need: CREATE TABLE IF NOT EXISTS at startup + in-memory `isHaltedInMemory` flag
+
+**Step 1: Write the failing tests**
+
+```typescript
+// packages/dashboard/src/services/CircuitBreakerService.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../database/index.js', () => ({
+  query: vi.fn(),
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+vi.mock('../database/repositories.js', () => ({
+  paperTradesRepo: { create: vi.fn() },
+  paperPositionsRepo: { getAll: vi.fn() },
+}));
+
+// Mock dependent singletons to avoid import side-effects
+vi.mock('./TradingAutomation.js', () => ({
+  getTradingAutomation: vi.fn(() => ({ on: vi.fn(), off: vi.fn() })),
+}));
+vi.mock('./StopLossService.js', () => ({
+  getStopLossService: vi.fn(() => ({ on: vi.fn(), off: vi.fn() })),
+}));
+
+import { query } from '../database/index.js';
+import { CircuitBreakerService } from './CircuitBreakerService.js';
+
+describe('CircuitBreakerService', () => {
+  let service: CircuitBreakerService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new CircuitBreakerService({ enabled: true });
+  });
+
+  describe('trading_config table creation', () => {
+    it('should CREATE TABLE IF NOT EXISTS on start()', async () => {
+      // Mock account query for checkDrawdown
+      vi.mocked(query).mockResolvedValue({ rows: [{ current_capital: '10000', initial_capital: '10000' }] } as any);
+
+      await service.start();
+
+      // First query should be CREATE TABLE IF NOT EXISTS
+      const calls = vi.mocked(query).mock.calls;
+      const createTableCall = calls.find(c =>
+        typeof c[0] === 'string' && c[0].includes('CREATE TABLE IF NOT EXISTS trading_config')
+      );
+      expect(createTableCall).toBeDefined();
+
+      service.stop();
+    });
+  });
+
+  describe('in-memory halt fallback', () => {
+    it('should track halt state in memory even if DB write fails', async () => {
+      // DB write fails
+      vi.mocked(query).mockRejectedValue(new Error('DB down'));
+
+      expect(service.isTradingHalted()).toBe(false);
+
+      // Trigger halt via internal method (we test the public API)
+      // Use forceCheck with drawdown > threshold
+      vi.mocked(query)
+        .mockResolvedValueOnce({ rows: [{ current_capital: '5000', initial_capital: '10000' }] } as any) // account check
+        .mockRejectedValue(new Error('DB down')); // all subsequent writes fail
+
+      await service.checkDrawdown();
+
+      // In-memory flag should be true even though DB write failed
+      expect(service.isTradingHalted()).toBe(true);
+    });
+
+    it('should return false when not halted', () => {
+      expect(service.isTradingHalted()).toBe(false);
+    });
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd packages/dashboard && npx vitest run src/services/CircuitBreakerService.test.ts --reporter=verbose`
+Expected: FAIL — `isTradingHalted` is not a function, CREATE TABLE not called
+
+**Step 3: Implement the fixes**
+
+In `CircuitBreakerService.ts`:
+
+A. Add `isHaltedInMemory` property (after line 54):
+```typescript
+private isHaltedInMemory = false;
+```
+
+B. Add `isTradingHalted()` public method (after `isActive()` at line 424):
+```typescript
+isTradingHalted(): boolean {
+  return this.isHaltedInMemory;
+}
+```
+
+C. Add table creation at start of `start()` method (after line 74, before `this.isRunning = true`):
+```typescript
+// Ensure trading_config table exists
+try {
+  await query(`
+    CREATE TABLE IF NOT EXISTS trading_config (
+      key VARCHAR(255) PRIMARY KEY,
+      value TEXT NOT NULL,
+      description TEXT,
+      updated_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `);
+} catch (error) {
+  console.error('[CircuitBreaker] Failed to create trading_config table:', error);
+}
+```
+
+D. Set in-memory flag in `haltTrading()` (line 313, before the try block):
+```typescript
+this.isHaltedInMemory = true;
+```
+
+E. Clear in-memory flag in `resumeTrading()` (line 333, after `if (!this.isHalted) return`... wait, resumeTrading doesn't check `isHalted` — it uses the `trading_config` table). Add after the successful DB write (or in the finally-equivalent spot):
+```typescript
+this.isHaltedInMemory = false;
+```
+Place this BEFORE the DB write attempt so it clears even if DB fails:
+```typescript
+private async resumeTrading(): Promise<void> {
+  this.isHaltedInMemory = false;  // Clear in-memory flag regardless of DB
+  try {
+    // ... existing DB write ...
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd packages/dashboard && npx vitest run src/services/CircuitBreakerService.test.ts --reporter=verbose`
+Expected: PASS
+
+**Step 5: Run full test suite**
+
+Run: `cd packages/dashboard && npx vitest run --reporter=verbose`
+Expected: All tests pass
+
+**Step 6: Commit**
+
+```bash
+git add packages/dashboard/src/services/CircuitBreakerService.ts packages/dashboard/src/services/CircuitBreakerService.test.ts
+git commit -m "fix: create trading_config table at startup + in-memory halt fallback"
+```
+
+---
+
+### Task 2: PositionClosingService — Add EventEmitter for Stop-Loss Events
+
+**Files:**
+- Modify: `packages/dashboard/src/services/PositionClosingService.ts`
+- Modify: `packages/dashboard/src/services/PositionClosingService.test.ts`
+
+**Context:**
+- PositionClosingService needs to emit `'position:closed'` events so AutoSignalExecutor can populate the stop-loss cooldown map
+- Currently not an EventEmitter
+- Minimal change: extend EventEmitter, add `super()`, emit after successful close
+
+**Step 1: Write the failing test**
+
+Add to existing `PositionClosingService.test.ts`:
+
+```typescript
+it('should emit position:closed event with marketId and reason after successful close', async () => {
+  const params: ClosePositionParams = {
+    positionId: 1,
+    marketId: 'market-abc',
+    tokenId: 'token-yes',
+    side: 'long',
+    size: 100,
+    entryPrice: 0.40,
+    exitPrice: 0.60,
+    reason: 'stop_loss',
+  };
+
+  const eventSpy = vi.fn();
+  service.on('position:closed', eventSpy);
+
+  await service.close(params);
+
+  expect(eventSpy).toHaveBeenCalledWith({
+    marketId: 'market-abc',
+    reason: 'stop_loss',
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && npx vitest run src/services/PositionClosingService.test.ts --reporter=verbose`
+Expected: FAIL — `service.on is not a function`
+
+**Step 3: Implement**
+
+In `PositionClosingService.ts`:
+
+A. Add import:
+```typescript
+import { EventEmitter } from 'events';
+```
+
+B. Change class declaration:
+```typescript
+export class PositionClosingService extends EventEmitter {
+```
+
+C. Add `super()` as first line of constructor:
+```typescript
+constructor(config?: { feeRate?: number }) {
+  super();
+  // ... existing code
+}
+```
+
+D. After successful close (after trade recording, before the return statement), emit:
+```typescript
+this.emit('position:closed', { marketId: params.marketId, reason: params.reason });
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd packages/dashboard && npx vitest run src/services/PositionClosingService.test.ts --reporter=verbose`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/src/services/PositionClosingService.ts packages/dashboard/src/services/PositionClosingService.test.ts
+git commit -m "feat: PositionClosingService emits position:closed events"
+```
+
+---
+
+### Task 3: AutoSignalExecutor — Stop-Loss Re-Entry Cooldown
+
+**Files:**
+- Modify: `packages/dashboard/src/services/AutoSignalExecutor.ts`
+- Create: `packages/dashboard/src/services/AutoSignalExecutor.test.ts`
+
+**Context:**
+- After StopLossService closes a position, next signal cycle opens a new one immediately
+- Need: in-memory `stoppedOutMarkets` map with 4-hour cooldown
+- AutoSignalExecutor listens to PositionClosingService `'position:closed'` event
+- Check in `processSignal()` before opening new positions
+
+**Step 1: Write the failing tests**
+
+```typescript
+// packages/dashboard/src/services/AutoSignalExecutor.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../database/index.js', () => ({
+  query: vi.fn(),
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+vi.mock('../database/repositories.js', () => ({
+  paperTradesRepo: { create: vi.fn() },
+  paperPositionsRepo: { getAll: vi.fn(), upsert: vi.fn() },
+  signalPredictionsRepo: { create: vi.fn() },
+  signalWeightsRepo: { get: vi.fn() },
+}));
+
+vi.mock('./PositionClosingService.js', () => {
+  const { EventEmitter } = require('events');
+  const mockService = new EventEmitter();
+  mockService.close = vi.fn();
+  return {
+    getPositionClosingService: vi.fn(() => mockService),
+  };
+});
+
+import { query } from '../database/index.js';
+import { paperPositionsRepo } from '../database/repositories.js';
+import { getPositionClosingService } from './PositionClosingService.js';
+import { AutoSignalExecutor, type SignalResult } from './AutoSignalExecutor.js';
+
+const makeSignal = (overrides?: Partial<SignalResult>): SignalResult => ({
+  signalId: 'momentum',
+  marketId: 'market-123',
+  tokenId: 'token-yes',
+  direction: 'long',
+  strength: 0.8,
+  confidence: 0.7,
+  price: 0.50,
+  ...overrides,
+});
+
+describe('AutoSignalExecutor — Stop-Loss Cooldown', () => {
+  let executor: AutoSignalExecutor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executor = new AutoSignalExecutor();
+
+    // Default: market exists, active, not resolved
+    vi.mocked(query).mockResolvedValue({
+      rows: [{ is_active: true, is_resolved: false }],
+    } as any);
+
+    // Default: no open positions
+    vi.mocked(paperPositionsRepo.getAll).mockResolvedValue([]);
+  });
+
+  it('should reject signal for a market in stop-loss cooldown', async () => {
+    // Simulate stop-loss event
+    const closingService = getPositionClosingService();
+    (closingService as any).emit('position:closed', {
+      marketId: 'market-123',
+      reason: 'stop_loss',
+    });
+
+    // Register the listener (executor needs to subscribe)
+    executor.registerStopLossCooldown(closingService as any);
+
+    // Re-emit after registration
+    (closingService as any).emit('position:closed', {
+      marketId: 'market-123',
+      reason: 'stop_loss',
+    });
+
+    const result = await executor.processSignal(makeSignal());
+    expect(result.executed).toBe(false);
+    expect(result.reason).toContain('stop-loss cooldown');
+  });
+
+  it('should allow signal after cooldown expires', async () => {
+    executor.registerStopLossCooldown(getPositionClosingService() as any);
+
+    // Manually set a cooldown that's already expired
+    (executor as any).stoppedOutMarkets.set('market-123', Date.now() - 5 * 60 * 60 * 1000); // 5h ago
+
+    // Should pass cooldown check (will fail later for other reasons, that's OK)
+    const result = await executor.processSignal(makeSignal());
+    // If it gets past cooldown, it won't say "stop-loss cooldown"
+    expect(result.reason || '').not.toContain('stop-loss cooldown');
+  });
+
+  it('should not cooldown for non-stop-loss closes', async () => {
+    executor.registerStopLossCooldown(getPositionClosingService() as any);
+
+    (getPositionClosingService() as any).emit('position:closed', {
+      marketId: 'market-123',
+      reason: 'signal', // Not stop_loss
+    });
+
+    const result = await executor.processSignal(makeSignal());
+    expect(result.reason || '').not.toContain('stop-loss cooldown');
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd packages/dashboard && npx vitest run src/services/AutoSignalExecutor.test.ts --reporter=verbose`
+Expected: FAIL — `registerStopLossCooldown` not a function, `stoppedOutMarkets` doesn't exist
+
+**Step 3: Implement**
+
+In `AutoSignalExecutor.ts`:
+
+A. Add constant after `DEFAULT_CONFIG` (around line 66):
+```typescript
+const STOP_LOSS_COOLDOWN_MS = 4 * 60 * 60 * 1000; // 4 hours
+```
+
+B. Add property (after line 90):
+```typescript
+private stoppedOutMarkets: Map<string, number> = new Map();
+```
+
+C. Add `registerStopLossCooldown()` method (after constructor):
+```typescript
+/**
+ * Listen for stop-loss close events to enforce re-entry cooldown.
+ * Called at startup with the PositionClosingService singleton.
+ */
+registerStopLossCooldown(closingService: import('events').EventEmitter): void {
+  closingService.on('position:closed', ({ marketId, reason }: { marketId: string; reason: string }) => {
+    if (reason === 'stop_loss') {
+      this.stoppedOutMarkets.set(marketId, Date.now());
+      console.log(`[AutoExecutor] Stop-loss cooldown activated for ${marketId.substring(0, 12)}... (${STOP_LOSS_COOLDOWN_MS / 3600000}h)`);
+    }
+  });
+}
+```
+
+D. Add cooldown check in `processSignal()` after the market cooldown check (after line 180, before signal dedup at line 182):
+```typescript
+// 3a. Stop-loss re-entry cooldown
+const stoppedAt = this.stoppedOutMarkets.get(signal.marketId);
+if (stoppedAt && Date.now() - stoppedAt < STOP_LOSS_COOLDOWN_MS) {
+  const remainingH = ((STOP_LOSS_COOLDOWN_MS - (Date.now() - stoppedAt)) / 3600000).toFixed(1);
+  return { executed: false, reason: `Market in stop-loss cooldown (${remainingH}h remaining)` };
+}
+// Clean expired cooldowns
+for (const [key, ts] of this.stoppedOutMarkets) {
+  if (Date.now() - ts > STOP_LOSS_COOLDOWN_MS) {
+    this.stoppedOutMarkets.delete(key);
+  }
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd packages/dashboard && npx vitest run src/services/AutoSignalExecutor.test.ts --reporter=verbose`
+Expected: PASS
+
+**Step 5: Wire up in server.ts**
+
+In `packages/dashboard/src/server.ts`, after executor initialization, add:
+```typescript
+// Wire stop-loss cooldown: executor listens for stop-loss events from PositionClosingService
+import { getPositionClosingService } from './services/PositionClosingService.js';
+executor.registerStopLossCooldown(getPositionClosingService());
+```
+
+**Step 6: Commit**
+
+```bash
+git add packages/dashboard/src/services/AutoSignalExecutor.ts packages/dashboard/src/services/AutoSignalExecutor.test.ts packages/dashboard/src/server.ts
+git commit -m "feat: 4-hour stop-loss re-entry cooldown to prevent repeated losses"
+```
+
+---
+
+### Task 4: AutoSignalExecutor — Per-Market Position Concentration Limit
+
+**Files:**
+- Modify: `packages/dashboard/src/services/AutoSignalExecutor.ts`
+- Modify: `packages/dashboard/src/services/AutoSignalExecutor.test.ts`
+
+**Context:**
+- System can open unlimited positions on same market
+- Need: `MAX_POSITIONS_PER_MARKET = 2`, checked against open positions before opening
+
+**Step 1: Write the failing test**
+
+Add to `AutoSignalExecutor.test.ts`:
+
+```typescript
+describe('AutoSignalExecutor — Per-Market Limit', () => {
+  let executor: AutoSignalExecutor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executor = new AutoSignalExecutor();
+
+    vi.mocked(query).mockResolvedValue({
+      rows: [{ is_active: true, is_resolved: false }],
+    } as any);
+  });
+
+  it('should reject signal when market has MAX_POSITIONS_PER_MARKET open positions', async () => {
+    // 2 existing positions on same market
+    vi.mocked(paperPositionsRepo.getAll).mockResolvedValue([
+      { market_id: 'market-123', token_id: 'token-a', size: 50 } as any,
+      { market_id: 'market-123', token_id: 'token-b', size: 30 } as any,
+    ]);
+
+    const result = await executor.processSignal(makeSignal({ direction: 'long' }));
+    expect(result.executed).toBe(false);
+    expect(result.reason).toContain('market position limit');
+  });
+
+  it('should allow signal when market has fewer than limit', async () => {
+    vi.mocked(paperPositionsRepo.getAll).mockResolvedValue([
+      { market_id: 'market-123', token_id: 'token-a', size: 50 } as any,
+    ]);
+
+    // Will get past per-market check (may fail on existingPosition check since same market)
+    const result = await executor.processSignal(makeSignal({ direction: 'long' }));
+    // It should NOT mention market position limit
+    expect(result.reason || '').not.toContain('market position limit');
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && npx vitest run src/services/AutoSignalExecutor.test.ts --reporter=verbose`
+Expected: FAIL — no per-market limit check exists
+
+**Step 3: Implement**
+
+A. Add constant (near STOP_LOSS_COOLDOWN_MS):
+```typescript
+const MAX_POSITIONS_PER_MARKET = 2;
+```
+
+B. In `processSignal()`, after positions are fetched (after line 210), before the SHORT/LONG handling:
+```typescript
+// 4a. Per-market concentration limit
+const openOnMarket = positions.filter(
+  p => p.market_id === signal.marketId && Number(p.size) > 0
+).length;
+if (openOnMarket >= MAX_POSITIONS_PER_MARKET) {
+  return { executed: false, reason: `At market position limit (${openOnMarket}/${MAX_POSITIONS_PER_MARKET})` };
+}
+```
+
+**Step 4: Run tests**
+
+Run: `cd packages/dashboard && npx vitest run src/services/AutoSignalExecutor.test.ts --reporter=verbose`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/src/services/AutoSignalExecutor.ts packages/dashboard/src/services/AutoSignalExecutor.test.ts
+git commit -m "feat: per-market position concentration limit (max 2)"
+```
+
+---
+
+### Task 5: AutoSignalExecutor — Near-Resolution Market Protection
+
+**Files:**
+- Modify: `packages/dashboard/src/services/AutoSignalExecutor.ts`
+- Modify: `packages/dashboard/src/services/AutoSignalExecutor.test.ts`
+
+**Context:**
+- Sports/event markets resolving within 24h: block mean-reversion, require higher confidence, halve position size
+- `end_date_iso` available in markets table
+- Extend existing market query (line 125-128) to include `end_date_iso`
+- Flag `nearResolution` on signal, apply 0.5 size multiplier in `openPosition()`
+
+**Step 1: Write the failing tests**
+
+Add to `AutoSignalExecutor.test.ts`:
+
+```typescript
+describe('AutoSignalExecutor — Near-Resolution Protection', () => {
+  let executor: AutoSignalExecutor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executor = new AutoSignalExecutor();
+    vi.mocked(paperPositionsRepo.getAll).mockResolvedValue([]);
+  });
+
+  it('should reject mean_reversion signals on near-resolution markets', async () => {
+    const inSixHours = new Date(Date.now() + 6 * 3600000).toISOString();
+    vi.mocked(query).mockResolvedValue({
+      rows: [{ is_active: true, is_resolved: false, end_date_iso: inSixHours }],
+    } as any);
+
+    const result = await executor.processSignal(makeSignal({
+      signalId: 'mean_reversion',
+      direction: 'long',
+    }));
+    expect(result.executed).toBe(false);
+    expect(result.reason).toContain('mean_reversion');
+    expect(result.reason).toContain('near-resolution');
+  });
+
+  it('should reject weak signals on near-resolution markets', async () => {
+    const inSixHours = new Date(Date.now() + 6 * 3600000).toISOString();
+    vi.mocked(query).mockResolvedValue({
+      rows: [{ is_active: true, is_resolved: false, end_date_iso: inSixHours }],
+    } as any);
+
+    const result = await executor.processSignal(makeSignal({
+      signalId: 'momentum',
+      confidence: 0.50, // Below 0.65 threshold
+    }));
+    expect(result.executed).toBe(false);
+    expect(result.reason).toContain('near-resolution');
+  });
+
+  it('should allow strong momentum signals on near-resolution markets', async () => {
+    const inSixHours = new Date(Date.now() + 6 * 3600000).toISOString();
+    vi.mocked(query).mockResolvedValue({
+      rows: [{ is_active: true, is_resolved: false, end_date_iso: inSixHours }],
+    } as any);
+
+    // High confidence momentum signal — should pass near-resolution filter
+    const result = await executor.processSignal(makeSignal({
+      signalId: 'momentum',
+      confidence: 0.80,
+    }));
+    // Should NOT be rejected for near-resolution reasons
+    expect(result.reason || '').not.toContain('near-resolution');
+  });
+
+  it('should pass markets with no end_date_iso (open-ended)', async () => {
+    vi.mocked(query).mockResolvedValue({
+      rows: [{ is_active: true, is_resolved: false, end_date_iso: null }],
+    } as any);
+
+    const result = await executor.processSignal(makeSignal());
+    expect(result.reason || '').not.toContain('near-resolution');
+  });
+
+  it('should pass markets resolving in >24h', async () => {
+    const inThreeDays = new Date(Date.now() + 72 * 3600000).toISOString();
+    vi.mocked(query).mockResolvedValue({
+      rows: [{ is_active: true, is_resolved: false, end_date_iso: inThreeDays }],
+    } as any);
+
+    const result = await executor.processSignal(makeSignal());
+    expect(result.reason || '').not.toContain('near-resolution');
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd packages/dashboard && npx vitest run src/services/AutoSignalExecutor.test.ts --reporter=verbose`
+Expected: FAIL — no near-resolution check exists
+
+**Step 3: Implement**
+
+A. Add constants:
+```typescript
+const NEAR_RESOLUTION_HOURS = 24;
+const MIN_CONFIDENCE_NEAR_RESOLUTION = 0.65;
+```
+
+B. Extend market query (line 125) to include `end_date_iso`:
+```typescript
+const marketCheck = await query<{ is_active: boolean; is_resolved: boolean; end_date_iso: string | null }>(
+  `SELECT is_active, is_resolved, end_date_iso FROM markets WHERE id = $1 OR condition_id = $1`,
+  [signal.marketId]
+);
+```
+
+C. After market active/resolved checks (after line 143), add near-resolution check:
+```typescript
+// Near-resolution market protection
+const endDate = marketCheck.rows[0].end_date_iso;
+let isNearResolution = false;
+if (endDate) {
+  const hoursToResolution = (new Date(endDate).getTime() - Date.now()) / 3600000;
+  if (hoursToResolution > 0 && hoursToResolution < NEAR_RESOLUTION_HOURS) {
+    isNearResolution = true;
+
+    // Block mean-reversion signals — nonsensical near resolution
+    if (signal.signalId === 'mean_reversion') {
+      return { executed: false, reason: `Rejecting mean_reversion on near-resolution market (${hoursToResolution.toFixed(1)}h to resolve)` };
+    }
+
+    // Require higher confidence
+    if (signal.confidence < MIN_CONFIDENCE_NEAR_RESOLUTION) {
+      return { executed: false, reason: `Insufficient confidence for near-resolution market (${signal.confidence.toFixed(2)} < ${MIN_CONFIDENCE_NEAR_RESOLUTION})` };
+    }
+
+    console.log(`[AutoExecutor] Near-resolution market (${hoursToResolution.toFixed(1)}h) — half position size`);
+  }
+}
+```
+
+D. Pass `isNearResolution` to `openPosition()`. Add parameter to method signature:
+```typescript
+private async openPosition(signal: SignalResult, isNearResolution = false): Promise<SignalProcessResult> {
+```
+
+E. In `openPosition()`, apply 0.5 multiplier to position size (after line 306):
+```typescript
+const positionValue = Math.min(
+  this.config.maxPositionSize * sizeMultiplier,
+  this.config.maxPositionSize
+) * (isNearResolution ? 0.5 : 1.0);
+```
+
+F. Update the two `openPosition()` call sites in `processSignal()`:
+- Line 235: `return this.openPosition(signal, isNearResolution);`
+- Line 249: `return this.openPosition(signal, isNearResolution);`
+
+G. For near-resolution stop-loss → permanent cooldown, add in the stop-loss cooldown handler:
+```typescript
+// In registerStopLossCooldown listener:
+if (reason === 'stop_loss') {
+  // Use a very long cooldown for near-resolution markets (effectively permanent)
+  this.stoppedOutMarkets.set(marketId, Date.now());
+}
+```
+(This already works since 4h cooldown > typical remaining resolution time for near-resolution markets)
+
+**Step 4: Run tests**
+
+Run: `cd packages/dashboard && npx vitest run src/services/AutoSignalExecutor.test.ts --reporter=verbose`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/src/services/AutoSignalExecutor.ts packages/dashboard/src/services/AutoSignalExecutor.test.ts
+git commit -m "feat: near-resolution market protection (block mean_reversion, higher confidence, half size)"
+```
+
+---
+
+### Task 6: RiskManager — Default to BLOCK on Failure
+
+**Files:**
+- Modify: `packages/dashboard/src/services/RiskManager.ts`
+- Create: `packages/dashboard/src/services/RiskManager.test.ts`
+
+**Context:**
+- `canOpenPosition()` line 446-448: returns `{ allowed: true }` on DB error
+- Should return `{ allowed: false }` — fail closed, not fail open
+
+**Step 1: Write the failing test**
+
+```typescript
+// packages/dashboard/src/services/RiskManager.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../database/index.js', () => ({
+  query: vi.fn(),
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+vi.mock('../database/repositories.js', () => ({
+  paperPositionsRepo: { getAll: vi.fn() },
+  portfolioSnapshotsRepo: {},
+}));
+
+import { query } from '../database/index.js';
+import { RiskManager } from './RiskManager.js';
+
+describe('RiskManager', () => {
+  let rm: RiskManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rm = new RiskManager({ enabled: true });
+  });
+
+  describe('canOpenPosition — fail-closed', () => {
+    it('should BLOCK trades when DB query fails', async () => {
+      vi.mocked(query).mockRejectedValue(new Error('connection refused'));
+
+      const result = await rm.canOpenPosition(100);
+
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('risk_check_failed');
+    });
+
+    it('should ALLOW trades when DB query succeeds and within limits', async () => {
+      vi.mocked(query).mockResolvedValue({
+        rows: [{ initial_capital: '10000' }],
+      } as any);
+
+      // Mock positions for exposure check
+      const { paperPositionsRepo } = await import('../database/repositories.js');
+      vi.mocked(paperPositionsRepo.getAll).mockResolvedValue([]);
+
+      const result = await rm.canOpenPosition(100);
+      expect(result.allowed).toBe(true);
+    });
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && npx vitest run src/services/RiskManager.test.ts --reporter=verbose`
+Expected: FAIL — `allowed` is `true` when DB fails
+
+**Step 3: Implement**
+
+In `RiskManager.ts`, line 446-448, change:
+```typescript
+// BEFORE:
+} catch (error) {
+  console.error('[RiskManager] Position check failed:', error);
+  return { allowed: true, adaptiveMultiplier: 1 };  // Allow on error
+}
+
+// AFTER:
+} catch (error) {
+  console.error('[RiskManager] Position check failed, BLOCKING trade:', error);
+  return { allowed: false, reason: 'risk_check_failed', adaptiveMultiplier: 0 };
+}
+```
+
+**Step 4: Run tests**
+
+Run: `cd packages/dashboard && npx vitest run src/services/RiskManager.test.ts --reporter=verbose`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/src/services/RiskManager.ts packages/dashboard/src/services/RiskManager.test.ts
+git commit -m "fix: RiskManager defaults to BLOCK on DB failure (fail-closed)"
+```
+
+---
+
+### Task 7: SignalEngine — 50/50 Market Filtering
+
+**Files:**
+- Modify: `packages/dashboard/src/services/SignalEngine.ts`
+- Modify: `packages/dashboard/src/services/SignalEngine.test.ts`
+
+**Context:**
+- Markets at 0.45-0.55 are coin flips with negative expected value after fees
+- Add filter in `setActiveMarkets()` alongside existing extreme-price filter
+- Also add to `convertToSignalResult()` PRICE_FILTERS as safety net
+
+**Step 1: Write the failing test**
+
+Add to existing `SignalEngine.test.ts`:
+
+```typescript
+describe('SignalEngine — 50/50 Market Filter', () => {
+  it('should filter out markets with price in 0.45-0.55 range', () => {
+    const engine = new SignalEngine({ enabled: false });
+
+    engine.setActiveMarkets([
+      { id: 'a', question: 'Q1', tokenIdYes: 't1', currentPrice: 0.50 },  // 50/50 → filtered
+      { id: 'b', question: 'Q2', tokenIdYes: 't2', currentPrice: 0.48 },  // 50/50 → filtered
+      { id: 'c', question: 'Q3', tokenIdYes: 't3', currentPrice: 0.70 },  // OK
+      { id: 'd', question: 'Q4', tokenIdYes: 't4', currentPrice: 0.30 },  // OK
+      { id: 'e', question: 'Q5', tokenIdYes: 't5', currentPrice: 0.45 },  // boundary → filtered
+      { id: 'f', question: 'Q6', tokenIdYes: 't6', currentPrice: 0.55 },  // boundary → filtered
+      { id: 'g', question: 'Q7', tokenIdYes: 't7', currentPrice: 0.44 },  // just outside → OK
+      { id: 'h', question: 'Q8', tokenIdYes: 't8', currentPrice: 0.56 },  // just outside → OK
+    ]);
+
+    const status = engine.getStatus();
+    expect(status.marketCount).toBe(4); // c, d, g, h
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && npx vitest run src/services/SignalEngine.test.ts --reporter=verbose`
+Expected: FAIL — 50/50 markets not filtered, marketCount will be 8 (minus any extreme-price filtered)
+
+**Step 3: Implement**
+
+In `SignalEngine.ts`, `setActiveMarkets()` method (around line 228):
+
+A. Add constants at top of method:
+```typescript
+const FIFTY_FIFTY_MIN = 0.45;
+const FIFTY_FIFTY_MAX = 0.55;
+```
+
+B. Add filter and counter (after the existing extremePriceCount logic, around line 252):
+```typescript
+let fiftyFiftyCount = 0;
+```
+
+C. Add filter condition inside the `.filter()` callback (after the extreme price check):
+```typescript
+// Filter 4: Skip 50/50 markets (no edge, fees make EV negative)
+if (price >= FIFTY_FIFTY_MIN && price <= FIFTY_FIFTY_MAX) {
+  fiftyFiftyCount++;
+  return false;
+}
+```
+
+D. Update the log line to include 50/50 count:
+```typescript
+const totalExcluded = inactiveCount + resolvedCount + extremePriceCount + fiftyFiftyCount;
+if (totalExcluded > 0) {
+  console.log(`[SignalEngine] Filtered markets: ${inactiveCount} inactive, ${resolvedCount} resolved, ${extremePriceCount} extreme prices, ${fiftyFiftyCount} 50/50`);
+}
+```
+
+**Step 4: Run tests**
+
+Run: `cd packages/dashboard && npx vitest run src/services/SignalEngine.test.ts --reporter=verbose`
+Expected: PASS
+
+**Step 5: Run full test suite + type check**
+
+Run: `cd packages/dashboard && npx vitest run --reporter=verbose`
+Run: `cd packages/dashboard && npx tsc --noEmit`
+Expected: All pass, no type errors
+
+**Step 6: Commit**
+
+```bash
+git add packages/dashboard/src/services/SignalEngine.ts packages/dashboard/src/services/SignalEngine.test.ts
+git commit -m "feat: filter 50/50 markets (0.45-0.55 price range)"
+```
+
+---
+
+### Task 8: Final Build Verification + Integration
+
+**Files:** None new — verification only
+
+**Step 1: Run full test suite**
+
+Run: `cd packages/dashboard && npx vitest run --reporter=verbose`
+Expected: All tests pass (existing + new)
+
+**Step 2: Type check**
+
+Run: `cd packages/dashboard && npx tsc --noEmit`
+Expected: No errors
+
+**Step 3: Verify no regressions in other packages**
+
+Run: `cd packages/signals && npm test 2>/dev/null; cd packages/backtest && npm test 2>/dev/null`
+Expected: Pass or no test suites
+
+**Step 4: Final commit with all files**
+
+Review git status and ensure all changes are committed.
+
+---
+
+## Summary
+
+| Task | File(s) | Lines Changed | Risk |
+|------|---------|---------------|------|
+| 1. trading_config table | CircuitBreakerService.ts | ~20 | Low |
+| 2. PositionClosingService events | PositionClosingService.ts | ~5 | Low |
+| 3. Stop-loss cooldown | AutoSignalExecutor.ts, server.ts | ~25 | Medium |
+| 4. Per-market limit | AutoSignalExecutor.ts | ~8 | Low |
+| 5. Near-resolution protection | AutoSignalExecutor.ts | ~25 | Medium |
+| 6. RiskManager fail-closed | RiskManager.ts | ~3 | Low |
+| 7. 50/50 filter | SignalEngine.ts | ~8 | Low |
+| 8. Build verification | — | — | — |
+
+**Total: ~94 lines across 4 modified files + 3 new test files**

--- a/docs/plans/2026-03-13-issue17-designs.md
+++ b/docs/plans/2026-03-13-issue17-designs.md
@@ -1,0 +1,179 @@
+# Issue #17 Follow-up Designs
+
+**Date**: 2026-03-13
+**Trigger**: Issue #17 — all 7 active markets filtered by 50/50 rule, zero signals generated
+**Status**: Design approved
+
+## Overview
+
+Three improvements addressing signal generation quality and operational review:
+
+1. **PriceRangeWeightModifier** — Replace hard 50/50 block with weight reduction
+2. **Hysteresis on combined_exit** — Different thresholds for open vs close to prevent churn
+3. **Claude-first daily review** — Claude analyzes severity before routing alerts
+
+---
+
+## Design 1: PriceRangeWeightModifier
+
+### Problem
+
+The hard 50/50 filter (`setActiveMarkets()` excludes markets with Yes price 0.45–0.55) completely silences signal generation when the market universe is small. Order-flow signals (OFI, MLOFI, Hawkes) remain informative even at near-50% prices — only momentum and mean_reversion lose edge there.
+
+### Architecture
+
+Same pattern as `DurationWeightModifier`: a modifier class that applies per-signal multipliers based on market price range, composing multiplicatively with duration weights.
+
+**File**: `packages/signals/src/modifiers/PriceRangeWeightModifier.ts`
+
+### Price Bands
+
+| Band | Range | Description |
+|------|-------|-------------|
+| **uncertain** | 0.45 – 0.55 | Coin-flip territory |
+| **transitional** | 0.40–0.45 / 0.55–0.60 | Some edge, reduced confidence |
+| **normal** | < 0.40 / > 0.60 | Full signal validity |
+
+### Weight Multiplier Matrix
+
+| Signal | normal | transitional | uncertain |
+|--------|--------|-------------|-----------|
+| momentum | 1.0 | 0.6 | 0 |
+| mean_reversion | 1.0 | 0.4 | 0 |
+| OFI | 1.0 | 1.0 | 1.0 |
+| MLOFI | 1.0 | 1.0 | 1.0 |
+| Hawkes | 1.0 | 1.0 | 1.0 |
+| volume_anomaly | 1.0 | 1.0 | 1.0 |
+| spread_compression | 1.0 | 1.0 | 0.8 |
+| cross_market_corr | 1.0 | 0.8 | 0.5 |
+| price_divergence | 1.0 | 1.0 | 1.0 |
+| attention_spike | 1.0 | 1.0 | 1.0 |
+| news_sentiment | 1.0 | 1.0 | 0.7 |
+
+### Integration
+
+- Remove hard block from `SignalEngine.setActiveMarkets()` (the `price < 0.05 || price > 0.95` extreme check stays)
+- Apply `PriceRangeWeightModifier` in the same pipeline slot as `DurationWeightModifier`, composing multiplicatively:
+  ```
+  finalWeight = baseWeight × durationMultiplier × priceRangeMultiplier
+  ```
+- `currentPrice` (Yes token price) passed as context to modifier
+
+### Optimizer Candidates
+
+All band boundaries (0.45, 0.55, 0.40, 0.60) and all multiplier values in the matrix are candidates for Bayesian optimization. Store in `trading_config` table, load on startup.
+
+---
+
+## Design 2: Hysteresis on combined_exit
+
+### Problem
+
+A single threshold for both opening and closing positions causes churn: if combined confidence fluctuates near the threshold, positions open, weaken slightly, close, re-open. Each round-trip costs fees with no directional gain.
+
+### Design
+
+Two thresholds in `trading_config`:
+- `open_threshold`: 0.43 — confidence required to enter a position (current `minCombinedConfidence`)
+- `exit_threshold`: 0.25 — confidence required to exit (opposing signal must reach this level)
+
+**Logic in `AutoSignalExecutor.processSignal()`:**
+
+- **Open**: signal confidence ≥ `open_threshold` → enter (unchanged)
+- **Exit**: signal direction reverses AND confidence ≥ `exit_threshold` → close
+- **Hold**: signal weakens below `open_threshold` but opposing signal < `exit_threshold` → hold position
+
+The dead band (0.25–0.43) means weak contrary noise doesn't trigger exits. A real reversal (confidence ≥ 0.25 in the opposite direction) still closes the position.
+
+**No minimum hold time** — hysteresis achieves anti-churn without an arbitrary time floor. Strong reversals close immediately.
+
+### Optimizer Candidates
+
+Both `open_threshold` (0.43) and `exit_threshold` (0.25) go into the Bayesian parameter space. The optimizer can tune the gap between them to minimize churn while capturing reversals.
+
+### Implementation Note
+
+Rename `minCombinedConfidence` → `openThreshold` in `SignalEngine` config and `trading_config` for clarity. Keep backward-compatible read of old key during transition.
+
+---
+
+## Design 3: Claude-first Daily Review
+
+### Problem
+
+Hardcoded thresholds in the alert pipeline generate false alarms. Example: "7 markets filtered" is flagged as a signal problem but is actually correct behavior of the 50/50 rule. Claude has context to distinguish expected from unexpected behavior.
+
+### Flow
+
+```
+daily-review.sh (raw JSON, 20 sections)
+  → GitHub Actions: call Claude (Sonnet 4.6) with raw JSON + format-review.js template
+  → Claude outputs: narrative + alerts.json
+  → Routing: GitHub Issue (always) + Gmail (if critical) + Slack (if critical)
+```
+
+### Components
+
+**`daily-review.sh`** — unchanged. Produces raw JSON.
+
+**`format-review.js`** — becomes a template/prompt guide. Defines:
+- Output structure (sections, what to analyze)
+- Threshold hints for Claude (e.g., "drawdown >10% is typically critical")
+- Format for `alerts.json`: `{ severity: "critical"|"warning"|"info", message, reason }`
+
+Claude uses these as guidelines, not hard rules — it can override based on context.
+
+**New GitHub Actions step** (`analyze-review`):
+```yaml
+- name: Analyze with Claude
+  run: |
+    node scripts/analyze-review.js "$RAW_JSON" "$FORMAT_TEMPLATE"
+  # outputs: GITHUB_ISSUE_BODY, ALERTS_JSON, GMAIL_SUMMARY
+```
+
+**`scripts/analyze-review.js`** — calls Claude API (Sonnet 4.6):
+- System prompt: "You are a trading system monitor. Analyze the daily review data and produce: (1) a narrative GitHub issue body, (2) alerts.json with only genuinely concerning items, (3) a 3-5 bullet Gmail summary."
+- Passes raw JSON + template as user message
+- Writes outputs to env vars for downstream routing steps
+
+**Routing** uses `alerts.json` severity counts:
+- Always: create GitHub Issue with Claude's narrative
+- If `critical` count > 0: send Gmail summary + Slack alert
+- `warnings` only: GitHub Issue only (no noise in Slack/Gmail)
+
+### Cost
+
+~2000 tokens per daily review call ≈ $0.003/day at Sonnet 4.6 pricing. Negligible.
+
+---
+
+## Implementation Plan
+
+### Phase A — PriceRangeWeightModifier (signals + dashboard)
+
+1. `PriceRangeWeightModifier.ts` — modifier class with matrix
+2. Wire into `SignalEngine` (compose with DurationWeightModifier)
+3. Remove 50/50 hard block from `setActiveMarkets()`
+4. Add band boundaries + multipliers to optimizer parameter space
+
+### Phase B — Hysteresis (dashboard)
+
+5. Add `exit_threshold` to `trading_config` table + load on startup
+6. Modify `AutoSignalExecutor.processSignal()` — split open/exit threshold logic
+7. Rename `minCombinedConfidence` → `openThreshold` in config
+
+### Phase C — Claude-first review (GitHub Actions + scripts)
+
+8. `scripts/analyze-review.js` — Claude API call, parse outputs
+9. Update `.github/workflows/daily-trade-review.yml` — add analyze step, wire routing
+10. Update `format-review.js` — convert to template/prompt guide
+
+### Phase Dependencies
+
+```
+Phase A ─── standalone
+Phase B ─── standalone
+Phase C ─── standalone (can run in parallel with A and B)
+```
+
+All three phases can execute in parallel.

--- a/docs/plans/2026-03-13-issue17-plan.md
+++ b/docs/plans/2026-03-13-issue17-plan.md
@@ -1,0 +1,895 @@
+# Issue #17 Follow-up Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace hard 50/50 filter with weight reduction, add hysteresis open/exit thresholds, and wire Claude as the daily review intelligence layer.
+
+**Architecture:**
+- `PriceRangeWeightModifier` mirrors `DurationWeightModifier` exactly; both compose multiplicatively in `SignalEngine.computeSignalForMarket()`
+- Hysteresis: lower `minCombinedConfidence` to exit_threshold (0.25), add open_threshold (0.43) check in `AutoSignalExecutor` after position lookup
+- Claude review: new `scripts/analyze-review.js` calls Sonnet 4.6 with raw JSON, writes `report.md`/`email.html`/`slack.json`/`alerts.json`; workflow routes from `alerts.json`
+
+**Tech Stack:** TypeScript, Vitest, Node.js @anthropic-ai/sdk, GitHub Actions YAML
+
+---
+
+## Phase A — PriceRangeWeightModifier
+
+### Task 1: PriceRangeWeightModifier — tests
+
+**Files:**
+- Create: `packages/signals/src/modifiers/PriceRangeWeightModifier.test.ts`
+
+**Step 1: Write the failing tests**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { PriceRangeWeightModifier } from './PriceRangeWeightModifier.js';
+
+describe('PriceRangeWeightModifier', () => {
+  const mod = new PriceRangeWeightModifier();
+
+  describe('getPriceBand', () => {
+    it('returns normal for price < 0.40', () => {
+      expect(mod.getPriceBand(0.30)).toBe('normal');
+    });
+    it('returns normal for price > 0.60', () => {
+      expect(mod.getPriceBand(0.75)).toBe('normal');
+    });
+    it('returns transitional for price in 0.40–0.45', () => {
+      expect(mod.getPriceBand(0.42)).toBe('transitional');
+    });
+    it('returns transitional for price in 0.55–0.60', () => {
+      expect(mod.getPriceBand(0.58)).toBe('transitional');
+    });
+    it('returns uncertain for price in 0.45–0.55', () => {
+      expect(mod.getPriceBand(0.50)).toBe('uncertain');
+    });
+    it('returns uncertain at exact boundary 0.45', () => {
+      expect(mod.getPriceBand(0.45)).toBe('uncertain');
+    });
+    it('returns uncertain at exact boundary 0.55', () => {
+      expect(mod.getPriceBand(0.55)).toBe('uncertain');
+    });
+  });
+
+  describe('getWeightMultiplier', () => {
+    it('momentum is 0 in uncertain band', () => {
+      expect(mod.getWeightMultiplier('momentum', 'uncertain')).toBe(0);
+    });
+    it('momentum is 0.6 in transitional band', () => {
+      expect(mod.getWeightMultiplier('momentum', 'transitional')).toBe(0.6);
+    });
+    it('momentum is 1.0 in normal band', () => {
+      expect(mod.getWeightMultiplier('momentum', 'normal')).toBe(1.0);
+    });
+    it('ofi is 1.0 in all bands', () => {
+      expect(mod.getWeightMultiplier('ofi', 'uncertain')).toBe(1.0);
+      expect(mod.getWeightMultiplier('ofi', 'transitional')).toBe(1.0);
+      expect(mod.getWeightMultiplier('ofi', 'normal')).toBe(1.0);
+    });
+    it('returns 0.5 for unknown signals', () => {
+      expect(mod.getWeightMultiplier('unknown_signal', 'normal')).toBe(0.5);
+    });
+  });
+
+  describe('modifyWeights', () => {
+    it('zeroes momentum/mean_reversion at uncertain price', () => {
+      const weights = { momentum: 0.15, ofi: 0.15 };
+      const result = mod.modifyWeights(weights, 0.50);
+      expect(result.momentum).toBe(0);
+      expect(result.ofi).toBe(0.15);
+    });
+    it('does not mutate the original weights object', () => {
+      const weights = { momentum: 0.15 };
+      mod.modifyWeights(weights, 0.50);
+      expect(weights.momentum).toBe(0.15);
+    });
+    it('applies 1.0 multiplier for normal price', () => {
+      const weights = { momentum: 0.15, ofi: 0.15 };
+      const result = mod.modifyWeights(weights, 0.30);
+      expect(result.momentum).toBeCloseTo(0.15);
+      expect(result.ofi).toBeCloseTo(0.15);
+    });
+  });
+
+  describe('custom matrix and updateMatrix', () => {
+    it('accepts a custom matrix in constructor', () => {
+      const custom = new PriceRangeWeightModifier({
+        momentum: { normal: 1.0, transitional: 0.0, uncertain: 0.0 },
+      });
+      expect(custom.getWeightMultiplier('momentum', 'transitional')).toBe(0.0);
+    });
+    it('updateMatrix overrides at runtime', () => {
+      const m = new PriceRangeWeightModifier();
+      m.updateMatrix({ hawkes: { normal: 0.5, transitional: 0.5, uncertain: 0.5 } });
+      expect(m.getWeightMultiplier('hawkes', 'normal')).toBe(0.5);
+    });
+  });
+});
+```
+
+**Step 2: Run tests — verify they fail**
+
+```bash
+cd packages/signals && npx vitest run src/modifiers/PriceRangeWeightModifier.test.ts
+```
+Expected: FAIL — `Cannot find module './PriceRangeWeightModifier.js'`
+
+**Step 3: Implement PriceRangeWeightModifier**
+
+Create `packages/signals/src/modifiers/PriceRangeWeightModifier.ts`:
+
+```typescript
+/**
+ * PriceRangeWeightModifier
+ *
+ * Scales signal weights based on the market's current Yes-token price.
+ * Near-50% markets have more uncertainty; only order-flow signals remain
+ * informative there. Momentum/mean-reversion lose edge near the coin-flip point.
+ *
+ * Bands:
+ *   normal       < 0.40  or  > 0.60   Full signal validity
+ *   transitional  0.40–0.45 / 0.55–0.60  Reduced confidence
+ *   uncertain     0.45–0.55            Only flow signals meaningful
+ */
+
+export type PriceRangeBand = 'normal' | 'transitional' | 'uncertain';
+
+export type PriceBandMultipliers = Record<PriceRangeBand, number>;
+
+const DEFAULT_MATRIX: Record<string, PriceBandMultipliers> = {
+  momentum:           { normal: 1.0, transitional: 0.6, uncertain: 0   },
+  mean_reversion:     { normal: 1.0, transitional: 0.4, uncertain: 0   },
+  ofi:                { normal: 1.0, transitional: 1.0, uncertain: 1.0 },
+  mlofi:              { normal: 1.0, transitional: 1.0, uncertain: 1.0 },
+  hawkes:             { normal: 1.0, transitional: 1.0, uncertain: 1.0 },
+  volume_anomaly:     { normal: 1.0, transitional: 1.0, uncertain: 1.0 },
+  spread_compression: { normal: 1.0, transitional: 1.0, uncertain: 0.8 },
+  cross_market_corr:  { normal: 1.0, transitional: 0.8, uncertain: 0.5 },
+  price_divergence:   { normal: 1.0, transitional: 1.0, uncertain: 1.0 },
+  attention_spike:    { normal: 1.0, transitional: 1.0, uncertain: 1.0 },
+  news_sentiment:     { normal: 1.0, transitional: 1.0, uncertain: 0.7 },
+};
+
+const DEFAULT_UNKNOWN_MULTIPLIER = 0.5;
+
+// Band boundaries (optimizable via Bayesian optimizer)
+const UNCERTAIN_MIN = 0.45;
+const UNCERTAIN_MAX = 0.55;
+const TRANSITIONAL_MIN = 0.40;
+const TRANSITIONAL_MAX = 0.60;
+
+export class PriceRangeWeightModifier {
+  private matrix: Record<string, PriceBandMultipliers>;
+
+  constructor(customMatrix?: Partial<Record<string, PriceBandMultipliers>>) {
+    this.matrix = Object.fromEntries(
+      Object.entries(DEFAULT_MATRIX).map(([k, v]) => [k, { ...v }])
+    );
+    if (customMatrix) {
+      for (const [signalId, row] of Object.entries(customMatrix)) {
+        if (row != null) {
+          this.matrix[signalId] = { ...row } as PriceBandMultipliers;
+        }
+      }
+    }
+  }
+
+  getPriceBand(price: number): PriceRangeBand {
+    if (price >= UNCERTAIN_MIN && price <= UNCERTAIN_MAX) return 'uncertain';
+    if (price >= TRANSITIONAL_MIN && price <= TRANSITIONAL_MAX) return 'transitional';
+    return 'normal';
+  }
+
+  getWeightMultiplier(signalId: string, band: PriceRangeBand): number {
+    const row = this.matrix[signalId];
+    if (row == null) return DEFAULT_UNKNOWN_MULTIPLIER;
+    return row[band];
+  }
+
+  modifyWeights(
+    weights: Record<string, number>,
+    currentPrice: number
+  ): Record<string, number> {
+    const band = this.getPriceBand(currentPrice);
+    const result: Record<string, number> = {};
+    for (const [signalId, weight] of Object.entries(weights)) {
+      result[signalId] = weight * this.getWeightMultiplier(signalId, band);
+    }
+    return result;
+  }
+
+  updateMatrix(updates: Partial<Record<string, PriceBandMultipliers>>): void {
+    for (const [signalId, row] of Object.entries(updates)) {
+      if (row != null) {
+        this.matrix[signalId] = { ...row };
+      }
+    }
+  }
+
+  getMatrix(): Record<string, PriceBandMultipliers> {
+    return Object.fromEntries(
+      Object.entries(this.matrix).map(([k, v]) => [k, { ...v }])
+    );
+  }
+}
+```
+
+**Step 4: Run tests — verify they pass**
+
+```bash
+cd packages/signals && npx vitest run src/modifiers/PriceRangeWeightModifier.test.ts
+```
+Expected: All tests PASS
+
+**Step 5: Export from signals package**
+
+In `packages/signals/src/index.ts`, add alongside the DurationWeightModifier export:
+```typescript
+export { PriceRangeWeightModifier } from './modifiers/PriceRangeWeightModifier.js';
+export type { PriceRangeBand, PriceBandMultipliers } from './modifiers/PriceRangeWeightModifier.js';
+```
+
+**Step 6: Commit**
+
+```bash
+git add packages/signals/src/modifiers/PriceRangeWeightModifier.ts \
+        packages/signals/src/modifiers/PriceRangeWeightModifier.test.ts \
+        packages/signals/src/index.ts
+git commit -m "feat: add PriceRangeWeightModifier with weight reduction for near-50% markets"
+```
+
+---
+
+### Task 2: Wire PriceRangeWeightModifier into SignalEngine, remove hard 50/50 block
+
+**Files:**
+- Modify: `packages/dashboard/src/services/SignalEngine.ts`
+
+**Step 1: Add import**
+
+In `SignalEngine.ts`, add to the imports from `@polymarket-trader/signals`:
+```typescript
+PriceRangeWeightModifier,
+type PriceRangeBand,
+```
+
+**Step 2: Add private field**
+
+In the `SignalEngine` class, alongside `private durationModifier`:
+```typescript
+private priceRangeModifier: PriceRangeWeightModifier = new PriceRangeWeightModifier();
+```
+
+**Step 3: Apply price-range modifier in computeSignalForMarket**
+
+In `computeSignalForMarket()`, after the duration weight block (lines 405–413), add:
+
+```typescript
+// Apply price-range weight scaling after duration scaling
+const priceWeights = this.priceRangeModifier.modifyWeights(
+  this.combiner.getWeights(),
+  market.currentPrice
+);
+this.combiner.setWeights(priceWeights);
+```
+
+And restore after `combine()`:
+```typescript
+// Restore original weights after combining
+this.combiner.setWeights(originalWeights);
+```
+
+The full block should look like:
+```typescript
+// Apply duration-based weight scaling before combining
+const originalWeights = this.combiner.getWeights();
+const durationWeights = this.durationModifier.modifyWeights(originalWeights, market.endDate ?? null);
+// Apply price-range weight scaling (multiplicative composition)
+const combinedWeights = this.priceRangeModifier.modifyWeights(durationWeights, market.currentPrice);
+this.combiner.setWeights(combinedWeights);
+
+// Combine signals with market-type-specific weights
+const combined = this.combiner.combine(signalOutputs, undefined, market.marketType);
+
+// Restore original weights after combining
+this.combiner.setWeights(originalWeights);
+```
+
+**Step 4: Remove the 50/50 hard block from setActiveMarkets()**
+
+In `setActiveMarkets()`, remove Filter 4 entirely (lines 297–303):
+```typescript
+// DELETE these lines:
+// Filter 4: Skip 50/50 markets (no edge, fees make EV negative)
+if (price >= FIFTY_FIFTY_MIN && price <= FIFTY_FIFTY_MAX) {
+  fiftyFiftyCount++;
+  return false;
+}
+```
+
+Also remove the unused constants:
+```typescript
+// DELETE:
+const FIFTY_FIFTY_MIN = 0.45;
+const FIFTY_FIFTY_MAX = 0.55;
+```
+
+And remove `fiftyFiftyCount` variable and its reference in the log message:
+```typescript
+// Change log line to:
+console.log(`[SignalEngine] Filtered markets: ${inactiveCount} inactive, ${resolvedCount} resolved, ${extremePriceCount} extreme prices`);
+```
+
+**Step 5: Build and typecheck**
+
+```bash
+cd packages/signals && npx tsc --noEmit
+cd packages/dashboard && npx tsc --noEmit
+```
+Expected: No errors
+
+**Step 6: Commit**
+
+```bash
+git add packages/dashboard/src/services/SignalEngine.ts
+git commit -m "feat: wire PriceRangeWeightModifier into SignalEngine, remove hard 50/50 block"
+```
+
+---
+
+## Phase B — Hysteresis on combined_exit
+
+### Task 3: Add exit_threshold to config and adjust SignalEngine
+
+**Files:**
+- Modify: `packages/dashboard/src/services/SignalEngine.ts`
+
+**Context:** Currently `SignalEngine.computeSignalForMarket()` at line 424 checks:
+```typescript
+if (combined.confidence < (this.config.minCombinedConfidence ?? 0.43)) {
+  return null;
+}
+```
+This is the open threshold. We need to lower it to the exit threshold (0.25) so weak reversal signals pass through to the executor, which will then apply the higher open threshold for new positions.
+
+**Step 1: Add exitThreshold to SignalEngineConfig**
+
+```typescript
+export interface SignalEngineConfig {
+  // ... existing fields ...
+  minCombinedConfidence?: number;  // Open threshold — minimum to enter a new position
+  minCombinedStrength?: number;
+  exitThreshold?: number;          // Exit threshold — minimum to close an existing position (lower)
+}
+
+const DEFAULT_CONFIG: SignalEngineConfig = {
+  // ... existing fields ...
+  minCombinedConfidence: 0.43,   // Open threshold
+  minCombinedStrength: 0.27,
+  exitThreshold: 0.25,           // Exit threshold (lower — only exits on real reversals)
+};
+```
+
+**Step 2: Use exitThreshold as the signal engine's pass-through floor**
+
+In `computeSignalForMarket()`, change line 424 from:
+```typescript
+if (combined.confidence < (this.config.minCombinedConfidence ?? 0.43)) {
+```
+to:
+```typescript
+if (combined.confidence < (this.config.exitThreshold ?? 0.25)) {
+```
+
+This lets signals with confidence ≥ 0.25 reach the executor. The executor will re-apply the higher open threshold (0.43) for new positions.
+
+**Step 3: Pass exitThreshold to combiner config**
+
+In `SignalEngine` constructor, update the combiner initialization:
+```typescript
+this.combiner = new WeightedAverageCombiner(
+  { /* weights unchanged */ },
+  {
+    minCombinedConfidence: this.config.exitThreshold ?? 0.25,  // Use exit threshold as combiner floor
+    minCombinedStrength: this.config.minCombinedStrength ?? 0.27,
+  }
+);
+```
+
+**Step 4: Typecheck**
+
+```bash
+cd packages/dashboard && npx tsc --noEmit
+```
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/src/services/SignalEngine.ts
+git commit -m "feat: lower SignalEngine pass-through floor to exit_threshold (0.25) for hysteresis"
+```
+
+---
+
+### Task 4: Apply open/exit threshold split in AutoSignalExecutor
+
+**Files:**
+- Modify: `packages/dashboard/src/services/AutoSignalExecutor.ts`
+
+**Step 1: Add openThreshold to ExecutorConfig**
+
+```typescript
+export interface ExecutorConfig {
+  // ... existing fields ...
+  openThreshold: number;    // Minimum confidence to OPEN a new position (0.43)
+  exitThreshold: number;    // Minimum confidence to CLOSE an existing position (0.25)
+}
+
+const DEFAULT_CONFIG: ExecutorConfig = {
+  // ... existing fields ...
+  openThreshold: parseFloat(process.env.EXECUTOR_OPEN_THRESHOLD || '0.43'),
+  exitThreshold: parseFloat(process.env.EXECUTOR_EXIT_THRESHOLD || '0.25'),
+};
+```
+
+**Step 2: Apply position-aware threshold check**
+
+The existing check at step 1 in `processSignal()` (line 198) uses `this.config.minConfidence` which is 0 by default — it never fires. Replace it with a position-aware check.
+
+REMOVE the old check:
+```typescript
+// REMOVE:
+if (signal.confidence < this.config.minConfidence) {
+  const reason = `Confidence ${signal.confidence.toFixed(2)} below threshold ${this.config.minConfidence}`;
+  return { executed: false, reason };
+}
+```
+
+ADD a new check after the position lookup (step 4, after line ~265 where `existingPosition` is determined):
+```typescript
+// Hysteresis: use lower exit threshold when closing, higher open threshold when opening
+const isClosingExistingLong = signal.direction === 'short' && !!existingPosition;
+const threshold = isClosingExistingLong
+  ? this.config.exitThreshold
+  : this.config.openThreshold;
+if (signal.confidence < threshold) {
+  const action = isClosingExistingLong ? 'exit' : 'open';
+  return {
+    executed: false,
+    reason: `Confidence ${signal.confidence.toFixed(2)} below ${action} threshold ${threshold}`,
+  };
+}
+```
+
+Place this check immediately after `existingPosition` is assigned (after line ~265).
+
+**Step 3: Typecheck**
+
+```bash
+cd packages/dashboard && npx tsc --noEmit
+```
+
+**Step 4: Write a unit test for the threshold logic**
+
+Create `packages/dashboard/src/services/__tests__/AutoSignalExecutor.hysteresis.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock database
+vi.mock('../database/index.js', () => ({
+  isDatabaseConfigured: () => false,
+  query: vi.fn(),
+}));
+vi.mock('../database/repositories.js', () => ({
+  paperTradesRepo: { create: vi.fn() },
+  paperPositionsRepo: { getAll: vi.fn().mockResolvedValue([]) },
+  signalPredictionsRepo: { create: vi.fn() },
+  signalWeightsRepo: { getAll: vi.fn().mockResolvedValue([]) },
+}));
+vi.mock('../services/PositionClosingService.js', () => ({
+  getPositionClosingService: () => ({ closePosition: vi.fn() }),
+}));
+vi.mock('../services/CircuitBreakerService.js', () => ({
+  getCircuitBreakerService: () => ({ isTradingHalted: () => false }),
+}));
+
+import { AutoSignalExecutor } from '../AutoSignalExecutor.js';
+
+const makeSignal = (confidence: number, direction: 'long' | 'short' = 'long') => ({
+  signalId: 'test',
+  marketId: 'market-1',
+  tokenId: 'token-1',
+  direction,
+  strength: 0.5,
+  confidence,
+  price: 0.6,
+});
+
+describe('AutoSignalExecutor — hysteresis thresholds', () => {
+  let executor: AutoSignalExecutor;
+
+  beforeEach(() => {
+    executor = new AutoSignalExecutor({ openThreshold: 0.43, exitThreshold: 0.25 });
+    executor.start();
+  });
+
+  it('rejects LONG signal below openThreshold', async () => {
+    const result = await executor.processSignal(makeSignal(0.35, 'long'));
+    expect(result.executed).toBe(false);
+    expect(result.reason).toMatch(/open threshold/);
+  });
+
+  it('accepts LONG signal at openThreshold', async () => {
+    // Will fail at DB check (not configured), but passes threshold gate
+    const result = await executor.processSignal(makeSignal(0.43, 'long'));
+    expect(result.reason).not.toMatch(/open threshold/);
+  });
+});
+```
+
+**Step 5: Run tests**
+
+```bash
+cd packages/dashboard && npx vitest run src/services/__tests__/AutoSignalExecutor.hysteresis.test.ts
+```
+
+**Step 6: Commit**
+
+```bash
+git add packages/dashboard/src/services/AutoSignalExecutor.ts \
+        packages/dashboard/src/services/__tests__/AutoSignalExecutor.hysteresis.test.ts
+git commit -m "feat: hysteresis open/exit thresholds — open 0.43, exit 0.25"
+```
+
+---
+
+## Phase C — Claude-first Daily Review
+
+### Task 5: Create analyze-review.js
+
+**Files:**
+- Create: `scripts/analyze-review.js`
+
+**Step 1: Install @anthropic-ai/sdk in the scripts context**
+
+The script runs in the GitHub Actions runner with Node.js 20. Add it as a dev dependency at root:
+```bash
+npm install --save-dev @anthropic-ai/sdk
+```
+
+Check `package.json` at root to confirm there is a `package.json` to add it to. If not, scripts use inline require — use dynamic import in the script with `npx` prefix, or add it to the closest relevant package. The cleanest option: add to root `package.json` devDependencies.
+
+**Step 2: Write analyze-review.js**
+
+```javascript
+#!/usr/bin/env node
+// analyze-review.js — Calls Claude (Sonnet 4.6) to analyze daily review data.
+// Usage: node scripts/analyze-review.js <review-data.json>
+// Outputs:
+//   report.md       — Full GitHub issue body (Claude narrative)
+//   email.html      — Short HTML summary
+//   slack.json      — Slack Block Kit payload (only if critical)
+//   alerts.json     — Structured alerts: [{severity, message, reason}]
+// Prints JSON to stdout: {has_critical_alerts, alert_count}
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const Anthropic = require('@anthropic-ai/sdk').default;
+
+const inputPath = process.argv[2] || '/dev/stdin';
+let rawData;
+try {
+  rawData = fs.readFileSync(inputPath, 'utf8');
+} catch (err) {
+  console.error(`Error reading input: ${err.message}`);
+  process.exit(1);
+}
+
+// Load format template as guidance
+let formatTemplate = '';
+try {
+  const templatePath = path.join(__dirname, 'format-review.js');
+  formatTemplate = fs.readFileSync(templatePath, 'utf8');
+} catch {
+  // Non-fatal — Claude will use defaults
+}
+
+const SYSTEM_PROMPT = `You are a trading system monitor for an automated prediction market trading bot.
+Your job is to analyze daily review data and produce structured outputs.
+
+THRESHOLD GUIDANCE (use as reference, not hard rules — apply judgment based on context):
+- drawdown > 10%: typically critical
+- 5+ consecutive losses: typically warning
+- no price data for 1h: typically critical (unless market is quiet)
+- container down: always critical
+- daily PnL < -$200: critical
+- high memory > 85%: warning
+- 0 signals generated: INFO only if markets are correctly filtered (e.g. all in 50/50 range, or no active markets); WARNING/CRITICAL if due to engine error
+- markets filtered by 50/50 rule: expected behavior, mention but do NOT flag as alert
+- CPU spikes: warning if sustained (>10min), info if brief (<2min, likely vacuum/maintenance)
+
+IMPORTANT: Distinguish expected behavior from actual problems. The system has many safety filters — markets being filtered is correct behavior.
+
+OUTPUTS REQUIRED (write each to a file):
+
+1. report.md — Full GitHub-flavored markdown issue body. Include:
+   - Summary section (3-5 bullets with key metrics)
+   - Detailed sections for: account status, signals, trades, risk, infrastructure
+   - Alert section if any warnings/critical items
+   - Use clear emoji status indicators: ✅ OK, ⚠️ Warning, 🔴 Critical
+
+2. email.html — Short HTML email (3-5 bullet points, plain styling, no external CSS)
+
+3. slack.json — Slack Block Kit JSON payload. ONLY include if there are critical alerts.
+   Format: {"blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": "..."}}]}
+
+4. alerts.json — Structured alert array:
+   [{"severity": "critical"|"warning"|"info", "message": "...", "reason": "..."}]
+   Only include items that genuinely warrant attention. Empty array [] is fine.
+
+Respond with a JSON object:
+{
+  "report_md": "...",
+  "email_html": "...",
+  "slack_json": null or {...},
+  "alerts": [...]
+}`;
+
+async function main() {
+  const client = new Anthropic();
+
+  let parsed;
+  try {
+    parsed = JSON.parse(rawData);
+  } catch {
+    parsed = { raw: rawData };
+  }
+
+  const userMessage = `Analyze this daily trading review data and produce the required outputs.
+
+Raw review data:
+\`\`\`json
+${JSON.stringify(parsed, null, 2).substring(0, 80000)}
+\`\`\`
+
+${formatTemplate ? `\nFormat reference (existing template):\n\`\`\`javascript\n${formatTemplate.substring(0, 5000)}\n\`\`\`` : ''}
+
+Write the analysis. Return valid JSON with report_md, email_html, slack_json, and alerts fields.`;
+
+  let response;
+  try {
+    const message = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 4096,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userMessage }],
+    });
+
+    const content = message.content[0];
+    if (content.type !== 'text') throw new Error('Unexpected response type');
+
+    // Extract JSON from response (may be wrapped in markdown code block)
+    let jsonText = content.text.trim();
+    const jsonMatch = jsonText.match(/```(?:json)?\s*([\s\S]*?)```/);
+    if (jsonMatch) jsonText = jsonMatch[1].trim();
+
+    response = JSON.parse(jsonText);
+  } catch (err) {
+    console.error(`Claude API error: ${err.message}`);
+    // Fallback: write minimal outputs so the workflow doesn't fail
+    fs.writeFileSync('report.md', `# Daily Review\n\nClaude analysis failed: ${err.message}\n\nRaw data attached to workflow artifacts.`);
+    fs.writeFileSync('email.html', `<p>Claude analysis failed: ${err.message}</p>`);
+    fs.writeFileSync('alerts.json', '[]');
+    console.log(JSON.stringify({ has_critical_alerts: false, alert_count: 0 }));
+    process.exit(0);
+  }
+
+  // Write output files
+  fs.writeFileSync('report.md', response.report_md || '# Daily Review\n\nNo report generated.');
+  fs.writeFileSync('email.html', response.email_html || '<p>No email summary generated.</p>');
+
+  const alerts = Array.isArray(response.alerts) ? response.alerts : [];
+  fs.writeFileSync('alerts.json', JSON.stringify(alerts, null, 2));
+
+  const hasCritical = alerts.some(a => a.severity === 'critical');
+  if (hasCritical && response.slack_json) {
+    fs.writeFileSync('slack.json', JSON.stringify(response.slack_json, null, 2));
+  }
+
+  const summary = {
+    has_critical_alerts: hasCritical,
+    alert_count: alerts.length,
+  };
+  console.log(JSON.stringify(summary));
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+**Step 3: Test locally (optional — verify structure)**
+
+```bash
+echo '{"test": true}' | node scripts/analyze-review.js /dev/stdin
+```
+Expected: Creates report.md, email.html, alerts.json
+
+**Step 4: Commit**
+
+```bash
+git add scripts/analyze-review.js
+git commit -m "feat: analyze-review.js — Claude-first daily review analysis"
+```
+
+---
+
+### Task 6: Update GitHub Actions workflow
+
+**Files:**
+- Modify: `.github/workflows/daily-trade-review.yml`
+
+**Step 1: Add ANTHROPIC_API_KEY to secrets usage and re-enable schedule**
+
+Replace the `on:` block:
+```yaml
+on:
+  schedule:
+    - cron: '0 8 * * *'   # Daily at 8:00 UTC
+  workflow_dispatch:        # Manual fallback
+```
+
+**Step 2: Add npm install step (for @anthropic-ai/sdk)**
+
+After the `Setup Node.js` step, add:
+```yaml
+      - name: Install script dependencies
+        run: npm install --prefix . @anthropic-ai/sdk 2>/dev/null || npm install @anthropic-ai/sdk
+```
+
+Or more robustly, create a minimal `scripts/package.json`:
+```json
+{
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0"
+  }
+}
+```
+Then in the workflow: `npm install --prefix scripts`
+
+**Step 3: Replace the Format report step with Analyze step**
+
+Replace:
+```yaml
+      - name: Format report
+        id: format
+        if: steps.gather.outputs.data_collected == 'true'
+        run: |
+          OUTPUT=$(cat review-data.json | node scripts/format-review.js)
+
+          HAS_CRITICAL=$(echo "$OUTPUT" | jq -r '.has_critical_alerts')
+          ALERT_COUNT=$(echo "$OUTPUT" | jq -r '.alert_count')
+          REVIEW_DATE=$(date -u +%Y-%m-%d)
+
+          echo "has_critical_alerts=$HAS_CRITICAL" >> $GITHUB_OUTPUT
+          echo "alert_count=$ALERT_COUNT" >> $GITHUB_OUTPUT
+          echo "review_date=$REVIEW_DATE" >> $GITHUB_OUTPUT
+```
+
+With:
+```yaml
+      - name: Analyze with Claude
+        id: format
+        if: steps.gather.outputs.data_collected == 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          cd scripts && npm install --silent
+          OUTPUT=$(node analyze-review.js ../review-data.json)
+
+          HAS_CRITICAL=$(echo "$OUTPUT" | jq -r '.has_critical_alerts')
+          ALERT_COUNT=$(echo "$OUTPUT" | jq -r '.alert_count')
+          REVIEW_DATE=$(date -u +%Y-%m-%d)
+
+          # Move output files to working dir for subsequent steps
+          mv report.md ../report.md 2>/dev/null || true
+          mv email.html ../email.html 2>/dev/null || true
+          mv slack.json ../slack.json 2>/dev/null || true
+          mv alerts.json ../alerts.json 2>/dev/null || true
+          cd ..
+
+          echo "has_critical_alerts=$HAS_CRITICAL" >> $GITHUB_OUTPUT
+          echo "alert_count=$ALERT_COUNT" >> $GITHUB_OUTPUT
+          echo "review_date=$REVIEW_DATE" >> $GITHUB_OUTPUT
+```
+
+**Step 4: Add ANTHROPIC_API_KEY to GitHub repo secrets**
+
+This must be done manually in GitHub → Settings → Secrets and variables → Actions.
+The key value is available in `packages/data-collector/.env` as `ANTHROPIC_API_KEY`.
+
+**Step 5: Add scripts/package.json**
+
+Create `scripts/package.json`:
+```json
+{
+  "name": "polymarket-scripts",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0"
+  }
+}
+```
+
+**Step 6: Commit**
+
+```bash
+git add .github/workflows/daily-trade-review.yml scripts/package.json
+git commit -m "feat: wire Claude analysis into daily review workflow, re-enable daily schedule"
+```
+
+---
+
+## Final Steps
+
+### Task 7: Build verification and push
+
+**Step 1: Run full typecheck**
+
+```bash
+cd packages/signals && npx tsc --noEmit
+cd ../dashboard && npx tsc --noEmit
+```
+
+**Step 2: Run all signal tests**
+
+```bash
+cd packages/signals && npx vitest run
+```
+
+**Step 3: Push to main**
+
+```bash
+gh auth switch --user JaviMaligno
+git push origin main
+```
+
+**Step 4: Add ANTHROPIC_API_KEY to GitHub secrets**
+
+```bash
+gh secret set ANTHROPIC_API_KEY --body "$(grep ANTHROPIC_API_KEY packages/data-collector/.env | cut -d= -f2)"
+```
+
+**Step 5: Test the workflow manually**
+
+```bash
+gh workflow run daily-trade-review.yml
+gh run list --workflow=daily-trade-review.yml --limit=1
+```
+
+Watch for success. If the Claude step fails, check `ANTHROPIC_API_KEY` is set correctly.
+
+---
+
+## Optimizer Integration Note
+
+New parameters introduced in this plan that are candidates for Bayesian optimization:
+
+| Parameter | Default | Location |
+|-----------|---------|----------|
+| `uncertain_min` band boundary | 0.45 | `PriceRangeWeightModifier.ts` |
+| `uncertain_max` band boundary | 0.55 | `PriceRangeWeightModifier.ts` |
+| `transitional_min` boundary | 0.40 | `PriceRangeWeightModifier.ts` |
+| `transitional_max` boundary | 0.60 | `PriceRangeWeightModifier.ts` |
+| All 11 × 3 multiplier matrix values | See design | `PriceRangeWeightModifier.ts` |
+| `openThreshold` | 0.43 | `AutoSignalExecutor.ts` / `trading_config` |
+| `exitThreshold` | 0.25 | `AutoSignalExecutor.ts` + `SignalEngine.ts` |
+
+These should be added to `StrategyOptimizer`'s parameter space in a follow-up task once baseline data is collected with the new system.

--- a/docs/plans/2026-03-14-issue20-critical-fixes-design.md
+++ b/docs/plans/2026-03-14-issue20-critical-fixes-design.md
@@ -1,0 +1,326 @@
+# Issue #20 Critical Fixes — Design Document
+
+**Date:** 2026-03-14
+**Issue:** [#20 — Daily Review 2026-03-14: Critical — 38% Drawdown, Circuit Breaker Threshold Bug, Missing DB Tables](https://github.com/JaviMaligno/polymarket-trader/issues/20)
+**Status:** Design
+
+---
+
+## Problem Summary
+
+The trading system lost 38% of capital ($3,815 of $10,000) due to a combination of 6 bugs:
+
+1. **Upsert Zombie Bug** — positions re-opened on same market become invisible, trapping capital permanently
+2. **Circuit breaker threshold** — hardcoded at 30% instead of reading MAX_DRAWDOWN env var (15%)
+3. **Circuit breaker drawdown formula** — uses capital-only, not equity (capital + positions)
+4. **50/50 market filter missing** — order flow signals bypass PriceRangeWeightModifier at $0.50
+5. **CircuitBreakerService bypasses PositionClosingService** — direct SQL, no events, potential inconsistency
+6. **Missing DB tables** — external_signals and market_crossref never applied to production
+
+### Accounting Gap Investigation
+
+**DB evidence (2026-03-14):**
+- `paper_account.total_realized_pnl = -$79.97` but positions sum to `+$324.52`
+- **29 zombie positions** with `size > 0` AND `closed_at IS NOT NULL` → **$2,656.80 trapped**
+- 253 buys vs only 78 sells — massive imbalance
+- Expected capital from position PnL: $10,324.52 vs actual: $6,185.11 → **$4,139 gap**
+
+**Root cause:** `paperPositionsRepo.upsert()` uses `ON CONFLICT (market_id, token_id) DO UPDATE` but does NOT reset `closed_at = NULL`. When a new BUY fires for a previously-closed position:
+1. Capital deducted from account
+2. `size` overwritten with new value
+3. `closed_at` stays set (from previous close)
+4. `getAll()` filters `WHERE closed_at IS NULL` → position invisible
+5. No service can see it → capital permanently trapped
+
+This bug has been active since the system started and explains why the accounting gap keeps growing across account resets.
+
+---
+
+## Fix 1: Upsert Zombie Bug
+
+**File:** `packages/dashboard/src/database/repositories.ts:327-358`
+
+**Current code (line 334):**
+```sql
+ON CONFLICT (market_id, token_id) DO UPDATE SET
+  current_price = EXCLUDED.current_price,
+  unrealized_pnl = EXCLUDED.unrealized_pnl,
+  unrealized_pnl_pct = EXCLUDED.unrealized_pnl_pct,
+  realized_pnl = EXCLUDED.realized_pnl,
+  size = EXCLUDED.size,
+  updated_at = NOW()
+```
+
+**Fix — add `closed_at = NULL` and reset open fields:**
+```sql
+ON CONFLICT (market_id, token_id) DO UPDATE SET
+  current_price = EXCLUDED.current_price,
+  unrealized_pnl = EXCLUDED.unrealized_pnl,
+  unrealized_pnl_pct = EXCLUDED.unrealized_pnl_pct,
+  realized_pnl = EXCLUDED.realized_pnl,
+  size = EXCLUDED.size,
+  closed_at = NULL,
+  opened_at = EXCLUDED.opened_at,
+  avg_entry_price = EXCLUDED.avg_entry_price,
+  signal_type = EXCLUDED.signal_type,
+  metadata = EXCLUDED.metadata,
+  stop_loss = EXCLUDED.stop_loss,
+  take_profit = EXCLUDED.take_profit,
+  updated_at = NOW()
+```
+
+**Why each field:** When a new BUY re-uses a market_id+token_id, it's a brand new position. All fields must reflect the new entry — not carry stale data from the previous close. `closed_at = NULL` is the critical one (makes it visible), but `opened_at`, `avg_entry_price`, `signal_type`, `metadata`, `stop_loss`, `take_profit` must also reset to avoid stale data.
+
+**Test:** Open position → close it → open new position on same market → verify `closed_at IS NULL` and position appears in `getAll()`.
+
+---
+
+## Fix 2: Circuit Breaker Threshold
+
+**Files:**
+- `packages/dashboard/src/server.ts:187`
+- `packages/dashboard/src/services/CircuitBreakerService.ts:42`
+
+**Current:** `maxDrawdownPct: 30` (hardcoded)
+
+**Fix in server.ts:**
+```typescript
+const circuitBreakerService = initializeCircuitBreakerService({
+  enabled: true,
+  checkIntervalMs: 5 * 60 * 1000,
+  maxDrawdownPct: parseFloat(process.env.MAX_DRAWDOWN || '0.15') * 100,
+  initialCapital: parseFloat(process.env.INITIAL_CAPITAL || '10000'),
+});
+```
+
+**Fix in CircuitBreakerService.ts DEFAULT_CONFIG:**
+```typescript
+const DEFAULT_CONFIG: CircuitBreakerConfig = {
+  enabled: true,
+  checkIntervalMs: 5 * 60 * 1000,
+  maxDrawdownPct: parseFloat(process.env.MAX_DRAWDOWN || '0.15') * 100,  // 15% default
+  initialCapital: parseFloat(process.env.INITIAL_CAPITAL || '10000'),
+  cooldownMs: 30 * 60 * 1000,
+  autoReset: false,
+};
+```
+
+This reads `MAX_DRAWDOWN=0.15` (decimal) and converts to `15` (percentage) to match the field name `maxDrawdownPct`.
+
+---
+
+## Fix 3: Circuit Breaker Drawdown Formula
+
+**File:** `packages/dashboard/src/services/CircuitBreakerService.ts:160-171`
+
+**Current (line 171):**
+```typescript
+const drawdownPct = ((initialCapital - currentCapital) / initialCapital) * 100;
+```
+
+This only uses `currentCapital` (cash). When $5,000 is in positions, it shows 50% drawdown even though equity is $10,000.
+
+**Fix — use equity (capital + positions), matching RiskManager:**
+```typescript
+// Get total exposure from open positions
+const exposureResult = await query<{ total_exposure: string }>(
+  `SELECT COALESCE(SUM(size * current_price), 0) as total_exposure
+   FROM paper_positions WHERE closed_at IS NULL`
+);
+const totalExposure = parseFloat(exposureResult.rows[0]?.total_exposure || '0');
+const currentEquity = currentCapital + totalExposure;
+const drawdownPct = ((initialCapital - currentEquity) / initialCapital) * 100;
+```
+
+---
+
+## Fix 4: 50/50 Market Filter in setActiveMarkets
+
+**File:** `packages/dashboard/src/services/SignalEngine.ts:271-310`
+
+The `PriceRangeWeightModifier` zeros momentum/mean_reversion for 0.45-0.55 but OFI, MLOFI, Hawkes stay at weight 1.0. This allows trades at $0.50 where there's no edge.
+
+**Fix — add explicit filter in `setActiveMarkets()`:**
+```typescript
+setActiveMarkets(markets: ActiveMarket[]): void {
+  const MIN_PRICE = 0.05;
+  const MAX_PRICE = 0.95;
+  const FIFTY_FIFTY_MIN = 0.45;
+  const FIFTY_FIFTY_MAX = 0.55;
+
+  let inactiveCount = 0;
+  let resolvedCount = 0;
+  let extremePriceCount = 0;
+  let fiftyFiftyCount = 0;
+
+  const filtered = markets.filter(m => {
+    if (m.isActive === false) { inactiveCount++; return false; }
+    if (m.isResolved === true) { resolvedCount++; return false; }
+
+    const price = m.currentPrice;
+    if (price < MIN_PRICE || price > MAX_PRICE) { extremePriceCount++; return false; }
+
+    // Filter 4: Skip 50/50 markets (no edge, fees make EV negative)
+    if (price >= FIFTY_FIFTY_MIN && price <= FIFTY_FIFTY_MAX) {
+      fiftyFiftyCount++;
+      return false;
+    }
+
+    return true;
+  });
+
+  const totalExcluded = inactiveCount + resolvedCount + extremePriceCount + fiftyFiftyCount;
+  if (totalExcluded > 0) {
+    console.log(`[SignalEngine] Filtered markets: ${inactiveCount} inactive, ${resolvedCount} resolved, ${extremePriceCount} extreme, ${fiftyFiftyCount} near-50/50`);
+  }
+
+  this.activeMarkets = filtered;
+  console.log(`[SignalEngine] Updated active markets: ${filtered.length}`);
+  this.emit('markets:updated', filtered.length);
+}
+```
+
+**Note:** `PriceRangeWeightModifier` stays as defense-in-depth — it handles transitional bands (0.40-0.45, 0.55-0.60) where signals should be reduced but not eliminated.
+
+---
+
+## Fix 5: CircuitBreakerService → PositionClosingService
+
+**File:** `packages/dashboard/src/services/CircuitBreakerService.ts:270-326`
+
+Currently `closeAllPositions()` does direct SQL for each position (lines 291-314). This bypasses PositionClosingService and doesn't emit `position:closed` events.
+
+**Fix — delegate to PositionClosingService:**
+```typescript
+private async closeAllPositions(): Promise<number> {
+  const positions = await query<any>(
+    'SELECT * FROM paper_positions WHERE closed_at IS NULL'
+  );
+
+  let closed = 0;
+  const closingService = getPositionClosingService();
+
+  for (const pos of positions.rows) {
+    const exitPrice = parseFloat(pos.current_price) || parseFloat(pos.avg_entry_price);
+    const result = await closingService.close({
+      marketId: pos.market_id,
+      tokenId: pos.token_id,
+      exitPrice,
+      reason: 'circuit_breaker_exit',
+      size: parseFloat(pos.size),
+    });
+    if (result.executed) {
+      closed++;
+      console.log(`[CircuitBreaker] Closed ${pos.market_id.substring(0, 12)}... | P&L: $${result.netPnl.toFixed(2)}`);
+    }
+  }
+
+  console.log(`[CircuitBreaker] Closed ${closed} positions`);
+  return closed;
+}
+```
+
+This removes ~50 lines of duplicated SQL and ensures consistent fee/PnL handling plus event emission.
+
+---
+
+## Fix 6: Missing DB Tables
+
+**File:** `packages/data-collector/src/database/init/004_external_data_schema.sql`
+
+The schema exists but was never applied to the production database. Apply it via SSH:
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+    CREATE TABLE IF NOT EXISTS market_crossref (
+      polymarket_id VARCHAR(128) NOT NULL,
+      platform VARCHAR(50) NOT NULL,
+      external_id VARCHAR(255) NOT NULL,
+      external_question TEXT,
+      external_price DECIMAL(10,6),
+      match_confidence FLOAT NOT NULL DEFAULT 0.0,
+      matched_at TIMESTAMPTZ DEFAULT NOW(),
+      last_fetched_at TIMESTAMPTZ,
+      PRIMARY KEY (polymarket_id, platform)
+    );
+    CREATE INDEX IF NOT EXISTS idx_crossref_platform ON market_crossref(platform);
+    CREATE INDEX IF NOT EXISTS idx_crossref_confidence ON market_crossref(match_confidence);
+    CREATE TABLE IF NOT EXISTS external_signals (
+      id SERIAL PRIMARY KEY,
+      market_id VARCHAR(128) NOT NULL,
+      source VARCHAR(50) NOT NULL,
+      signal_type VARCHAR(50) NOT NULL,
+      value FLOAT NOT NULL,
+      confidence FLOAT DEFAULT 0.5,
+      metadata JSONB DEFAULT '{}',
+      fetched_at TIMESTAMPTZ DEFAULT NOW()
+    );
+    CREATE INDEX IF NOT EXISTS idx_external_signals_market ON external_signals(market_id, fetched_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_external_signals_source ON external_signals(source, signal_type);
+  \""
+```
+
+**Also:** Add `CREATE TABLE IF NOT EXISTS` for both tables in the dashboard-api startup (database init) so they auto-create on future deployments.
+
+---
+
+## Post-Fix: Account Reset
+
+After deploying all 6 fixes:
+
+1. Reset paper_account to $10,000
+2. Close all zombie positions (29 with `size > 0 AND closed_at IS NOT NULL`)
+3. Clear max_drawdown to 0
+4. Reset peak_equity to $10,000
+5. Reset trade counters
+
+```sql
+-- Clean zombies
+UPDATE paper_positions SET size = 0, realized_pnl = 0 WHERE closed_at IS NOT NULL AND size > 0;
+
+-- Reset account
+UPDATE paper_account SET
+  current_capital = 10000,
+  available_capital = 10000,
+  initial_capital = 10000,
+  total_realized_pnl = 0,
+  total_unrealized_pnl = 0,
+  total_fees_paid = 0,
+  peak_equity = 10000,
+  max_drawdown = 0,
+  total_trades = 0,
+  winning_trades = 0,
+  losing_trades = 0,
+  updated_at = NOW()
+WHERE id = 1;
+
+-- Clear halt status
+UPDATE trading_config SET value = 'false', updated_at = NOW() WHERE key = 'trading_halted';
+```
+
+---
+
+## Implementation Order
+
+| Step | Fix | Risk if skipped | Effort |
+|------|-----|----------------|--------|
+| 1 | Fix 1: Upsert zombie | Capital keeps leaking | Small (1 SQL line) |
+| 2 | Fix 2: CB threshold | System allows 30% loss | Small (2 lines) |
+| 3 | Fix 3: CB drawdown formula | Phantom triggers when capital in positions | Small (5 lines) |
+| 4 | Fix 4: 50/50 filter | Trades with no edge | Small (8 lines) |
+| 5 | Fix 5: CB → PositionClosingService | Inconsistent closes | Medium (refactor method) |
+| 6 | Fix 6: Missing DB tables | Log noise, data gaps | Small (apply SQL) |
+| 7 | Account reset | Corrupted data | Small (run SQL) |
+
+All fixes are independent and can be implemented in any order. Recommended: deploy fixes 1-5 as a single commit, apply fix 6 + reset on production DB separately.
+
+---
+
+## Testing Strategy
+
+1. **Unit test for upsert zombie** — open, close, re-open same market, verify `closed_at IS NULL`
+2. **Unit test for CB threshold** — verify it reads `MAX_DRAWDOWN` env var
+3. **Unit test for CB drawdown** — mock positions with exposure, verify equity-based calculation
+4. **Integration test for 50/50 filter** — set market at 0.50, verify excluded from `setActiveMarkets()`
+5. **Existing tests** — run full test suite to verify no regressions

--- a/docs/plans/2026-03-14-issue20-critical-fixes-plan.md
+++ b/docs/plans/2026-03-14-issue20-critical-fixes-plan.md
@@ -1,0 +1,692 @@
+# Issue #20 Critical Fixes — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix the 6 bugs causing the 38% drawdown and $3,722 capital leak, then reset the account.
+
+**Architecture:** All fixes are in `packages/dashboard/src/`. Fix 1 (upsert zombie) is in `database/repositories.ts`. Fixes 2-5 are in `services/CircuitBreakerService.ts` and `services/SignalEngine.ts`. Fix 6 is a SQL migration on the VM. Tests use vitest with mocked DB.
+
+**Tech Stack:** TypeScript, vitest, PostgreSQL, SSH to GCP VM
+
+**Design doc:** `docs/plans/2026-03-14-issue20-critical-fixes-design.md`
+
+---
+
+### Task 1: Fix Upsert Zombie Bug
+
+The most critical fix. `paperPositionsRepo.upsert()` doesn't reset `closed_at = NULL` on conflict, causing reopened positions to be invisible (29 zombie positions, $2,656 trapped).
+
+**Files:**
+- Modify: `packages/dashboard/src/database/repositories.ts:334-340`
+- Test: `packages/dashboard/src/database/repositories.test.ts` (create new)
+
+**Step 1: Write the failing test**
+
+Create `packages/dashboard/src/database/repositories.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./index.js', () => ({
+  query: vi.fn(),
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+import { query } from './index.js';
+import { paperPositionsRepo } from './repositories.js';
+
+describe('paperPositionsRepo.upsert', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(query).mockResolvedValue({ rows: [], rowCount: 1 } as any);
+  });
+
+  it('should include closed_at = NULL in ON CONFLICT UPDATE', async () => {
+    await paperPositionsRepo.upsert({
+      market_id: 'market-1',
+      token_id: 'token-1',
+      side: 'long',
+      size: 100,
+      avg_entry_price: 0.50,
+      current_price: 0.50,
+      unrealized_pnl: 0,
+      unrealized_pnl_pct: 0,
+      opened_at: new Date(),
+    } as any);
+
+    const sql = vi.mocked(query).mock.calls[0][0] as string;
+    // The ON CONFLICT clause must reset closed_at to NULL
+    expect(sql).toContain('closed_at = NULL');
+    // Must also reset opened_at and avg_entry_price for the new position
+    expect(sql).toContain('opened_at = EXCLUDED.opened_at');
+    expect(sql).toContain('avg_entry_price = EXCLUDED.avg_entry_price');
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && npx vitest run src/database/repositories.test.ts`
+Expected: FAIL — current SQL doesn't contain `closed_at = NULL`
+
+**Step 3: Fix the upsert SQL**
+
+In `packages/dashboard/src/database/repositories.ts`, replace the ON CONFLICT clause (lines 334-340):
+
+```typescript
+       ON CONFLICT (market_id, token_id) DO UPDATE SET
+         current_price = EXCLUDED.current_price,
+         unrealized_pnl = EXCLUDED.unrealized_pnl,
+         unrealized_pnl_pct = EXCLUDED.unrealized_pnl_pct,
+         realized_pnl = EXCLUDED.realized_pnl,
+         size = EXCLUDED.size,
+         closed_at = NULL,
+         opened_at = EXCLUDED.opened_at,
+         avg_entry_price = EXCLUDED.avg_entry_price,
+         signal_type = EXCLUDED.signal_type,
+         metadata = EXCLUDED.metadata,
+         stop_loss = EXCLUDED.stop_loss,
+         take_profit = EXCLUDED.take_profit,
+         updated_at = NOW()`,
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd packages/dashboard && npx vitest run src/database/repositories.test.ts`
+Expected: PASS
+
+**Step 5: Run full test suite for regressions**
+
+Run: `cd packages/dashboard && npx vitest run`
+Expected: All existing tests pass
+
+**Step 6: Commit**
+
+```bash
+git add packages/dashboard/src/database/repositories.ts packages/dashboard/src/database/repositories.test.ts
+git commit -m "fix: reset closed_at on upsert to prevent zombie positions"
+```
+
+---
+
+### Task 2: Fix Circuit Breaker Threshold + Default Config
+
+Hardcoded `maxDrawdownPct: 30` should read `MAX_DRAWDOWN` env var (0.15 = 15%).
+
+**Files:**
+- Modify: `packages/dashboard/src/server.ts:184-189`
+- Modify: `packages/dashboard/src/services/CircuitBreakerService.ts:39-46`
+
+**Step 1: Write the failing test**
+
+Add to `packages/dashboard/src/services/CircuitBreakerService.test.ts`:
+
+```typescript
+it('DEFAULT_CONFIG should read MAX_DRAWDOWN env var', () => {
+  // Set env before importing fresh module
+  process.env.MAX_DRAWDOWN = '0.15';
+  const service = new CircuitBreakerService();
+  // Access the config via the check method behavior
+  // The default maxDrawdownPct should be 15 (from 0.15 * 100)
+  expect((service as any).config.maxDrawdownPct).toBe(15);
+  delete process.env.MAX_DRAWDOWN;
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && npx vitest run src/services/CircuitBreakerService.test.ts`
+Expected: FAIL — config.maxDrawdownPct is 30, not 15
+
+**Step 3: Fix DEFAULT_CONFIG in CircuitBreakerService.ts**
+
+Replace lines 39-46:
+
+```typescript
+const DEFAULT_CONFIG: CircuitBreakerConfig = {
+  enabled: true,
+  checkIntervalMs: 5 * 60 * 1000,
+  maxDrawdownPct: parseFloat(process.env.MAX_DRAWDOWN || '0.15') * 100,
+  initialCapital: parseFloat(process.env.INITIAL_CAPITAL || '10000'),
+  cooldownMs: 30 * 60 * 1000,
+  autoReset: false,
+};
+```
+
+**Step 4: Fix server.ts to read env var**
+
+Replace lines 184-189:
+
+```typescript
+      const circuitBreakerService = initializeCircuitBreakerService({
+        enabled: true,
+        checkIntervalMs: 5 * 60 * 1000,
+        maxDrawdownPct: parseFloat(process.env.MAX_DRAWDOWN || '0.15') * 100,
+        initialCapital: parseFloat(process.env.INITIAL_CAPITAL || '10000'),
+      });
+```
+
+**Step 5: Run test to verify it passes**
+
+Run: `cd packages/dashboard && npx vitest run src/services/CircuitBreakerService.test.ts`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add packages/dashboard/src/services/CircuitBreakerService.ts packages/dashboard/src/server.ts
+git commit -m "fix: circuit breaker reads MAX_DRAWDOWN env var (15% not hardcoded 30%)"
+```
+
+---
+
+### Task 3: Fix Circuit Breaker Drawdown Formula
+
+Uses capital-only instead of equity (capital + positions). When capital is in positions, shows phantom drawdown.
+
+**Files:**
+- Modify: `packages/dashboard/src/services/CircuitBreakerService.ts:155-175`
+
+**Step 1: Write the failing test**
+
+Add to `CircuitBreakerService.test.ts`:
+
+```typescript
+it('drawdown check should use equity (capital + positions), not capital alone', async () => {
+  // Account has $5000 capital but $5000 in open positions = $10000 equity
+  // With initialCapital=$10000, drawdown should be 0%, not 50%
+  vi.mocked(query)
+    .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any) // CREATE TABLE
+    .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any) // SELECT trading_config
+    .mockResolvedValueOnce({  // SELECT paper_account
+      rows: [{ current_capital: '5000', initial_capital: '10000' }],
+      rowCount: 1,
+    } as any)
+    .mockResolvedValueOnce({  // SELECT total exposure from positions
+      rows: [{ total_exposure: '5000' }],
+      rowCount: 1,
+    } as any);
+
+  const service = new CircuitBreakerService({
+    checkIntervalMs: 60_000,
+    maxDrawdownPct: 30,
+    initialCapital: 10000,
+  });
+  await service.start();
+
+  // Advance timer to trigger check
+  await vi.advanceTimersByTimeAsync(60_000);
+
+  // Should NOT have triggered halt (equity = $10000, drawdown = 0%)
+  expect(service.isTradingHalted()).toBe(false);
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && npx vitest run src/services/CircuitBreakerService.test.ts`
+Expected: FAIL — current code sees 50% drawdown from capital-only calculation and triggers halt
+
+**Step 3: Fix the drawdown calculation**
+
+In `CircuitBreakerService.ts`, replace lines 155-171 (inside `checkDrawdown()`):
+
+Find the current capital-only calculation:
+```typescript
+      const currentCapital = parseFloat(accountResult.rows[0].current_capital);
+      const initialCapital = this.config.initialCapital;
+
+      // Calculate drawdown percentage
+      const drawdownPct = ((initialCapital - currentCapital) / initialCapital) * 100;
+```
+
+Replace with equity-based calculation:
+```typescript
+      const currentCapital = parseFloat(accountResult.rows[0].current_capital);
+      const initialCapital = this.config.initialCapital;
+
+      // Get total exposure from open positions
+      const exposureResult = await query<{ total_exposure: string }>(
+        `SELECT COALESCE(SUM(size * current_price), 0) as total_exposure
+         FROM paper_positions WHERE closed_at IS NULL`
+      );
+      const totalExposure = parseFloat(exposureResult.rows[0]?.total_exposure || '0');
+      const currentEquity = currentCapital + totalExposure;
+
+      // Calculate drawdown using equity (capital + positions), not capital alone
+      const drawdownPct = ((initialCapital - currentEquity) / initialCapital) * 100;
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd packages/dashboard && npx vitest run src/services/CircuitBreakerService.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/src/services/CircuitBreakerService.ts
+git commit -m "fix: circuit breaker uses equity (capital + positions) for drawdown"
+```
+
+---
+
+### Task 4: Add 50/50 Market Filter in setActiveMarkets
+
+`PriceRangeWeightModifier` zeros momentum/mean_reversion but OFI/MLOFI/Hawkes stay at full weight. Need explicit filter.
+
+**Files:**
+- Modify: `packages/dashboard/src/services/SignalEngine.ts:271-310`
+
+**Step 1: Write the failing test**
+
+The existing `SignalEngine.test.ts` tests Bayesian caps. Add a new test file for the market filter since SignalEngine has complex constructor dependencies:
+
+Create `packages/dashboard/src/services/SignalEngine.filter.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Extract the market filter logic for testing.
+ * Mirrors setActiveMarkets() in SignalEngine.
+ */
+function filterMarkets(markets: Array<{ currentPrice: number; isActive?: boolean; isResolved?: boolean }>) {
+  const MIN_PRICE = 0.05;
+  const MAX_PRICE = 0.95;
+  const FIFTY_FIFTY_MIN = 0.45;
+  const FIFTY_FIFTY_MAX = 0.55;
+
+  return markets.filter(m => {
+    if (m.isActive === false) return false;
+    if (m.isResolved === true) return false;
+    const price = m.currentPrice;
+    if (price < MIN_PRICE || price > MAX_PRICE) return false;
+    if (price >= FIFTY_FIFTY_MIN && price <= FIFTY_FIFTY_MAX) return false;
+    return true;
+  });
+}
+
+describe('setActiveMarkets 50/50 filter', () => {
+  it('should filter out markets at exactly 0.50', () => {
+    const markets = [
+      { currentPrice: 0.50, isActive: true },
+      { currentPrice: 0.30, isActive: true },
+    ];
+    expect(filterMarkets(markets)).toHaveLength(1);
+    expect(filterMarkets(markets)[0].currentPrice).toBe(0.30);
+  });
+
+  it('should filter out markets in 0.45-0.55 range', () => {
+    const markets = [
+      { currentPrice: 0.45, isActive: true },
+      { currentPrice: 0.55, isActive: true },
+      { currentPrice: 0.44, isActive: true },
+      { currentPrice: 0.56, isActive: true },
+    ];
+    const filtered = filterMarkets(markets);
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map(m => m.currentPrice)).toEqual([0.44, 0.56]);
+  });
+
+  it('should keep markets outside 50/50 range', () => {
+    const markets = [
+      { currentPrice: 0.10, isActive: true },
+      { currentPrice: 0.90, isActive: true },
+    ];
+    expect(filterMarkets(markets)).toHaveLength(2);
+  });
+
+  it('should still filter extreme prices', () => {
+    const markets = [
+      { currentPrice: 0.03, isActive: true },
+      { currentPrice: 0.97, isActive: true },
+    ];
+    expect(filterMarkets(markets)).toHaveLength(0);
+  });
+});
+```
+
+**Step 2: Run test to verify it passes (pure logic test)**
+
+Run: `cd packages/dashboard && npx vitest run src/services/SignalEngine.filter.test.ts`
+Expected: PASS (this tests the logic we want to implement)
+
+**Step 3: Implement the filter in SignalEngine.ts**
+
+Replace `setActiveMarkets()` (lines 271-310):
+
+```typescript
+  setActiveMarkets(markets: ActiveMarket[]): void {
+    const MIN_PRICE = 0.05;
+    const MAX_PRICE = 0.95;
+    const FIFTY_FIFTY_MIN = 0.45;
+    const FIFTY_FIFTY_MAX = 0.55;
+
+    let inactiveCount = 0;
+    let resolvedCount = 0;
+    let extremePriceCount = 0;
+    let fiftyFiftyCount = 0;
+
+    const filtered = markets.filter(m => {
+      // Filter 1: Skip inactive markets
+      if (m.isActive === false) {
+        inactiveCount++;
+        return false;
+      }
+
+      // Filter 2: Skip resolved markets
+      if (m.isResolved === true) {
+        resolvedCount++;
+        return false;
+      }
+
+      // Filter 3: Skip extreme prices (no profitable trade opportunity)
+      const price = m.currentPrice;
+      if (price < MIN_PRICE || price > MAX_PRICE) {
+        extremePriceCount++;
+        return false;
+      }
+
+      // Filter 4: Skip 50/50 markets (no edge, fees make EV negative)
+      if (price >= FIFTY_FIFTY_MIN && price <= FIFTY_FIFTY_MAX) {
+        fiftyFiftyCount++;
+        return false;
+      }
+
+      return true;
+    });
+
+    // Log filtering summary
+    const totalExcluded = inactiveCount + resolvedCount + extremePriceCount + fiftyFiftyCount;
+    if (totalExcluded > 0) {
+      console.log(`[SignalEngine] Filtered markets: ${inactiveCount} inactive, ${resolvedCount} resolved, ${extremePriceCount} extreme, ${fiftyFiftyCount} near-50/50`);
+    }
+
+    this.activeMarkets = filtered;
+    console.log(`[SignalEngine] Updated active markets: ${filtered.length}`);
+    this.emit('markets:updated', filtered.length);
+  }
+```
+
+**Step 4: Run full test suite**
+
+Run: `cd packages/dashboard && npx vitest run`
+Expected: All tests pass
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/src/services/SignalEngine.ts packages/dashboard/src/services/SignalEngine.filter.test.ts
+git commit -m "fix: add explicit 50/50 market filter in setActiveMarkets (0.45-0.55)"
+```
+
+---
+
+### Task 5: CircuitBreakerService Delegates to PositionClosingService
+
+`closeAllPositions()` does direct SQL (~50 lines). Should delegate to `PositionClosingService.close()`.
+
+**Files:**
+- Modify: `packages/dashboard/src/services/CircuitBreakerService.ts:1-21` (imports) and `:230-326` (closeAllPositions)
+
+**Step 1: Add import for PositionClosingService**
+
+At the top of `CircuitBreakerService.ts`, add:
+
+```typescript
+import { getPositionClosingService } from './PositionClosingService.js';
+```
+
+**Step 2: Replace closeAllPositions()**
+
+Replace lines 230-326 (the entire `closeAllPositions()` method):
+
+```typescript
+  private async closeAllPositions(): Promise<number> {
+    const openPositions = await query<{
+      market_id: string;
+      token_id: string;
+      side: string;
+      size: string;
+      avg_entry_price: string;
+      latest_price: string | null;
+    }>(`
+      SELECT
+        pp.market_id,
+        pp.token_id,
+        pp.side,
+        pp.size,
+        pp.avg_entry_price,
+        ph.close as latest_price
+      FROM paper_positions pp
+      LEFT JOIN LATERAL (
+        SELECT close FROM price_history
+        WHERE token_id = pp.token_id
+        ORDER BY time DESC LIMIT 1
+      ) ph ON true
+      WHERE pp.closed_at IS NULL
+    `);
+
+    let closed = 0;
+    const closingService = getPositionClosingService();
+
+    for (const pos of openPositions.rows) {
+      const size = parseFloat(pos.size);
+      if (size <= 0) continue;
+
+      const entryPrice = parseFloat(pos.avg_entry_price);
+      const exitPrice = pos.latest_price
+        ? parseFloat(pos.latest_price)
+        : entryPrice;
+
+      try {
+        const result = await closingService.close({
+          marketId: pos.market_id,
+          tokenId: pos.token_id,
+          side: pos.side as 'long' | 'short',
+          size,
+          entryPrice,
+          exitPrice,
+          reason: 'circuit_breaker_exit',
+        });
+
+        if (result.executed) {
+          closed++;
+          console.log(`[CircuitBreaker] Closed ${pos.market_id.substring(0, 12)}... | P&L: $${result.netPnl.toFixed(2)}`);
+        }
+      } catch (error) {
+        console.error(`[CircuitBreaker] Failed to close position ${pos.market_id}:`, error);
+      }
+    }
+
+    console.log(`[CircuitBreaker] Closed ${closed} positions`);
+    return closed;
+  }
+```
+
+**Step 3: Remove unused imports**
+
+The `paperTradesRepo` import is no longer needed by this service (it was only used in the direct SQL path). Check if it's used elsewhere in the file — if not, remove it from the import:
+
+```typescript
+// Remove paperTradesRepo from this import if unused:
+import { paperPositionsRepo } from '../database/repositories.js';
+```
+
+**Step 4: Update existing test mock**
+
+In `CircuitBreakerService.test.ts`, add the PositionClosingService mock:
+
+```typescript
+vi.mock('./PositionClosingService.js', () => ({
+  getPositionClosingService: vi.fn(() => ({
+    close: vi.fn().mockResolvedValue({ executed: true, netPnl: -5, fee: 0.01 }),
+  })),
+}));
+```
+
+**Step 5: Run full test suite**
+
+Run: `cd packages/dashboard && npx vitest run`
+Expected: All tests pass
+
+**Step 6: Commit**
+
+```bash
+git add packages/dashboard/src/services/CircuitBreakerService.ts packages/dashboard/src/services/CircuitBreakerService.test.ts
+git commit -m "fix: CircuitBreakerService delegates to PositionClosingService"
+```
+
+---
+
+### Task 6: Apply Missing DB Tables + Account Reset on Production
+
+This task runs SQL on the production VM. No code changes, no tests.
+
+**Files:**
+- No code files modified (tables already applied to prod during investigation; this step verifies + resets account)
+
+**Step 1: Verify tables exist (they were applied during issue #22 investigation)**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+    SELECT table_name FROM information_schema.tables
+    WHERE table_name IN ('market_crossref', 'external_signals')
+    ORDER BY table_name;
+  \""
+```
+
+Expected: Both tables listed. If not, apply `004_external_data_schema.sql`:
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+    CREATE TABLE IF NOT EXISTS market_crossref (
+      polymarket_id VARCHAR(128) NOT NULL,
+      platform VARCHAR(50) NOT NULL,
+      external_id VARCHAR(255) NOT NULL,
+      external_question TEXT,
+      external_price DECIMAL(10,6),
+      match_confidence FLOAT NOT NULL DEFAULT 0.0,
+      matched_at TIMESTAMPTZ DEFAULT NOW(),
+      last_fetched_at TIMESTAMPTZ,
+      PRIMARY KEY (polymarket_id, platform)
+    );
+    CREATE INDEX IF NOT EXISTS idx_crossref_platform ON market_crossref(platform);
+    CREATE INDEX IF NOT EXISTS idx_crossref_confidence ON market_crossref(match_confidence);
+    CREATE TABLE IF NOT EXISTS external_signals (
+      id SERIAL PRIMARY KEY,
+      market_id VARCHAR(128) NOT NULL,
+      source VARCHAR(50) NOT NULL,
+      signal_type VARCHAR(50) NOT NULL,
+      value FLOAT NOT NULL,
+      confidence FLOAT DEFAULT 0.5,
+      metadata JSONB DEFAULT '{}',
+      fetched_at TIMESTAMPTZ DEFAULT NOW()
+    );
+    CREATE INDEX IF NOT EXISTS idx_external_signals_market ON external_signals(market_id, fetched_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_external_signals_source ON external_signals(source, signal_type);
+  \""
+```
+
+**Step 2: Clean zombie positions**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+    UPDATE paper_positions SET size = 0, realized_pnl = 0
+    WHERE closed_at IS NOT NULL AND size > 0;
+  \""
+```
+
+**Step 3: Reset paper account to $10,000**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+    UPDATE paper_account SET
+      current_capital = 10000,
+      available_capital = 10000,
+      initial_capital = 10000,
+      total_realized_pnl = 0,
+      total_unrealized_pnl = 0,
+      total_fees_paid = 0,
+      peak_equity = 10000,
+      max_drawdown = 0,
+      total_trades = 0,
+      winning_trades = 0,
+      losing_trades = 0,
+      updated_at = NOW()
+    WHERE id = 1;
+  \""
+```
+
+**Step 4: Clear trading halt**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+    UPDATE trading_config SET value = 'false', updated_at = NOW()
+    WHERE key = 'trading_halted';
+  \""
+```
+
+**Step 5: Verify account is clean**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+    SELECT current_capital, available_capital, total_realized_pnl, max_drawdown, total_trades
+    FROM paper_account WHERE id = 1;
+  \""
+```
+
+Expected: `10000 | 10000 | 0 | 0 | 0`
+
+**Step 6: No commit needed** (DB-only changes)
+
+---
+
+### Task 7: Final Verification + Deploy
+
+**Step 1: Run full test suite**
+
+```bash
+cd packages/dashboard && npx vitest run
+```
+
+Expected: All tests pass
+
+**Step 2: Build to verify no TypeScript errors**
+
+```bash
+cd packages/dashboard && npx tsc --noEmit
+```
+
+Expected: No errors
+
+**Step 3: Create PR and deploy**
+
+Push the branch, create PR, deploy to VM via CI/CD after merge.
+
+```bash
+git push -u origin fix/issue20-critical-fixes
+gh pr create --title "fix: 6 critical bugs — upsert zombie, circuit breaker, 50/50 filter" \
+  --body-file docs/plans/2026-03-14-issue20-critical-fixes-design.md \
+  --label "daily-review"
+```
+
+**Step 4: After merge, deploy and verify on VM**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "cd /home/Usuario/polymarket-trader && git pull && docker compose -f docker-compose.gcp.yml pull && docker compose -f docker-compose.gcp.yml up -d --remove-orphans"
+```
+
+Verify:
+1. Containers healthy: `docker compose ps`
+2. Dashboard logs show 15% threshold: `docker compose logs dashboard-api | grep CircuitBreaker`
+3. No external_signals errors: `docker compose logs dashboard-api | grep -i "does not exist"`
+4. Account shows $10,000: run check-status.js

--- a/docs/plans/2026-03-16-cpu-fix-sync-optimization.md
+++ b/docs/plans/2026-03-16-cpu-fix-sync-optimization.md
@@ -1,0 +1,371 @@
+# Data-Collector Sync Optimization — CPU Fix
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix critical CPU usage (data-collector 400%, timescaledb 210%) caused by syncing all 52K+ Polymarket markets individually every 5 minutes.
+
+**Architecture:** Limit GammaCollector sync to top markets by volume (not the entire catalog), batch SQL upserts instead of individual INSERTs, remove redundant double-sync in upsertEvent(), and reduce sync frequency for market/event discovery.
+
+**Tech Stack:** TypeScript, PostgreSQL, node-cron
+
+---
+
+## Context
+
+The data-collector has two kinds of sync:
+1. **Market/event discovery** (`GammaCollector.syncMarketsToDb/syncEventsToDb`) — fetches from Gamma REST API, populates `markets`/`events` tables
+2. **Price tracking** (`ClobCollector.updateAllMarketPrices`) — updates prices for tracked markets via CLOB API
+
+Problem: #1 fetches ALL ~52K active markets (529 API pages) and upserts each individually (~108K SQL queries). On e2-micro (0.25 vCPU), this never completes. TimescaleDB autovacuum can't keep up → everything stalls.
+
+ClobCollector already has `MAX_TRACKED_MARKETS` limiting price sync. GammaCollector has no such limit.
+
+### Key Files
+
+| File | Key Methods | Lines |
+|------|-------------|-------|
+| `packages/data-collector/src/collectors/GammaCollector.ts` | `syncMarketsToDb()` (200-260), `syncEventsToDb()` (265-322), `upsertMarket()` (327-398), `upsertEvent()` (403-480) |
+| `packages/data-collector/src/services/Scheduler.ts` | `runInitialSync()` (196-222), cron defs (28-42), `syncMarkets()` (227-231), `syncEvents()` (236-240) |
+| `packages/data-collector/src/collectors/ClobCollector.ts` | `updateAllMarketPrices()` (639-722), `MAX_TRACKED_MARKETS` (line 13) |
+
+---
+
+## Task 1: Add MAX_SYNC_PAGES limit to GammaCollector
+
+Limit how many pages of markets/events we fetch from Gamma API. Top markets by volume come first, so 10 pages (1000 markets) is more than enough for the 50 we actually trade.
+
+**Files:**
+- Modify: `packages/data-collector/src/collectors/GammaCollector.ts:81-130` (fetchAllMarkets), `:135-178` (fetchAllEvents), `:200-260` (syncMarketsToDb), `:265-322` (syncEventsToDb)
+
+**Step 1: Add config constant**
+
+At the top of `GammaCollector.ts`, after existing imports/constants:
+
+```typescript
+const MAX_SYNC_PAGES = parseInt(process.env.MAX_SYNC_PAGES || '10', 10);
+```
+
+**Step 2: Add page limit to syncMarketsToDb()**
+
+In `syncMarketsToDb()` (line ~200), add a page counter to the while loop. The loop currently runs until no more results. Add:
+
+```typescript
+let pageCount = 0;
+// Inside the while loop, after processing a page:
+pageCount++;
+if (pageCount >= MAX_SYNC_PAGES) {
+  console.log(`[GammaCollector] Reached MAX_SYNC_PAGES (${MAX_SYNC_PAGES}), stopping market sync`);
+  break;
+}
+```
+
+**Step 3: Add page limit to syncEventsToDb()**
+
+Same pattern in `syncEventsToDb()` (line ~265):
+
+```typescript
+let pageCount = 0;
+// Inside the while loop:
+pageCount++;
+if (pageCount >= MAX_SYNC_PAGES) {
+  console.log(`[GammaCollector] Reached MAX_SYNC_PAGES (${MAX_SYNC_PAGES}), stopping event sync`);
+  break;
+}
+```
+
+**Step 4: Commit**
+
+```bash
+git add packages/data-collector/src/collectors/GammaCollector.ts
+git commit -m "fix: limit market/event sync to MAX_SYNC_PAGES (default 10)
+
+Syncing all 52K+ markets from Gamma API overwhelms the e2-micro VM.
+Limit to 10 pages (1000 markets) — more than enough for the 50 we trade."
+```
+
+---
+
+## Task 2: Batch upserts instead of individual INSERTs
+
+Currently each market is upserted individually (1 SQL query per market). Batch into multi-row VALUES to reduce DB round-trips from ~1000 to ~10.
+
+**Files:**
+- Modify: `packages/data-collector/src/collectors/GammaCollector.ts:200-260` (syncMarketsToDb), `:265-322` (syncEventsToDb)
+
+**Step 1: Create batchUpsertMarkets() method**
+
+Add after `upsertMarket()` method:
+
+```typescript
+async batchUpsertMarkets(markets: any[]): Promise<{ inserted: number; updated: number }> {
+  if (markets.length === 0) return { inserted: 0, updated: 0 };
+
+  let inserted = 0;
+  let updated = 0;
+
+  // Process in batches of 100
+  const BATCH_SIZE = 100;
+  for (let i = 0; i < markets.length; i += BATCH_SIZE) {
+    const batch = markets.slice(i, i + BATCH_SIZE);
+    const values: any[] = [];
+    const placeholders: string[] = [];
+
+    batch.forEach((market, idx) => {
+      const offset = idx * 18;
+      // Parse CLOB token IDs
+      let clobYes = market.clobTokenIds;
+      let clobNo: string | null = null;
+      if (typeof clobYes === 'string') {
+        try {
+          const parsed = JSON.parse(clobYes);
+          clobYes = parsed[0] || market.clobTokenIds;
+          clobNo = parsed[1] || null;
+        } catch { /* keep as-is */ }
+      }
+
+      // Parse outcome prices
+      let priceYes = market.outcomePrices ? null : (market.bestAsk || null);
+      let priceNo: number | null = null;
+      if (market.outcomePrices) {
+        try {
+          const prices = JSON.parse(market.outcomePrices);
+          priceYes = parseFloat(prices[0]) || null;
+          priceNo = parseFloat(prices[1]) || null;
+        } catch { /* keep nulls */ }
+      }
+
+      const category = this.inferCategoryFromQuestion
+        ? (this as any).constructor.inferCategoryFromQuestion?.(market.question)
+        : null;
+
+      values.push(
+        market.id, clobYes, clobNo, market.conditionId || null,
+        market.question, market.description || null,
+        category || market.category || null,
+        market.endDate || null,
+        priceYes, priceNo,
+        parseFloat(market.spread) || null,
+        parseFloat(market.volume24hr) || null,
+        parseFloat(market.liquidity) || null,
+        parseFloat(market.bestBid) || null,
+        parseFloat(market.bestAsk) || null,
+        parseFloat(market.lastTradePrice) || null,
+        market.active !== false,
+        market.resolved === true
+      );
+      placeholders.push(
+        `($${offset+1},$${offset+2},$${offset+3},$${offset+4},$${offset+5},$${offset+6},$${offset+7},$${offset+8},$${offset+9},$${offset+10},$${offset+11},$${offset+12},$${offset+13},$${offset+14},$${offset+15},$${offset+16},$${offset+17},$${offset+18})`
+      );
+    });
+
+    const result = await this.db.query(`
+      INSERT INTO markets (id, clob_token_id_yes, clob_token_id_no, condition_id,
+        question, description, category, end_date,
+        current_price_yes, current_price_no, spread, volume_24h, liquidity,
+        best_bid, best_ask, last_trade_price, is_active, is_resolved)
+      VALUES ${placeholders.join(',')}
+      ON CONFLICT (id) DO UPDATE SET
+        current_price_yes = EXCLUDED.current_price_yes,
+        current_price_no = EXCLUDED.current_price_no,
+        spread = EXCLUDED.spread,
+        volume_24h = EXCLUDED.volume_24h,
+        liquidity = EXCLUDED.liquidity,
+        best_bid = EXCLUDED.best_bid,
+        best_ask = EXCLUDED.best_ask,
+        last_trade_price = EXCLUDED.last_trade_price,
+        updated_at = NOW()
+    `, values);
+
+    // Approximate: can't distinguish insert vs update in multi-row, count total
+    updated += batch.length;
+  }
+
+  return { inserted, updated };
+}
+```
+
+**Step 2: Update syncMarketsToDb() to collect and batch**
+
+Replace the per-market upsert loop (lines 230-241) with:
+1. Collect all markets from the page into an array
+2. Call `batchUpsertMarkets()` for the whole page at once
+
+```typescript
+// Instead of: for (const market of markets) { await this.upsertMarket(market); }
+const result = await this.batchUpsertMarkets(markets);
+inserted += result.inserted;
+updated += result.updated;
+```
+
+**Step 3: Commit**
+
+```bash
+git add packages/data-collector/src/collectors/GammaCollector.ts
+git commit -m "perf: batch market upserts (100 per query instead of 1)
+
+Reduces DB round-trips from ~1000 to ~10 per sync cycle."
+```
+
+---
+
+## Task 3: Remove double-sync of markets inside upsertEvent()
+
+`upsertEvent()` (lines 443-456) loops through `event.markets` and calls `upsertMarket()` for each one, plus an additional `UPDATE markets SET event_id`. This duplicates the work of `syncMarketsToDb()`.
+
+**Files:**
+- Modify: `packages/data-collector/src/collectors/GammaCollector.ts:443-456`
+
+**Step 1: Replace nested market upserts with event_id-only update**
+
+Replace lines 443-456 with a single batch UPDATE that only sets event_id:
+
+```typescript
+// Instead of looping upsertMarket() + UPDATE for each market:
+if (event.markets && event.markets.length > 0) {
+  const marketIds = event.markets.map((m: any) => m.id).filter(Boolean);
+  if (marketIds.length > 0) {
+    await this.db.query(
+      `UPDATE markets SET event_id = $1 WHERE id = ANY($2::varchar[])`,
+      [event.id, marketIds]
+    );
+  }
+}
+```
+
+**Step 2: Commit**
+
+```bash
+git add packages/data-collector/src/collectors/GammaCollector.ts
+git commit -m "fix: remove double-sync of markets in upsertEvent()
+
+upsertEvent() was calling upsertMarket() for each event's markets,
+duplicating the work of syncMarketsToDb(). Now only sets event_id."
+```
+
+---
+
+## Task 4: Reduce sync frequency for market/event discovery
+
+Market discovery doesn't need to run every 5/10 minutes. New markets appear slowly. Hourly is plenty.
+
+**Files:**
+- Modify: `packages/data-collector/src/services/Scheduler.ts:32-33`
+
+**Step 1: Change cron schedules**
+
+```typescript
+// Line 32: sync-markets from */5 to hourly
+'sync-markets': '17 * * * *',      // Every hour at :17
+// Line 33: sync-events from */10 to every 2 hours
+'sync-events': '47 */2 * * *',     // Every 2 hours at :47
+```
+
+Use offset minutes (17, 47) to avoid stacking with other jobs that run at :00/:05.
+
+**Step 2: Commit**
+
+```bash
+git add packages/data-collector/src/services/Scheduler.ts
+git commit -m "perf: reduce market/event sync frequency to hourly/2h
+
+Market discovery doesn't need 5-minute frequency. New markets appear
+slowly. Reduces sustained DB load on e2-micro."
+```
+
+---
+
+## Task 5: Add timeout to runInitialSync()
+
+Currently `runInitialSync()` (line 196) runs all sync jobs sequentially on startup with no timeout. If market sync takes 1h+, the whole system is blocked.
+
+**Files:**
+- Modify: `packages/data-collector/src/services/Scheduler.ts:196-222`
+
+**Step 1: Add per-job timeout wrapper**
+
+```typescript
+private async withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T | null> {
+  const timeout = new Promise<null>((resolve) => {
+    setTimeout(() => {
+      console.warn(`[Scheduler] ${label} timed out after ${ms / 1000}s`);
+      resolve(null);
+    }, ms);
+  });
+  return Promise.race([promise, timeout]);
+}
+```
+
+**Step 2: Wrap each initial sync call**
+
+```typescript
+// In runInitialSync(), wrap each call:
+await this.withTimeout(this.syncEvents(), 120_000, 'Initial sync-events');
+await this.withTimeout(this.syncMarkets(), 120_000, 'Initial sync-markets');
+await this.withTimeout(this.syncPrices(), 60_000, 'Initial sync-prices');
+// ... etc
+```
+
+**Step 3: Commit**
+
+```bash
+git add packages/data-collector/src/services/Scheduler.ts
+git commit -m "fix: add 2-minute timeout to initial sync jobs
+
+Prevents startup from blocking for hours if Gamma API is slow or
+returning too many results."
+```
+
+---
+
+## Task 6: Deploy and verify
+
+**Step 1: Push to main**
+
+```bash
+git push origin main
+```
+
+**Step 2: Wait for CI/CD deploy**
+
+```bash
+gh run list --limit 3 --json name,status,conclusion
+```
+
+**Step 3: Verify CPU dropped on VM**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- 'docker stats --no-stream'
+```
+
+Expected: data-collector <50% CPU, timescaledb <100% CPU.
+
+**Step 4: Verify signals are flowing**
+
+```bash
+curl -s http://34.148.24.147:3001/api/automation/status | jq '.data.executor.dailyTrades'
+```
+
+---
+
+## Task 7: Merge PR #29 and close PR #28
+
+PR #29 is a superset of #28 (includes backtest exports fix + capital invariant fix). Both are verified correct.
+
+**Step 1: Merge PR #29**
+
+```bash
+gh pr merge 29 --squash
+```
+
+**Step 2: Close PR #28 as superseded**
+
+```bash
+gh pr close 28 --comment "Superseded by #29 which includes this fix plus the capital invariant correction."
+```
+
+**Step 3: Close stale PRs from yesterday if already fixed**
+
+```bash
+# PR #25 (BacktestService vectorization) — we already fixed this differently in main
+gh pr close 25 --comment "Fixed in main via SET LOCAL timescaledb.enable_vectorized_aggregation = off (commit 76d7526)"
+```

--- a/docs/plans/2026-03-16-system-health-timeline.md
+++ b/docs/plans/2026-03-16-system-health-timeline.md
@@ -1,0 +1,104 @@
+# System Health Timeline Analysis (March 10-16, 2026)
+
+## CPU History — Every Daily Review
+
+| Date | Issue | data-collector | timescaledb | dashboard-api | Trigger |
+|------|-------|---------------|-------------|---------------|---------|
+| Mar 10 | #5 | — | — | **UNHEALTHY 16h** | Dashboard down, no metrics collected |
+| Mar 12 (AM) | #9 | **98.58%** | — | — | sync-markets running full 52K catalog |
+| Mar 12 (PM) | #12 | 48.70% | **128.93%** | 0.04% (32min up) | Dashboard just restarted |
+| Mar 12 (PM) | #14 | — | — | — | No CPU data in report |
+| Mar 13 | #17 | **121%** | **482%** | — | sync-markets + autovacuum on bloated markets table |
+| Mar 14 | #20 | — | **711%** | — | Peak: autovacuum + compression + sync + backtest retries |
+| Mar 15 | #24 | — | **150.65%** | — | Lower after issue #8 fix (removed is_active re-activation) |
+| Mar 16 | #27 | **400.95%** | **209.98%** | 0.01% | Post-deploy runInitialSync() re-triggered full sync |
+| **Mar 16 (post-fix)** | — | **1.19%** | **0.04%** | 0.01% | After MAX_SYNC_PAGES + batch upserts + hourly frequency |
+
+### Root Cause: ONE bug, recurring across ALL reviews
+
+`syncMarketsToDb()` fetched ALL ~52,878 active markets from Gamma API (529 pages x 100/page) and upserted each individually every 5 minutes. On the e2-micro (0.25 vCPU):
+
+- **108K individual INSERT queries** per sync cycle
+- Sync **never completed** before the next cycle started
+- `markets` table bloated to **512MB** (189K rows) with dead tuples
+- TimescaleDB autovacuum ran constantly, consuming 200-700% CPU
+- All other queries (signals, backtest, prices) starved for resources
+
+**Why it varied in severity:**
+- Mar 12: Issue #8 fix stopped re-activating 118K zombie markets, reducing churn slightly
+- Mar 14: TimescaleDB compression job + autovacuum + sync = 711% peak
+- Mar 15: Lower because some zombie markets had been pruned
+- Mar 16: Deploy restart triggered `runInitialSync()` (fresh full sync with no timeout)
+
+**Fix applied today:** MAX_SYNC_PAGES=10 (1000 markets vs 52K), batch upserts (100/query), hourly frequency, 2-min startup timeout.
+
+---
+
+## Optimizer Failure History
+
+| Date | Issue | Error | Root Cause |
+|------|-------|-------|------------|
+| Mar 10 | #5 | 404: "Optimizer not found" (trials 10-15) | Render server restarted mid-run -> study session lost. `_running_trials` dict empty after restart. |
+| Mar 13 | #17 | 20+ 503 errors from Optuna server | Render free tier: cold start or overloaded. Server couldn't respond in time. |
+| Mar 15 | #24 | BacktestService VARCHAR vectorization | TimescaleDB can't GROUP BY VARCHAR on compressed chunks. Every trial's backtest failed silently. |
+| Mar 16 | — | Working (score 0.037->0.077) | All three fixes deployed |
+
+### Pattern: Three independent failure modes
+
+1. **Render server restart** (Mar 10, ongoing) -> `_running_trials` in-memory dict lost between `suggest()` and `report()`. **Fixed:** recovery via `study.tell(trial_id, score)` directly.
+
+2. **Render cold start / 503** (Mar 13) -> Free tier spins down after 15min idle, cold start can exceed timeout. **Fixed:** consecutive-failure abort (3 in a row -> stop wasting time, fall back to grid search).
+
+3. **BacktestService query failure** (Mar 15) -> VARCHAR in GROUP BY on compressed hypertable. **Fixed:** `SET LOCAL timescaledb.enable_vectorized_aggregation = off` inside transaction.
+
+**Correlation with system events:** Optimizer runs every 6 hours. Failures did NOT correlate with code deploys — they happened at scheduled times. The Render restart failures DID correlate with our pushes to main (Render auto-deploys on every commit, killing in-flight optimization runs).
+
+---
+
+## Signal Generation History
+
+| Date | Issue | Signals/hour | Cause |
+|------|-------|-------------|-------|
+| Mar 10 | #5 | 0 | dashboard-api UNHEALTHY for 16 hours |
+| Mar 12 (AM) | #9 | 0 | Signal gen stopped (dashboard restart lost state) |
+| Mar 12 (PM) | #12 | 2 | Recovering after restart |
+| Mar 13 | #17 | 0 | TimescaleDB 482% CPU -> queries timeout -> SignalEngine finds 0 markets |
+| Mar 14 | #20 | 0 | TimescaleDB 711% -> same as above + markets filtered (50/50) |
+| Mar 15 | #24 | 0 | DB overload + all markets near 50/50 price |
+| Mar 16 | #27 | 0 | Post-restart, containers only 19min old, not yet generated |
+
+**Pattern:** Signal stall is almost always a **consequence** of CPU/DB overload, not an independent bug. When TimescaleDB is at 200-700% CPU, the SignalEngine's market discovery query times out or returns 0 results. With today's CPU fix, signals should flow normally.
+
+---
+
+## Deploy -> Restart -> CPU Spike Pattern
+
+Every `git push` triggers CI/CD -> Docker image pull -> container restart -> `runInitialSync()` -> full market sync. This was the "periodic" pattern:
+
+```
+push to main
+  -> Deploy to GCP (2-3 min)
+    -> dashboard-api restarts
+    -> data-collector restarts
+      -> runInitialSync() starts
+        -> syncEvents() fetches 55K events (never finishes before timeout)
+        -> syncMarkets() fetches 52K markets (never finishes)
+        -> CPU spikes to 200-400%
+          -> TimescaleDB autovacuum adds another 200-400%
+            -> all queries slow -> signals stall -> optimizer fails
+```
+
+**Today's fix breaks this chain at step 5:** sync is now limited to 10 pages (1000 markets) with 2-min timeout per initial sync job.
+
+---
+
+## Summary
+
+| Problem | Recurring Since | Root Cause | Fix | Status |
+|---------|----------------|------------|-----|--------|
+| CPU critical | Mar 10 | syncMarketsToDb() fetches ALL 52K markets | MAX_SYNC_PAGES=10, batch upserts, hourly | Fixed |
+| Optimizer 404 | Mar 10 | Render restart loses _running_trials | Recovery via study.tell(id, score) | Fixed |
+| Optimizer 503 | Mar 13 | Render cold start timeout | 3-consecutive-failure abort | Fixed |
+| Optimizer backtest | Mar 15 | VARCHAR vectorization bug | SET LOCAL disable | Fixed |
+| Signal stall | Mar 10 | Consequence of CPU/DB overload | CPU fix resolves this | Fixed |
+| Flash positions | Mar 12 | CB fires on every BUY, no min hold | Min hold 5min, skip BUY events, pre-open check | Fixed |

--- a/docs/plans/2026-03-18-market-intelligence-system-design.md
+++ b/docs/plans/2026-03-18-market-intelligence-system-design.md
@@ -1,0 +1,377 @@
+# Market Intelligence System (MIS) — Design Document
+
+**Date**: 2026-03-18
+**Status**: Design approved, pending implementation
+**Problem**: Zero signals for 2+ days — data-collector tracks markets by volume only, all 40 slots filled with extreme/50-50 markets
+
+## Root Cause Analysis
+
+### Evidence (collected 2026-03-18 via SSH)
+
+```sql
+-- Market price distribution (all active, unresolved, with token_id)
+        price_range         | count
+----------------------------+-------
+ fifty_fifty (0.45-0.55)    | 22716
+ extreme_low (<0.05)        | 12903
+ tradeable_low (0.05-0.45)  | 10684
+ extreme_high (>0.95)       |  3881
+ tradeable_high (0.55-0.95) |  3452
+ no_price                   |    56
+
+-- Filter funnel
+ total_active | pass_extreme | pass_5050 | pass_volume
+--------------+--------------+-----------+-------------
+        53692 |        36852 |     14136 |        1840
+
+-- Dashboard logs
+[PolymarketService] Found 7 markets with recent price data (filtered by price_history)
+[SignalEngine] Filtered markets: 0 inactive, 0 resolved, 0 extreme prices, 7 near-50/50
+[SignalEngine] Updated active markets: 0
+```
+
+### Diagnosis
+
+1. Data-collector selects top 40 markets by `volume_24h DESC` — no price range filter
+2. High-volume Polymarket markets are dominated by resolved events (extreme prices) and stagnant political markets (50/50)
+3. All 7 markets with recent price_history fall in filtered ranges
+4. SignalEngine requires `EXISTS (price_history last 24h)` → only sees those 7
+5. All 7 filtered out → 0 active markets → 0 signals → 0 trades
+
+**1,840 markets** in the DB pass all filters but have no price data collected.
+
+---
+
+## Solution: Market Intelligence System
+
+Three phases, each building on the previous.
+
+### Phase 1: Smart Scoring + Dynamic Rotation
+
+Unblocks trading immediately by selecting tradeable markets.
+
+### Phase 2: Feedback Loop
+
+Learns which market categories are profitable and adjusts scoring.
+
+### Phase 2.5: Parameter Optimization
+
+Connects optimizable parameters to Optuna for automated tuning.
+
+### Phase 3: Review System Fix
+
+Ensures the daily auto-review investigates rather than speculates.
+
+---
+
+## Phase 1: MarketScorer
+
+### Composite Score
+
+Each market receives a score (0-1) computed by a single SQL query, executed once per hour inside the existing `sync-markets` job.
+
+**5 dimensions:**
+
+| Dimension | Weight | Measures | Computation |
+|-----------|--------|----------|-------------|
+| Tradeability | 0.30 | Is the price in a profitable range? | Distance to optimal ranges [0.15-0.40] ∪ [0.60-0.85]. Max score in those ranges, decays toward extremes and 50/50 |
+| Liquidity | 0.25 | Can we enter/exit without slippage? | `log(volume_24h)` normalized. Penalty if spread > 3% |
+| Volatility | 0.20 | Is there price movement for signals? | Stddev of price over last 24h from price_history. Penalizes both 0 (dead market) and >0.15 (likely resolving) |
+| Time-to-Resolution | 0.15 | Is there useful life remaining? | Based on `end_date_iso`. Optimal: 7-60 days. Penalizes <24h and >180 days |
+| Data Quality | 0.10 | Do we have real data? | Ratio of informative bars (source='api' or price changed) vs flat snapshots |
+
+**All weights are initial defaults — will be connected to Optuna in Phase 2.5.**
+
+### Tradeability Curve
+
+```
+Score
+1.0 |          ┌────────┐          ┌────────┐
+    |         /          \        /          \
+0.5 |        /            \      /            \
+    |       /              \    /              \
+0.0 |──────/                \──/                \──────
+    0.0  0.05  0.15   0.40 0.45 0.55 0.60   0.85 0.95 1.0
+         │     └─ optimal ─┘│    │└─ optimal ─┘     │
+         extreme            50/50               extreme
+```
+
+### Storage
+
+- New column: `market_score FLOAT DEFAULT 0` on `markets` table
+- No new tables, no extra memory
+- Query execution: ~50ms (indexed on is_active, is_resolved)
+
+---
+
+## Phase 1: MarketRotator
+
+### Market Tracking States
+
+```
+                    score rises
+    ┌──────────┐   ──────────>   ┌──────────┐   accumulates   ┌──────────┐
+    │   COLD   │                 │ WARMING  │   3+ real bars  │  ACTIVE  │
+    │ (no data)│                 │ (collects│   ──────────>   │(generates│
+    └──────────┘                 │  data)   │                 │ signals) │
+                                 └──────────┘                 └──────────┘
+                                      │                            │
+                                      │ score drops                │ score drops
+                                      ▼                            ▼
+                                 ┌──────────┐                 ┌──────────┐
+                                 │ DROPPED  │   if position   │ COOLING  │
+                                 │(exits now│   open          │(keeps    │
+                                 └──────────┘   ──────────>   │data 1h)  │
+                                                              └──────────┘
+```
+
+### Rotation Rules
+
+| Rule | Description |
+|------|-------------|
+| **Entry** | Top N markets by `market_score` not currently tracked enter as WARMING |
+| **Promotion** | WARMING → ACTIVE when they accumulate >=3 real bars in price_history |
+| **Re-eval on promotion** | Score rechecked before promoting. If score dropped below threshold, drop instead |
+| **Protection** | Markets with open positions NEVER dropped — move to COOLING |
+| **Cooling** | COOLING maintains data collection for 1 more hour for clean position exits |
+| **Cooling timeout** | After 6h in COOLING, notify StopLossService but keep tracking |
+| **Hysteresis** | ACTIVE market only exits if score < 60% of worst waiting candidate's score. Prevents flip-flop |
+| **Budget** | Max 5 rotations per hour under normal conditions |
+| **Emergency fill** | If ACTIVE count < 20, disable rotation limit and fill aggressively from WARMING |
+
+### Slot Distribution (40 total)
+
+| Type | Slots | Purpose |
+|------|-------|---------|
+| ACTIVE | 25-35 | Generate signals |
+| WARMING | 3-8 | Entry pipeline |
+| COOLING | 0-5 | Graceful exit |
+| Reserve | 2 | High-score opportunities |
+
+### Storage
+
+- New column: `tracking_status VARCHAR(10) DEFAULT 'cold'` on `markets` table
+  - Values: 'cold', 'warming', 'active', 'cooling'
+- Lives inside existing `sync-markets` job — score first, then rotate
+
+---
+
+## Phase 1: Edge Cases
+
+| Edge Case | Solution |
+|-----------|----------|
+| **Resolution avalanche** (15+ ACTIVE resolve at once) | Emergency fill: if ACTIVE < 20, bypass 5/hour limit |
+| **Price drift during WARMING** | Re-evaluate score at promotion time. Drop if below threshold |
+| **Flash crash/pump** | SignalEngine already filters extreme prices every 60s. Rotator doesn't need to be reactive |
+| **No tradeable markets anywhere** | Accept 0 signals as legitimate. Log "No tradeable markets available (best score: X)" for review system to distinguish from bugs |
+| **COOLING position never closes** | 6h timeout. After that, alert StopLossService but maintain tracking |
+
+---
+
+## Phase 2: Feedback Loop
+
+### Architecture
+
+```
+Closed trades ──> MarketPerformanceTracker ──> category_performance table
+                          │
+                          │ every 24h
+                          ▼
+                    Performance Priors ──> MarketScorer
+                          │                (score × prior)
+                          │
+                    Bootstrap:
+                    clean pre-reset trades
+                    + manual priors
+```
+
+### Category-Level Tracking
+
+Uses existing MarketClassifier. Evaluates categories, not individual markets (too short-lived).
+
+| Category | Example | Initial Prior |
+|----------|---------|---------------|
+| crypto_intraday | BTC > $90k today | 1.0 |
+| crypto_daily | ETH > $4k this week | 1.0 |
+| event_short | Arsenal win tomorrow | 1.0 |
+| event_long | Netanyahu out by March | 1.0 |
+| sports | (new subcategory) | 1.0 |
+| politics | (new subcategory) | 1.0 |
+
+### Metrics per Category
+
+Computed from `paper_trades` + `paper_positions`:
+
+| Metric | Formula |
+|--------|---------|
+| Win rate | winning trades / total trades |
+| Avg PnL | mean(realized_pnl) |
+| Signal accuracy | signals that predicted correct direction / total signals |
+| Sharpe ratio | avg_pnl / stddev_pnl |
+
+### Performance Prior
+
+```
+prior = 0.5 + 0.5 × sigmoid(sharpe_ratio × 2)
+```
+
+- Very negative Sharpe → prior ≈ 0.5 (penalizes but doesn't kill)
+- Neutral Sharpe → prior ≈ 1.0 (no effect)
+- Positive Sharpe → prior ≈ 1.5 (boost)
+
+**Bounded to [0.5, 1.5]** — feedback adjusts ±50% of base score, never dominates.
+
+**All parameters (bounds, sigmoid factor) are initial defaults — will be connected to Optuna in Phase 2.5.**
+
+### Clean Data Bootstrap
+
+For pre-reset trades:
+```sql
+SELECT t.* FROM paper_trades t
+JOIN paper_positions p ON t.position_id = p.id
+WHERE p.closed_at IS NOT NULL    -- complete lifecycle
+  AND p.size = 0                 -- not zombie
+  AND t.side IN ('buy','sell')   -- both sides exist
+  AND p.realized_pnl IS NOT NULL -- PnL recorded
+```
+
+Categories with <5 clean trades fall back to manual priors.
+
+### Storage
+
+- New table: `category_performance` (~6 rows, updated daily)
+- Query on existing trade data, no new collection needed
+- Prior cached in memory in MarketScorer — zero per-market overhead
+
+---
+
+## Phase 2.5: Parameter Optimization
+
+### Optimizable Parameters (connect to Optuna)
+
+| Parameter | Current Value | Optimize Against |
+|-----------|--------------|-----------------|
+| Scorer dimension weights | tradeability=0.30, liquidity=0.25, volatility=0.20, ttr=0.15, quality=0.10 | Rate of profitable signals generated |
+| Tradeability curve shape | Optimal [0.15-0.40] ∪ [0.60-0.85] | Win rate by price range |
+| Volatility penalty threshold | 0 and >0.15 | Signal accuracy by volatility level |
+| Optimal TTR range | 7-60 days | PnL by time-to-resolution |
+| Rotator hysteresis | 60% of worst candidate | Pool stability vs market quality |
+| Feedback prior bounds | [0.5, 1.5] and sigmoid ×2 | Portfolio Sharpe ratio |
+| Combiner thresholds | confidence=0.43, strength=0.27 | Already partially in Optuna |
+| Bayesian cap floor | 0.15 | Trade quality vs quantity |
+
+### Structural Parameters (NOT optimized — safety/operational)
+
+| Parameter | Value | Reason |
+|-----------|-------|--------|
+| MAX_TRACKED_MARKETS | 40 | e2-micro RAM constraint |
+| Max rotations/hour | 5 | Stability, prevents flip-flop |
+| COOLING timeout | 6h | Safety margin for position closing |
+| Min bars for promotion | 3 | SignalEngine hard requirement |
+| Emergency fill threshold | ACTIVE < 20 | Operational safety |
+| WARMING slots | 3-8 | Always need entry pipeline |
+| Reserve slots | 2 | Buffer for sudden opportunities |
+| Min trades for significance | 5 | Statistical minimum |
+| Feedback update frequency | 24h | Data accumulation constraint |
+
+### Implementation
+
+Add scorer/rotator parameters as hyperparameters in the existing Optuna study on Render. The optimizer already runs trials against the DB — extending it to include market selection parameters is a natural fit.
+
+---
+
+## Phase 3: Review System Fix
+
+### Problem
+
+The daily auto-review (scripts/daily-review-prompt.md) uses speculative language ("likely excluding", "may be", "appears to be") instead of investigating. Two days of 0 signals were classified as "expected behavior" without evidence.
+
+### Fix 1: Remove the "easy out"
+
+**Current** (Alert Guidance section):
+```
+0 signals generated → Info if markets correctly filtered (50/50 range, price-range modifier)
+Markets filtered by 50/50 → Expected behavior — not an alert
+```
+
+**New**:
+```
+0 signals generated → MUST investigate before classifying severity.
+  Required: Run SQL to check actual price distribution of tracked markets.
+  If ALL markets genuinely in 50/50 or extreme range → Info, but report the
+  distribution and flag that MarketRotator should have prevented this.
+  If markets exist in tradeable range but signals still 0 → Critical.
+  NEVER write "likely" or "probably" — show the query and the numbers.
+```
+
+### Fix 2: Evidence-first investigation rule
+
+**New section in prompt**:
+
+```
+INVESTIGATION RULE: Every anomaly (metric out of range, zero where >0 expected,
+discrepancy in numbers) requires at least ONE SQL query or log check before
+classifying severity. Report the query result as evidence. Without evidence,
+severity is "Unknown — requires manual investigation" with a specific next step.
+
+Examples of adequate investigation:
+- 0 signals → check price distribution of tracked markets
+- Capital discrepancy → check SUM of closed position PnLs vs account field
+- High trade count → check for duplicate trades in same market/minute
+- Container restarts → check OOM kill logs
+These are examples, not an exhaustive list. Apply the same rigor to any anomaly.
+```
+
+### Fix 3: Language rule
+
+**New rule in prompt**:
+```
+LANGUAGE RULE: Never use "likely", "probably", "may be", "suggests that",
+"appears to be" when describing root causes. Either:
+1. You investigated and know the cause → state it with evidence
+2. You couldn't investigate → say "Unknown — requires manual investigation"
+   with a specific next step the human can take
+Speculation disguised as analysis is worse than admitting ignorance.
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1 (Immediate — unblocks trading)
+
+1. Add `market_score` and `tracking_status` columns to markets table
+2. Implement `MarketScorer` class in data-collector with SQL scoring query
+3. Implement `MarketRotator` class in data-collector with state machine
+4. Wire into existing `sync-markets` scheduler job
+5. Update `ClobCollector` queries to use `tracking_status IN ('warming','active','cooling')` instead of raw `LIMIT 40`
+6. Deploy, verify markets rotate into tradeable ranges
+
+### Phase 2 (After Phase 1 generates trades)
+
+7. Create `category_performance` table
+8. Implement `MarketPerformanceTracker` in dashboard
+9. Bootstrap with clean pre-reset trade data
+10. Wire performance prior into MarketScorer
+11. Add daily update job
+
+### Phase 2.5 (After Phase 2 accumulates data)
+
+12. Add scorer parameters to Optuna study definition
+13. Extend optimization trials to include market selection quality
+14. Monitor and validate optimized parameters
+
+### Phase 3 (Parallel with Phase 1)
+
+15. Update `scripts/daily-review-prompt.md` with the three fixes
+16. Monitor next 3-5 daily reviews for compliance
+17. Iterate on prompt if model still takes shortcuts
+
+---
+
+## Constraints
+
+- **Memory**: All computations via SQL queries + small in-memory caches. No new services.
+- **CPU**: Scoring runs 1x/hour (~50ms). Rotation runs 1x/hour (~10ms). Negligible.
+- **Storage**: 2 new columns on existing table + 1 small table (~6 rows). Negligible.
+- **Compatibility**: SignalEngine, AutoSignalExecutor, PositionClosingService unchanged. Only data-collector market selection changes.

--- a/docs/plans/2026-03-18-market-intelligence-system-plan.md
+++ b/docs/plans/2026-03-18-market-intelligence-system-plan.md
@@ -1,0 +1,1326 @@
+# Market Intelligence System — Phase 1 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace volume-only market selection with smart scoring + dynamic rotation so the system tracks tradeable markets and generates signals.
+
+**Architecture:** MarketScorer computes a composite score (tradeability, liquidity, TTR) via SQL for all markets, plus volatility and data quality for tracked markets. MarketRotator manages state transitions (cold→warming→active→cooling) with hysteresis and position protection. Both run inside the existing `sync-markets` hourly job. ClobCollector queries switch from `ORDER BY volume_24h LIMIT 40` to `WHERE tracking_status IN ('warming','active','cooling')`.
+
+**Tech Stack:** TypeScript, PostgreSQL (TimescaleDB), vitest, node-cron (existing)
+
+**Design Doc:** `docs/plans/2026-03-18-market-intelligence-system-design.md`
+
+---
+
+## Task 1: Database Schema Migration
+
+**Files:**
+- Create: `packages/data-collector/src/database/init/005_market_intelligence.sql`
+
+**Step 1: Write the migration SQL**
+
+```sql
+-- Market Intelligence System: scoring and tracking status
+ALTER TABLE markets ADD COLUMN IF NOT EXISTS market_score FLOAT DEFAULT 0;
+ALTER TABLE markets ADD COLUMN IF NOT EXISTS tracking_status VARCHAR(10) DEFAULT 'cold';
+ALTER TABLE markets ADD COLUMN IF NOT EXISTS tracking_status_changed_at TIMESTAMPTZ DEFAULT NOW();
+
+-- Index for ClobCollector queries that filter by tracking_status
+CREATE INDEX IF NOT EXISTS idx_markets_tracking_status ON markets (tracking_status) WHERE tracking_status IN ('warming', 'active', 'cooling');
+
+-- Index for MarketScorer candidate selection
+CREATE INDEX IF NOT EXISTS idx_markets_score ON markets (market_score DESC) WHERE is_active = true AND is_resolved = false;
+
+-- Warm start: markets with recent price_history get 'active' status
+-- (Run once on deployment, then MarketRotator manages state)
+UPDATE markets SET tracking_status = 'active', tracking_status_changed_at = NOW()
+WHERE is_active = true
+  AND is_resolved = false
+  AND clob_token_id_yes IS NOT NULL
+  AND id IN (
+    SELECT DISTINCT m.id FROM markets m
+    JOIN price_history ph ON ph.token_id = m.clob_token_id_yes
+    WHERE ph.time > NOW() - INTERVAL '24 hours'
+  );
+```
+
+**Step 2: Register migration in the init sequence**
+
+Modify: `packages/data-collector/src/database/connection.ts` — the migrations are run via `src/database/migrate.ts` but schema files in `init/` are applied on first startup. Verify the file naming convention (005_ follows 004_).
+
+**Step 3: Test migration locally**
+
+Run:
+```bash
+cd packages/data-collector && pnpm build
+```
+Expected: Compiles without errors. Migration file is just SQL, no TS compilation needed.
+
+**Step 4: Commit**
+
+```bash
+git add packages/data-collector/src/database/init/005_market_intelligence.sql
+git commit -m "feat: add market_score and tracking_status columns to markets table"
+```
+
+---
+
+## Task 2: MarketScorer — Tests
+
+**Files:**
+- Create: `packages/data-collector/src/services/MarketScorer.test.ts`
+
+**Step 1: Write failing tests for score computation**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { MarketScorer } from './MarketScorer';
+
+describe('MarketScorer', () => {
+  describe('computeTradeabilityScore', () => {
+    it('returns 0 for null price', () => {
+      expect(MarketScorer.tradeabilityScore(null)).toBe(0);
+    });
+
+    it('returns 0 for extreme low price (<0.05)', () => {
+      expect(MarketScorer.tradeabilityScore(0.02)).toBe(0);
+      expect(MarketScorer.tradeabilityScore(0.04)).toBe(0);
+    });
+
+    it('returns 0 for extreme high price (>0.95)', () => {
+      expect(MarketScorer.tradeabilityScore(0.97)).toBe(0);
+      expect(MarketScorer.tradeabilityScore(0.99)).toBe(0);
+    });
+
+    it('returns 0 for 50/50 range (0.45-0.55)', () => {
+      expect(MarketScorer.tradeabilityScore(0.50)).toBe(0);
+      expect(MarketScorer.tradeabilityScore(0.45)).toBe(0);
+      expect(MarketScorer.tradeabilityScore(0.55)).toBe(0);
+    });
+
+    it('returns 1.0 for optimal low range (0.15-0.40)', () => {
+      expect(MarketScorer.tradeabilityScore(0.15)).toBe(1.0);
+      expect(MarketScorer.tradeabilityScore(0.25)).toBe(1.0);
+      expect(MarketScorer.tradeabilityScore(0.40)).toBe(1.0);
+    });
+
+    it('returns 1.0 for optimal high range (0.60-0.85)', () => {
+      expect(MarketScorer.tradeabilityScore(0.60)).toBe(1.0);
+      expect(MarketScorer.tradeabilityScore(0.75)).toBe(1.0);
+      expect(MarketScorer.tradeabilityScore(0.85)).toBe(1.0);
+    });
+
+    it('ramps linearly from extreme to optimal (0.05-0.15)', () => {
+      const score = MarketScorer.tradeabilityScore(0.10);
+      expect(score).toBeCloseTo(0.5, 1); // midpoint of ramp
+    });
+
+    it('ramps linearly from optimal to 50/50 (0.40-0.45)', () => {
+      const score = MarketScorer.tradeabilityScore(0.42);
+      expect(score).toBeCloseTo(0.6, 1); // 60% of ramp
+    });
+
+    it('ramps linearly from 50/50 to optimal (0.55-0.60)', () => {
+      const score = MarketScorer.tradeabilityScore(0.58);
+      expect(score).toBeCloseTo(0.6, 1);
+    });
+
+    it('ramps linearly from optimal to extreme (0.85-0.95)', () => {
+      const score = MarketScorer.tradeabilityScore(0.90);
+      expect(score).toBeCloseTo(0.5, 1);
+    });
+
+    it('is symmetric around 0.50', () => {
+      expect(MarketScorer.tradeabilityScore(0.30))
+        .toBeCloseTo(MarketScorer.tradeabilityScore(0.70), 5);
+      expect(MarketScorer.tradeabilityScore(0.10))
+        .toBeCloseTo(MarketScorer.tradeabilityScore(0.90), 5);
+    });
+  });
+
+  describe('computeLiquidityScore', () => {
+    it('returns 0 for null or zero volume', () => {
+      expect(MarketScorer.liquidityScore(null, null)).toBe(0);
+      expect(MarketScorer.liquidityScore(0, null)).toBe(0);
+    });
+
+    it('returns higher score for higher volume', () => {
+      const low = MarketScorer.liquidityScore(1000, null);
+      const high = MarketScorer.liquidityScore(1000000, null);
+      expect(high).toBeGreaterThan(low);
+    });
+
+    it('applies 50% penalty for wide spread (>0.03)', () => {
+      const normal = MarketScorer.liquidityScore(100000, 0.01);
+      const wide = MarketScorer.liquidityScore(100000, 0.05);
+      expect(wide).toBeCloseTo(normal * 0.5, 1);
+    });
+
+    it('caps at 1.0', () => {
+      expect(MarketScorer.liquidityScore(999999999, null)).toBeLessThanOrEqual(1.0);
+    });
+  });
+
+  describe('computeTTRScore', () => {
+    it('returns 0.5 for null end_date (unknown)', () => {
+      expect(MarketScorer.ttrScore(null)).toBe(0.5);
+    });
+
+    it('returns 0.1 for resolution < 24h away', () => {
+      const soon = new Date(Date.now() + 12 * 3600 * 1000); // 12h from now
+      expect(MarketScorer.ttrScore(soon)).toBeCloseTo(0.1, 1);
+    });
+
+    it('returns 1.0 for 7-60 day window', () => {
+      const optimal = new Date(Date.now() + 30 * 24 * 3600 * 1000); // 30 days
+      expect(MarketScorer.ttrScore(optimal)).toBe(1.0);
+    });
+
+    it('ramps between 24h and 7 days', () => {
+      const midway = new Date(Date.now() + 4 * 24 * 3600 * 1000); // 4 days
+      const score = MarketScorer.ttrScore(midway);
+      expect(score).toBeGreaterThan(0.1);
+      expect(score).toBeLessThan(1.0);
+    });
+
+    it('decays for >60 days but stays >= 0.5', () => {
+      const far = new Date(Date.now() + 120 * 24 * 3600 * 1000); // 120 days
+      const score = MarketScorer.ttrScore(far);
+      expect(score).toBeGreaterThanOrEqual(0.5);
+      expect(score).toBeLessThan(1.0);
+    });
+
+    it('returns 0.5 for very far out (>180 days)', () => {
+      const veryFar = new Date(Date.now() + 365 * 24 * 3600 * 1000);
+      expect(MarketScorer.ttrScore(veryFar)).toBe(0.5);
+    });
+  });
+
+  describe('computeVolatilityScore', () => {
+    it('returns 0 for zero volatility (dead market)', () => {
+      expect(MarketScorer.volatilityScore(0)).toBe(0);
+    });
+
+    it('returns 0 for null volatility', () => {
+      expect(MarketScorer.volatilityScore(null)).toBe(0);
+    });
+
+    it('returns high score for moderate volatility', () => {
+      const score = MarketScorer.volatilityScore(0.05);
+      expect(score).toBeGreaterThan(0.7);
+    });
+
+    it('penalizes extreme volatility (>0.15)', () => {
+      const moderate = MarketScorer.volatilityScore(0.05);
+      const extreme = MarketScorer.volatilityScore(0.20);
+      expect(extreme).toBeLessThan(moderate);
+    });
+
+    it('caps at 1.0', () => {
+      expect(MarketScorer.volatilityScore(0.08)).toBeLessThanOrEqual(1.0);
+    });
+  });
+
+  describe('computeDataQualityScore', () => {
+    it('returns 0 for no bars', () => {
+      expect(MarketScorer.dataQualityScore(0, 0)).toBe(0);
+    });
+
+    it('returns higher score for more informative bars', () => {
+      const low = MarketScorer.dataQualityScore(10, 100);  // 10% informative
+      const high = MarketScorer.dataQualityScore(80, 100);  // 80% informative
+      expect(high).toBeGreaterThan(low);
+    });
+
+    it('caps at 1.0', () => {
+      expect(MarketScorer.dataQualityScore(100, 100)).toBeLessThanOrEqual(1.0);
+    });
+  });
+
+  describe('compositeScore', () => {
+    it('combines all dimensions with correct weights', () => {
+      // All perfect scores should give 1.0
+      const score = MarketScorer.compositeScore({
+        tradeability: 1.0,
+        liquidity: 1.0,
+        volatility: 1.0,
+        ttr: 1.0,
+        dataQuality: 1.0,
+      });
+      expect(score).toBeCloseTo(1.0, 5);
+    });
+
+    it('uses partial score when volatility/quality unavailable (cold markets)', () => {
+      // Cold markets only have tradeability + liquidity + TTR
+      const score = MarketScorer.compositeScore({
+        tradeability: 1.0,
+        liquidity: 1.0,
+        volatility: null,
+        ttr: 1.0,
+        dataQuality: null,
+      });
+      // Should normalize: (0.30 + 0.25 + 0.15) / (0.30 + 0.25 + 0.15) = 1.0
+      expect(score).toBeCloseTo(1.0, 5);
+    });
+
+    it('returns 0 for all-zero scores', () => {
+      const score = MarketScorer.compositeScore({
+        tradeability: 0,
+        liquidity: 0,
+        volatility: 0,
+        ttr: 0,
+        dataQuality: 0,
+      });
+      expect(score).toBe(0);
+    });
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd packages/data-collector && pnpm test -- --run src/services/MarketScorer.test.ts`
+Expected: FAIL — `Cannot find module './MarketScorer'`
+
+**Step 3: Commit test file**
+
+```bash
+git add packages/data-collector/src/services/MarketScorer.test.ts
+git commit -m "test: add MarketScorer unit tests (red phase)"
+```
+
+---
+
+## Task 3: MarketScorer — Implementation
+
+**Files:**
+- Create: `packages/data-collector/src/services/MarketScorer.ts`
+
+**Step 1: Implement the scoring functions**
+
+```typescript
+import { query } from '../database/connection';
+import logger from '../utils/logger';
+
+// Weights — initial defaults, will be optimized via Optuna in Phase 2.5
+const WEIGHTS = {
+  tradeability: 0.30,
+  liquidity: 0.25,
+  volatility: 0.20,
+  ttr: 0.15,
+  dataQuality: 0.10,
+};
+
+// Reference volume for normalization (log scale)
+// ~$30M is the highest observed 24h volume on Polymarket
+const MAX_VOLUME_REF = 30_000_000;
+
+interface ScoreDimensions {
+  tradeability: number;
+  liquidity: number;
+  volatility: number | null;
+  ttr: number;
+  dataQuality: number | null;
+}
+
+export class MarketScorer {
+  /**
+   * Tradeability: how profitable is trading at this price?
+   * Optimal: [0.15-0.40] ∪ [0.60-0.85] → 1.0
+   * Zero: <0.05, >0.95, 0.45-0.55
+   * Linear ramps between zones
+   */
+  static tradeabilityScore(price: number | null): number {
+    if (price === null || price === undefined) return 0;
+    if (price < 0.05 || price > 0.95) return 0;
+    if (price >= 0.45 && price <= 0.55) return 0;
+
+    // Low side
+    if (price >= 0.15 && price <= 0.40) return 1.0;
+    if (price >= 0.05 && price < 0.15) return (price - 0.05) / 0.10;
+    if (price > 0.40 && price < 0.45) return (0.45 - price) / 0.05;
+
+    // High side (symmetric)
+    if (price >= 0.60 && price <= 0.85) return 1.0;
+    if (price > 0.55 && price < 0.60) return (price - 0.55) / 0.05;
+    if (price > 0.85 && price <= 0.95) return (0.95 - price) / 0.10;
+
+    return 0;
+  }
+
+  /**
+   * Liquidity: can we enter/exit without slippage?
+   * log(volume) normalized against reference max.
+   * 50% penalty if spread > 3%.
+   */
+  static liquidityScore(volume24h: number | null, spread: number | null): number {
+    if (!volume24h || volume24h <= 0) return 0;
+    const raw = Math.min(1.0, Math.log(volume24h) / Math.log(MAX_VOLUME_REF));
+    const spreadPenalty = spread !== null && spread > 0.03 ? 0.5 : 1.0;
+    return raw * spreadPenalty;
+  }
+
+  /**
+   * Time-to-Resolution: is there useful life remaining?
+   * Optimal: 7-60 days → 1.0
+   * <24h → 0.1 (too soon, near-resolution risks)
+   * >180 days → 0.5 (too slow)
+   */
+  static ttrScore(endDate: Date | null): number {
+    if (!endDate) return 0.5; // unknown, neutral
+
+    const hoursLeft = (endDate.getTime() - Date.now()) / (3600 * 1000);
+    if (hoursLeft < 0) return 0; // already past
+    if (hoursLeft < 24) return 0.1;
+
+    const daysLeft = hoursLeft / 24;
+    if (daysLeft < 7) return 0.1 + 0.9 * ((daysLeft - 1) / 6); // ramp 1-7 days
+    if (daysLeft <= 60) return 1.0; // optimal
+    if (daysLeft <= 180) return 1.0 - 0.5 * ((daysLeft - 60) / 120); // decay
+    return 0.5; // very far out
+  }
+
+  /**
+   * Volatility: is there price movement for signal generation?
+   * Optimal: stddev ~0.05-0.10 → high score
+   * Zero: dead market → 0
+   * >0.15: likely resolving → penalized
+   */
+  static volatilityScore(stddev: number | null): number {
+    if (stddev === null || stddev === undefined || stddev === 0) return 0;
+    // Bell curve peaking at stddev=0.07
+    const optimal = 0.07;
+    const width = 0.06;
+    const normalized = Math.exp(-Math.pow(stddev - optimal, 2) / (2 * Math.pow(width, 2)));
+    return Math.min(1.0, normalized);
+  }
+
+  /**
+   * Data Quality: ratio of informative bars vs flat snapshots
+   * More real data (from trades) = better signals
+   */
+  static dataQualityScore(informativeBars: number, totalBars: number): number {
+    if (totalBars === 0) return 0;
+    return Math.min(1.0, informativeBars / totalBars);
+  }
+
+  /**
+   * Combine dimensions into composite score.
+   * For cold markets (no volatility/quality data), normalize by available weights.
+   */
+  static compositeScore(dims: ScoreDimensions): number {
+    let score = 0;
+    let totalWeight = 0;
+
+    score += WEIGHTS.tradeability * dims.tradeability;
+    totalWeight += WEIGHTS.tradeability;
+
+    score += WEIGHTS.liquidity * dims.liquidity;
+    totalWeight += WEIGHTS.liquidity;
+
+    score += WEIGHTS.ttr * dims.ttr;
+    totalWeight += WEIGHTS.ttr;
+
+    if (dims.volatility !== null) {
+      score += WEIGHTS.volatility * dims.volatility;
+      totalWeight += WEIGHTS.volatility;
+    }
+
+    if (dims.dataQuality !== null) {
+      score += WEIGHTS.dataQuality * dims.dataQuality;
+      totalWeight += WEIGHTS.dataQuality;
+    }
+
+    return totalWeight > 0 ? score / totalWeight : 0;
+  }
+
+  /**
+   * Score all active, unresolved markets in the DB.
+   * Two-pass approach:
+   *   1. Score all candidates on tradeability + liquidity + TTR (from markets table)
+   *   2. Enrich tracked markets with volatility + data quality (from price_history)
+   */
+  async scoreAllMarkets(): Promise<{ scored: number; enriched: number }> {
+    const log = logger.child({ name: 'MarketScorer' });
+
+    // Pass 1: Score all candidates using markets table data only
+    const candidates = await query<{
+      id: string;
+      current_price_yes: number | null;
+      volume_24h: number | null;
+      spread: number | null;
+      end_date: Date | null;
+    }>(
+      `SELECT id, current_price_yes, volume_24h, spread, end_date
+       FROM markets
+       WHERE is_active = true AND is_resolved = false AND clob_token_id_yes IS NOT NULL`
+    );
+
+    if (candidates.rows.length === 0) {
+      log.warn('No active markets to score');
+      return { scored: 0, enriched: 0 };
+    }
+
+    // Compute base scores (3 dimensions)
+    const updates: { id: string; score: number }[] = [];
+    for (const m of candidates.rows) {
+      const score = MarketScorer.compositeScore({
+        tradeability: MarketScorer.tradeabilityScore(m.current_price_yes),
+        liquidity: MarketScorer.liquidityScore(
+          m.volume_24h ? parseFloat(String(m.volume_24h)) : null,
+          m.spread ? parseFloat(String(m.spread)) : null
+        ),
+        ttr: MarketScorer.ttrScore(m.end_date),
+        volatility: null,
+        dataQuality: null,
+      });
+      updates.push({ id: m.id, score });
+    }
+
+    // Batch update scores (500 at a time)
+    let scored = 0;
+    for (let i = 0; i < updates.length; i += 500) {
+      const batch = updates.slice(i, i + 500);
+      const cases = batch.map((u, idx) => `WHEN $${idx * 2 + 1} THEN $${idx * 2 + 2}::float`).join(' ');
+      const ids = batch.map((u, idx) => `$${idx * 2 + 1}`).join(', ');
+      const params = batch.flatMap(u => [u.id, u.score]);
+
+      await query(
+        `UPDATE markets SET market_score = CASE id ${cases} END
+         WHERE id IN (${ids})`,
+        params
+      );
+      scored += batch.length;
+    }
+
+    // Pass 2: Enrich tracked markets with volatility + data quality
+    const tracked = await query<{
+      id: string;
+      current_price_yes: number | null;
+      volume_24h: number | null;
+      spread: number | null;
+      end_date: Date | null;
+      price_stddev: number | null;
+      informative_bars: number;
+      total_bars: number;
+    }>(
+      `SELECT m.id, m.current_price_yes, m.volume_24h, m.spread, m.end_date,
+              STDDEV(ph.close) as price_stddev,
+              COUNT(*) FILTER (WHERE ph.source != 'snapshot' OR ph.open != ph.close) as informative_bars,
+              COUNT(*) as total_bars
+       FROM markets m
+       JOIN price_history ph ON ph.token_id = m.clob_token_id_yes
+         AND ph.time > NOW() - INTERVAL '24 hours'
+       WHERE m.tracking_status IN ('warming', 'active', 'cooling')
+       GROUP BY m.id, m.current_price_yes, m.volume_24h, m.spread, m.end_date`
+    );
+
+    let enriched = 0;
+    for (const m of tracked.rows) {
+      const score = MarketScorer.compositeScore({
+        tradeability: MarketScorer.tradeabilityScore(m.current_price_yes),
+        liquidity: MarketScorer.liquidityScore(
+          m.volume_24h ? parseFloat(String(m.volume_24h)) : null,
+          m.spread ? parseFloat(String(m.spread)) : null
+        ),
+        ttr: MarketScorer.ttrScore(m.end_date),
+        volatility: MarketScorer.volatilityScore(
+          m.price_stddev ? parseFloat(String(m.price_stddev)) : null
+        ),
+        dataQuality: MarketScorer.dataQualityScore(
+          parseInt(String(m.informative_bars)),
+          parseInt(String(m.total_bars))
+        ),
+      });
+
+      await query(
+        `UPDATE markets SET market_score = $1 WHERE id = $2`,
+        [score, m.id]
+      );
+      enriched++;
+    }
+
+    log.info({ scored, enriched }, 'Market scoring complete');
+    return { scored, enriched };
+  }
+}
+```
+
+**Step 2: Run tests to verify they pass**
+
+Run: `cd packages/data-collector && pnpm test -- --run src/services/MarketScorer.test.ts`
+Expected: ALL PASS
+
+**Step 3: Commit**
+
+```bash
+git add packages/data-collector/src/services/MarketScorer.ts
+git commit -m "feat: implement MarketScorer with composite scoring (5 dimensions)"
+```
+
+---
+
+## Task 4: MarketRotator — Tests
+
+**Files:**
+- Create: `packages/data-collector/src/services/MarketRotator.test.ts`
+
+**Step 1: Write failing tests for rotation logic**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MarketRotator, RotationConfig, MarketRow } from './MarketRotator';
+
+// Mock the database module
+vi.mock('../database/connection', () => ({
+  query: vi.fn(),
+  transaction: vi.fn(),
+}));
+
+import { query, transaction } from '../database/connection';
+const mockQuery = vi.mocked(query);
+const mockTransaction = vi.mocked(transaction);
+
+function makeMarket(overrides: Partial<MarketRow> = {}): MarketRow {
+  return {
+    id: 'market-1',
+    market_score: 0.8,
+    tracking_status: 'cold',
+    tracking_status_changed_at: new Date(Date.now() - 3600_000),
+    current_price_yes: 0.30,
+    has_open_positions: false,
+    bars_24h: 0,
+    ...overrides,
+  };
+}
+
+const DEFAULT_CONFIG: RotationConfig = {
+  maxTracked: 40,
+  maxRotationsPerHour: 5,
+  warmingPromotionBars: 3,
+  coolingTimeoutHours: 6,
+  emergencyFillThreshold: 20,
+  hysteresisRatio: 0.60,
+  reserveSlots: 2,
+};
+
+describe('MarketRotator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('selectDemotions', () => {
+    it('demotes ACTIVE market with low score when better candidates wait', () => {
+      const rotator = new MarketRotator(DEFAULT_CONFIG);
+      const active = [makeMarket({ id: 'a1', tracking_status: 'active', market_score: 0.2 })];
+      const candidates = [makeMarket({ id: 'c1', tracking_status: 'cold', market_score: 0.8 })];
+
+      const demotions = rotator.selectDemotions(active, candidates);
+      expect(demotions.map(m => m.id)).toContain('a1');
+    });
+
+    it('does NOT demote ACTIVE market with open positions', () => {
+      const rotator = new MarketRotator(DEFAULT_CONFIG);
+      const active = [makeMarket({
+        id: 'a1', tracking_status: 'active', market_score: 0.1, has_open_positions: true,
+      })];
+      const candidates = [makeMarket({ id: 'c1', tracking_status: 'cold', market_score: 0.9 })];
+
+      const demotions = rotator.selectDemotions(active, candidates);
+      expect(demotions).toHaveLength(0);
+    });
+
+    it('applies hysteresis — only demotes if score < 60% of worst candidate', () => {
+      const rotator = new MarketRotator(DEFAULT_CONFIG);
+      // Worst candidate score: 0.5. Hysteresis threshold: 0.5 * 0.60 = 0.30
+      // Active score 0.35 > 0.30, so should NOT demote
+      const active = [makeMarket({ id: 'a1', tracking_status: 'active', market_score: 0.35 })];
+      const candidates = [makeMarket({ id: 'c1', tracking_status: 'cold', market_score: 0.5 })];
+
+      const demotions = rotator.selectDemotions(active, candidates);
+      expect(demotions).toHaveLength(0);
+    });
+
+    it('respects max rotations per hour', () => {
+      const rotator = new MarketRotator({ ...DEFAULT_CONFIG, maxRotationsPerHour: 2 });
+      const active = [
+        makeMarket({ id: 'a1', tracking_status: 'active', market_score: 0.01 }),
+        makeMarket({ id: 'a2', tracking_status: 'active', market_score: 0.02 }),
+        makeMarket({ id: 'a3', tracking_status: 'active', market_score: 0.03 }),
+      ];
+      const candidates = [
+        makeMarket({ id: 'c1', market_score: 0.9 }),
+        makeMarket({ id: 'c2', market_score: 0.8 }),
+        makeMarket({ id: 'c3', market_score: 0.7 }),
+      ];
+
+      const demotions = rotator.selectDemotions(active, candidates);
+      expect(demotions.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe('selectPromotions', () => {
+    it('promotes WARMING market with enough bars', () => {
+      const rotator = new MarketRotator(DEFAULT_CONFIG);
+      const warming = [makeMarket({
+        id: 'w1', tracking_status: 'warming', bars_24h: 5, market_score: 0.7,
+      })];
+
+      const promotions = rotator.selectPromotions(warming);
+      expect(promotions.map(m => m.id)).toContain('w1');
+    });
+
+    it('does NOT promote WARMING market with insufficient bars', () => {
+      const rotator = new MarketRotator(DEFAULT_CONFIG);
+      const warming = [makeMarket({
+        id: 'w1', tracking_status: 'warming', bars_24h: 1, market_score: 0.7,
+      })];
+
+      const promotions = rotator.selectPromotions(warming);
+      expect(promotions).toHaveLength(0);
+    });
+
+    it('re-evaluates score before promoting — drops if score decayed', () => {
+      const rotator = new MarketRotator(DEFAULT_CONFIG);
+      // Has enough bars but score dropped to near-zero (price moved to 50/50)
+      const warming = [makeMarket({
+        id: 'w1', tracking_status: 'warming', bars_24h: 10, market_score: 0.01,
+      })];
+
+      const promotions = rotator.selectPromotions(warming);
+      expect(promotions).toHaveLength(0);
+    });
+  });
+
+  describe('selectCoolingExpired', () => {
+    it('expires COOLING market after timeout', () => {
+      const rotator = new MarketRotator(DEFAULT_CONFIG);
+      const cooling = [makeMarket({
+        id: 'cool1',
+        tracking_status: 'cooling',
+        tracking_status_changed_at: new Date(Date.now() - 7 * 3600_000), // 7h ago
+        has_open_positions: false,
+      })];
+
+      const expired = rotator.selectCoolingExpired(cooling);
+      expect(expired.map(m => m.id)).toContain('cool1');
+    });
+
+    it('does NOT expire COOLING market with open positions before timeout', () => {
+      const rotator = new MarketRotator(DEFAULT_CONFIG);
+      const cooling = [makeMarket({
+        id: 'cool1',
+        tracking_status: 'cooling',
+        tracking_status_changed_at: new Date(Date.now() - 2 * 3600_000), // 2h ago
+        has_open_positions: true,
+      })];
+
+      const expired = rotator.selectCoolingExpired(cooling);
+      expect(expired).toHaveLength(0);
+    });
+
+    it('expires COOLING market with open positions after timeout (flags for stop-loss)', () => {
+      const rotator = new MarketRotator(DEFAULT_CONFIG);
+      const cooling = [makeMarket({
+        id: 'cool1',
+        tracking_status: 'cooling',
+        tracking_status_changed_at: new Date(Date.now() - 7 * 3600_000), // 7h, past 6h timeout
+        has_open_positions: true,
+      })];
+
+      const expired = rotator.selectCoolingExpired(cooling);
+      expect(expired.map(m => m.id)).toContain('cool1');
+    });
+  });
+
+  describe('computeNewWarmingSlots', () => {
+    it('fills warming slots up to available capacity', () => {
+      const rotator = new MarketRotator(DEFAULT_CONFIG);
+      const currentCounts = { active: 30, warming: 2, cooling: 1 };
+      // maxTracked=40, reserve=2 → usable=38. Used=33. Available=5.
+      const slots = rotator.computeNewWarmingSlots(currentCounts);
+      expect(slots).toBe(5);
+    });
+
+    it('returns 0 when at capacity', () => {
+      const rotator = new MarketRotator(DEFAULT_CONFIG);
+      const currentCounts = { active: 35, warming: 3, cooling: 0 };
+      // usable=38. Used=38. Available=0.
+      const slots = rotator.computeNewWarmingSlots(currentCounts);
+      expect(slots).toBe(0);
+    });
+  });
+
+  describe('emergency fill', () => {
+    it('bypasses rotation limit when ACTIVE < threshold', () => {
+      const rotator = new MarketRotator(DEFAULT_CONFIG);
+      const isEmergency = rotator.isEmergencyFill(15); // threshold=20
+      expect(isEmergency).toBe(true);
+    });
+
+    it('does not trigger when ACTIVE >= threshold', () => {
+      const rotator = new MarketRotator(DEFAULT_CONFIG);
+      const isEmergency = rotator.isEmergencyFill(25);
+      expect(isEmergency).toBe(false);
+    });
+  });
+
+  describe('targetState for demotion', () => {
+    it('demotes to COOLING if has open positions', () => {
+      const rotator = new MarketRotator(DEFAULT_CONFIG);
+      expect(rotator.demotionTarget(true)).toBe('cooling');
+    });
+
+    it('demotes to COLD if no open positions', () => {
+      const rotator = new MarketRotator(DEFAULT_CONFIG);
+      expect(rotator.demotionTarget(false)).toBe('cold');
+    });
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd packages/data-collector && pnpm test -- --run src/services/MarketRotator.test.ts`
+Expected: FAIL — `Cannot find module './MarketRotator'`
+
+**Step 3: Commit test file**
+
+```bash
+git add packages/data-collector/src/services/MarketRotator.test.ts
+git commit -m "test: add MarketRotator unit tests (red phase)"
+```
+
+---
+
+## Task 5: MarketRotator — Implementation
+
+**Files:**
+- Create: `packages/data-collector/src/services/MarketRotator.ts`
+
+**Step 1: Implement the rotation state machine**
+
+```typescript
+import { query } from '../database/connection';
+import logger from '../utils/logger';
+
+export interface RotationConfig {
+  maxTracked: number;          // MAX_TRACKED_MARKETS (40)
+  maxRotationsPerHour: number; // 5 (structural)
+  warmingPromotionBars: number; // 3 (structural — SignalEngine minimum)
+  coolingTimeoutHours: number; // 6 (structural)
+  emergencyFillThreshold: number; // 20 (structural)
+  hysteresisRatio: number;     // 0.60 (optimizable)
+  reserveSlots: number;        // 2 (structural)
+}
+
+export interface MarketRow {
+  id: string;
+  market_score: number;
+  tracking_status: string;
+  tracking_status_changed_at: Date;
+  current_price_yes: number | null;
+  has_open_positions: boolean;
+  bars_24h: number;
+}
+
+const DEFAULT_CONFIG: RotationConfig = {
+  maxTracked: parseInt(process.env.MAX_TRACKED_MARKETS || '40', 10),
+  maxRotationsPerHour: 5,
+  warmingPromotionBars: 3,
+  coolingTimeoutHours: 6,
+  emergencyFillThreshold: 20,
+  hysteresisRatio: 0.60,
+  reserveSlots: 2,
+};
+
+// Minimum score to be considered for warming
+const MIN_CANDIDATE_SCORE = 0.15;
+
+export class MarketRotator {
+  private config: RotationConfig;
+
+  constructor(config: Partial<RotationConfig> = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  isEmergencyFill(activeCount: number): boolean {
+    return activeCount < this.config.emergencyFillThreshold;
+  }
+
+  demotionTarget(hasOpenPositions: boolean): 'cooling' | 'cold' {
+    return hasOpenPositions ? 'cooling' : 'cold';
+  }
+
+  computeNewWarmingSlots(counts: { active: number; warming: number; cooling: number }): number {
+    const usable = this.config.maxTracked - this.config.reserveSlots;
+    const used = counts.active + counts.warming + counts.cooling;
+    return Math.max(0, usable - used);
+  }
+
+  selectDemotions(active: MarketRow[], candidates: MarketRow[]): MarketRow[] {
+    if (candidates.length === 0) return [];
+
+    // Worst candidate score (the floor for hysteresis comparison)
+    const worstCandidateScore = Math.min(...candidates.map(c => c.market_score));
+    const hysteresisThreshold = worstCandidateScore * this.config.hysteresisRatio;
+
+    const demotable = active
+      .filter(m => !m.has_open_positions)
+      .filter(m => m.market_score < hysteresisThreshold)
+      .sort((a, b) => a.market_score - b.market_score); // worst first
+
+    return demotable.slice(0, this.config.maxRotationsPerHour);
+  }
+
+  selectPromotions(warming: MarketRow[]): MarketRow[] {
+    return warming.filter(m =>
+      m.bars_24h >= this.config.warmingPromotionBars && m.market_score >= MIN_CANDIDATE_SCORE
+    );
+  }
+
+  selectCoolingExpired(cooling: MarketRow[]): MarketRow[] {
+    const timeoutMs = this.config.coolingTimeoutHours * 3600_000;
+    return cooling.filter(m => {
+      const elapsed = Date.now() - m.tracking_status_changed_at.getTime();
+      return elapsed >= timeoutMs;
+    });
+  }
+
+  /**
+   * Main rotation logic. Called once per hour after scoring.
+   */
+  async rotate(): Promise<{
+    promoted: number;
+    demoted: number;
+    newWarming: number;
+    coolingExpired: number;
+  }> {
+    const log = logger.child({ name: 'MarketRotator' });
+
+    // Fetch all tracked markets + their position status + bar count
+    const trackedResult = await query<MarketRow>(
+      `SELECT m.id, m.market_score, m.tracking_status,
+              m.tracking_status_changed_at, m.current_price_yes,
+              EXISTS(
+                SELECT 1 FROM paper_positions pp
+                WHERE pp.market_id = m.condition_id
+                  AND pp.closed_at IS NULL
+              ) as has_open_positions,
+              (
+                SELECT COUNT(*) FROM price_history ph
+                WHERE ph.token_id = m.clob_token_id_yes
+                  AND ph.time > NOW() - INTERVAL '24 hours'
+              ) as bars_24h
+       FROM markets m
+       WHERE m.tracking_status IN ('warming', 'active', 'cooling')`
+    );
+
+    const tracked = trackedResult.rows.map(r => ({
+      ...r,
+      market_score: parseFloat(String(r.market_score)),
+      bars_24h: parseInt(String(r.bars_24h)),
+      has_open_positions: r.has_open_positions === true || r.has_open_positions === 't' as any,
+    }));
+
+    const active = tracked.filter(m => m.tracking_status === 'active');
+    const warming = tracked.filter(m => m.tracking_status === 'warming');
+    const cooling = tracked.filter(m => m.tracking_status === 'cooling');
+
+    const emergency = this.isEmergencyFill(active.length);
+    if (emergency) {
+      log.warn({ activeCount: active.length }, 'Emergency fill mode — ACTIVE below threshold');
+    }
+
+    // Step 1: Expire cooling markets past timeout
+    const coolingExpired = this.selectCoolingExpired(cooling);
+    for (const m of coolingExpired) {
+      await this.setStatus(m.id, 'cold');
+      if (m.has_open_positions) {
+        log.warn({ marketId: m.id }, 'Cooling timeout with open position — needs stop-loss review');
+      }
+    }
+
+    // Step 2: Promote warming → active
+    const promotions = this.selectPromotions(warming);
+    for (const m of promotions) {
+      await this.setStatus(m.id, 'active');
+    }
+
+    // Step 3: Demote active → cooling/cold (skip in emergency mode)
+    let demotions: MarketRow[] = [];
+    if (!emergency) {
+      // Get top candidates waiting to enter
+      const candidateResult = await query<MarketRow>(
+        `SELECT id, market_score, tracking_status, tracking_status_changed_at,
+                current_price_yes, false as has_open_positions, 0 as bars_24h
+         FROM markets
+         WHERE tracking_status = 'cold'
+           AND is_active = true AND is_resolved = false
+           AND clob_token_id_yes IS NOT NULL
+           AND market_score >= $1
+         ORDER BY market_score DESC
+         LIMIT 50`,
+        [MIN_CANDIDATE_SCORE]
+      );
+
+      const candidates = candidateResult.rows.map(r => ({
+        ...r,
+        market_score: parseFloat(String(r.market_score)),
+        bars_24h: 0,
+        has_open_positions: false,
+      }));
+
+      demotions = this.selectDemotions(active, candidates);
+      for (const m of demotions) {
+        const target = this.demotionTarget(m.has_open_positions);
+        await this.setStatus(m.id, target);
+      }
+    }
+
+    // Step 4: Fill warming slots from top cold candidates
+    const currentCounts = {
+      active: active.length + promotions.length - demotions.length,
+      warming: warming.length - promotions.length,
+      cooling: cooling.length - coolingExpired.length + demotions.filter(m => m.has_open_positions).length,
+    };
+
+    let slotsAvailable = this.computeNewWarmingSlots(currentCounts);
+    if (emergency) {
+      // In emergency, fill as many as possible
+      slotsAvailable = Math.max(slotsAvailable, this.config.emergencyFillThreshold - currentCounts.active);
+    }
+
+    let newWarming = 0;
+    if (slotsAvailable > 0) {
+      const newCandidates = await query<{ id: string; market_score: number }>(
+        `SELECT id, market_score FROM markets
+         WHERE tracking_status = 'cold'
+           AND is_active = true AND is_resolved = false
+           AND clob_token_id_yes IS NOT NULL
+           AND market_score >= $1
+         ORDER BY market_score DESC
+         LIMIT $2`,
+        [MIN_CANDIDATE_SCORE, slotsAvailable]
+      );
+
+      for (const m of newCandidates.rows) {
+        await this.setStatus(m.id, 'warming');
+        newWarming++;
+      }
+    }
+
+    log.info({
+      active: currentCounts.active,
+      warming: currentCounts.warming + newWarming,
+      cooling: currentCounts.cooling,
+      promoted: promotions.length,
+      demoted: demotions.length,
+      newWarming,
+      coolingExpired: coolingExpired.length,
+      emergency,
+    }, 'Market rotation complete');
+
+    return {
+      promoted: promotions.length,
+      demoted: demotions.length,
+      newWarming,
+      coolingExpired: coolingExpired.length,
+    };
+  }
+
+  private async setStatus(marketId: string, status: string): Promise<void> {
+    await query(
+      `UPDATE markets SET tracking_status = $1, tracking_status_changed_at = NOW() WHERE id = $2`,
+      [status, marketId]
+    );
+  }
+}
+```
+
+**Step 2: Run tests to verify they pass**
+
+Run: `cd packages/data-collector && pnpm test -- --run src/services/MarketRotator.test.ts`
+Expected: ALL PASS
+
+**Step 3: Commit**
+
+```bash
+git add packages/data-collector/src/services/MarketRotator.ts
+git commit -m "feat: implement MarketRotator state machine with hysteresis and position protection"
+```
+
+---
+
+## Task 6: Wire Scorer + Rotator into Scheduler
+
+**Files:**
+- Modify: `packages/data-collector/src/services/Scheduler.ts`
+
+**Step 1: Import and instantiate**
+
+At the top of `Scheduler.ts`, add imports:
+
+```typescript
+import { MarketScorer } from './MarketScorer';
+import { MarketRotator } from './MarketRotator';
+```
+
+Add class properties (near other collector properties):
+
+```typescript
+private marketScorer: MarketScorer;
+private marketRotator: MarketRotator;
+```
+
+In the constructor, initialize them:
+
+```typescript
+this.marketScorer = new MarketScorer();
+this.marketRotator = new MarketRotator();
+```
+
+**Step 2: Modify syncMarkets() to run scoring + rotation after gamma sync**
+
+Find the `syncMarkets()` method (around line 242-246). Currently:
+
+```typescript
+private async syncMarkets(): Promise<void> {
+  const result = await this.getGammaCollector().syncMarketsToDb();
+  this.log.info(result, 'Markets synced');
+}
+```
+
+Replace with:
+
+```typescript
+private async syncMarkets(): Promise<void> {
+  const result = await this.getGammaCollector().syncMarketsToDb();
+  this.log.info(result, 'Markets synced from Gamma API');
+
+  // Score all markets after sync
+  const scoreResult = await this.marketScorer.scoreAllMarkets();
+  this.log.info(scoreResult, 'Markets scored');
+
+  // Rotate tracked markets based on scores
+  const rotateResult = await this.marketRotator.rotate();
+  this.log.info(rotateResult, 'Market rotation complete');
+}
+```
+
+**Step 3: Build and verify**
+
+Run: `cd packages/data-collector && pnpm build`
+Expected: Compiles without errors
+
+**Step 4: Commit**
+
+```bash
+git add packages/data-collector/src/services/Scheduler.ts
+git commit -m "feat: wire MarketScorer and MarketRotator into sync-markets job"
+```
+
+---
+
+## Task 7: Update ClobCollector Market Selection Queries
+
+**Files:**
+- Modify: `packages/data-collector/src/collectors/ClobCollector.ts`
+
+All 5 data collection methods use the same pattern:
+```sql
+SELECT ... FROM markets
+WHERE is_active = true AND clob_token_id_yes IS NOT NULL
+ORDER BY volume_24h DESC NULLS LAST
+LIMIT ${MAX_TRACKED_MARKETS}
+```
+
+Replace ALL 5 with:
+```sql
+SELECT ... FROM markets
+WHERE tracking_status IN ('warming', 'active', 'cooling')
+  AND clob_token_id_yes IS NOT NULL
+ORDER BY market_score DESC NULLS LAST
+```
+
+No `LIMIT` needed — tracking_status already constrains to ~40 markets.
+
+**Step 1: Update `updateAllMarketPrices()` (around line 643-650)**
+
+Change the query from:
+```typescript
+      `SELECT id, clob_token_id_yes, clob_token_id_no
+       FROM markets
+       WHERE is_active = true AND clob_token_id_yes IS NOT NULL
+       ORDER BY volume_24h DESC NULLS LAST
+       ${limitClause}`
+```
+
+To:
+```typescript
+      `SELECT id, clob_token_id_yes, clob_token_id_no
+       FROM markets
+       WHERE tracking_status IN ('warming', 'active', 'cooling')
+         AND clob_token_id_yes IS NOT NULL
+       ORDER BY market_score DESC NULLS LAST`
+```
+
+**Step 2: Update `syncAllMarketsPriceHistory()` (around line 576-584)** — same change
+
+**Step 3: Update `syncAllOrderBooks()` (around line 530-537)** — same change
+
+**Step 4: Update `syncAllTrades()` (around line 274-280)** — same change
+
+**Step 5: Update `snapshotCurrentPricesToHistory()` (around line 732-741)**
+
+Change from:
+```typescript
+      `SELECT id, clob_token_id_yes, current_price_yes
+       FROM markets
+       WHERE is_active = true
+         AND clob_token_id_yes IS NOT NULL
+         AND current_price_yes IS NOT NULL
+         AND current_price_yes > 0
+       ORDER BY volume_24h DESC NULLS LAST
+       ${limitClause}`
+```
+
+To:
+```typescript
+      `SELECT id, clob_token_id_yes, current_price_yes
+       FROM markets
+       WHERE tracking_status IN ('warming', 'active', 'cooling')
+         AND clob_token_id_yes IS NOT NULL
+         AND current_price_yes IS NOT NULL
+         AND current_price_yes > 0
+       ORDER BY market_score DESC NULLS LAST`
+```
+
+**Step 6: Remove unused MAX_TRACKED_MARKETS and limitClause**
+
+At line 13:
+```typescript
+const MAX_TRACKED_MARKETS = parseInt(process.env.MAX_TRACKED_MARKETS || '0', 10) || undefined;
+```
+
+Keep this variable — it's still used by `MarketRotator` via env var. But remove the `limitClause` pattern from the query methods since it's no longer needed.
+
+Find all occurrences of:
+```typescript
+const limitClause = MAX_TRACKED_MARKETS ? `LIMIT ${MAX_TRACKED_MARKETS}` : '';
+```
+And remove them from each method.
+
+**Step 7: Build and verify**
+
+Run: `cd packages/data-collector && pnpm build`
+Expected: Compiles without errors
+
+**Step 8: Run existing tests**
+
+Run: `cd packages/data-collector && pnpm test -- --run`
+Expected: ALL PASS (existing tests should still work)
+
+**Step 9: Commit**
+
+```bash
+git add packages/data-collector/src/collectors/ClobCollector.ts
+git commit -m "feat: ClobCollector uses tracking_status instead of volume-ordered LIMIT"
+```
+
+---
+
+## Task 8: Add Logger Import to MarketScorer and MarketRotator
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketScorer.ts`
+- Modify: `packages/data-collector/src/services/MarketRotator.ts`
+
+**Step 1: Verify logger module location**
+
+Check the import path — data-collector might use `pino` directly or have a logger wrapper. Look at existing services (e.g., `Scheduler.ts`) for the correct import pattern. Common patterns:
+- `import logger from '../utils/logger'` (if wrapper exists)
+- `import pino from 'pino'; const logger = pino({ name: 'MarketScorer' })` (direct pino)
+
+If no `utils/logger` exists, use the same pattern as `Scheduler.ts`.
+
+**Step 2: Build and verify**
+
+Run: `cd packages/data-collector && pnpm build`
+Expected: No errors
+
+**Step 3: Commit if changes were needed**
+
+```bash
+git add packages/data-collector/src/services/MarketScorer.ts packages/data-collector/src/services/MarketRotator.ts
+git commit -m "fix: correct logger imports for MarketScorer and MarketRotator"
+```
+
+---
+
+## Task 9: End-to-End Smoke Test
+
+**Step 1: Run full test suite**
+
+Run: `cd packages/data-collector && pnpm test -- --run`
+Expected: ALL PASS
+
+**Step 2: Build the whole monorepo**
+
+Run: `pnpm build` (from repo root)
+Expected: No compilation errors
+
+**Step 3: Verify via SSH that migration applies cleanly**
+
+After deploying (CI/CD or manual), SSH to VM and verify:
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = 'markets' AND column_name IN ('market_score', 'tracking_status', 'tracking_status_changed_at');\""
+```
+
+Expected: 3 rows showing the new columns
+
+**Step 4: Verify rotation happened**
+
+After one sync-markets cycle (up to 1h, or trigger manually):
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"SELECT tracking_status, COUNT(*), AVG(market_score)::numeric(5,3) as avg_score FROM markets WHERE tracking_status != 'cold' GROUP BY tracking_status ORDER BY tracking_status;\""
+```
+
+Expected: Rows showing warming/active markets with non-zero scores
+
+**Step 5: Verify signals resume**
+
+After warming markets accumulate 3+ bars (~15 min of data collection):
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="docker compose -f /home/Usuario/polymarket-trader/docker-compose.gcp.yml logs --tail=50 dashboard-api 2>&1 | grep -E '(active markets|signals generated|Combined signal)'"
+```
+
+Expected: `[SignalEngine] Updated active markets: X` where X > 0
+
+**Step 6: Commit any fixes found during smoke test, final commit**
+
+```bash
+git add -A
+git commit -m "feat: Market Intelligence System Phase 1 complete — smart scoring + dynamic rotation"
+```
+
+---
+
+## Summary: File Change Map
+
+| Action | File | Purpose |
+|--------|------|---------|
+| CREATE | `packages/data-collector/src/database/init/005_market_intelligence.sql` | Migration: new columns + indexes + warm start |
+| CREATE | `packages/data-collector/src/services/MarketScorer.ts` | Composite market scoring (5 dimensions) |
+| CREATE | `packages/data-collector/src/services/MarketScorer.test.ts` | Unit tests for scoring math |
+| CREATE | `packages/data-collector/src/services/MarketRotator.ts` | State machine: cold→warming→active→cooling |
+| CREATE | `packages/data-collector/src/services/MarketRotator.test.ts` | Unit tests for rotation logic |
+| MODIFY | `packages/data-collector/src/services/Scheduler.ts` | Wire scorer + rotator into sync-markets job |
+| MODIFY | `packages/data-collector/src/collectors/ClobCollector.ts` | Use tracking_status filter instead of volume LIMIT |
+| MODIFY | `scripts/daily-review-prompt.md` | Phase 3: investigation rule, language rule (ALREADY DONE) |
+
+## Estimated Commits: 8-9
+## Estimated Implementation Time: Tasks are independent enough for parallel subagent execution where noted.

--- a/docs/plans/2026-03-19-phase25-scorer-weight-optimization.md
+++ b/docs/plans/2026-03-19-phase25-scorer-weight-optimization.md
@@ -1,0 +1,599 @@
+# Phase 2.5 — MarketScorer Weight Optimization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Optimize the 5 MarketScorer dimension weights (tradeability, liquidity, volatility, ttr, dataQuality) using closed trade outcomes, so markets are scored in a way that predicts profitable trades.
+
+**Architecture:** A new `scorer_weights` DB table stores the current weights; MarketScorer loads them at scoring time (with fallback to hardcoded defaults). A new `ScorerWeightOptimizer` service runs a random-search optimization: for each trial it recomputes every closed trade's score using trial weights, then maximizes Pearson correlation(score, realized_pnl). A weekly scheduler job triggers it once ≥ 30 closed trades with score dimensions are available.
+
+**Tech Stack:** TypeScript, PostgreSQL/TimescaleDB, vitest, existing `query()` helper from `packages/data-collector/src/database/connection.ts`.
+
+---
+
+## Context
+
+- `paper_positions.score_dimensions_at_entry` (JSONB) — captures `{tradeability, liquidity, ttr, volatility: null, dataQuality: null}` when a position is opened. `volatility` and `dataQuality` are null because they require the price_history LATERAL JOIN that only MarketScorer has.
+- Since only 3 dims are captured at entry, the optimizer only tunes the relative weight of those 3. Volatility and dataQuality weights stay at their current defaults in the DB row.
+- `compositeScore()` already handles null dims by normalizing `sumW` over available dims — so passing partial dims (null volatility/dataQuality) to the objective is safe.
+- Current hardcoded weights: `{ tradeability: 0.30, liquidity: 0.25, volatility: 0.20, ttr: 0.15, dataQuality: 0.10 }`
+
+---
+
+### Task 1: DB migration + `ScorerWeights` interface + `compositeScore` accepts weights
+
+**Files:**
+- Create: `packages/data-collector/src/database/init/007_scorer_weights.sql`
+- Modify: `packages/data-collector/src/services/MarketScorer.ts` (types + compositeScore signature)
+- Test: `packages/data-collector/src/services/MarketScorer.test.ts` (add compositeScore with custom weights tests)
+
+**Step 1: Create the migration file**
+
+```sql
+-- packages/data-collector/src/database/init/007_scorer_weights.sql
+-- Stores the current MarketScorer dimension weights (single-row table).
+-- MarketScorer reads from here at each scoring run; fallback to code defaults.
+CREATE TABLE IF NOT EXISTS scorer_weights (
+  id             SERIAL PRIMARY KEY,
+  tradeability   FLOAT NOT NULL DEFAULT 0.30,
+  liquidity      FLOAT NOT NULL DEFAULT 0.25,
+  volatility     FLOAT NOT NULL DEFAULT 0.20,
+  ttr            FLOAT NOT NULL DEFAULT 0.15,
+  data_quality   FLOAT NOT NULL DEFAULT 0.10,
+  n_trades       INT,        -- trades used in last optimization
+  n_trials       INT,        -- trials run in last optimization
+  best_value     FLOAT,      -- best Pearson correlation achieved
+  updated_at     TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Seed default row (only if table is empty)
+INSERT INTO scorer_weights (tradeability, liquidity, volatility, ttr, data_quality)
+SELECT 0.30, 0.25, 0.20, 0.15, 0.10
+WHERE NOT EXISTS (SELECT 1 FROM scorer_weights);
+```
+
+**Step 2: Add `ScorerWeights` interface and update `compositeScore` in MarketScorer.ts**
+
+In `packages/data-collector/src/services/MarketScorer.ts`:
+
+Add `ScorerWeights` interface right after `ScoreDimensions` (around line 28):
+```typescript
+export interface ScorerWeights {
+  tradeability: number;
+  liquidity: number;
+  volatility: number;
+  ttr: number;
+  dataQuality: number;
+}
+```
+
+Change `compositeScore` signature to accept optional weights (find this method — it iterates over available dims and normalizes by sumW):
+```typescript
+static compositeScore(dims: ScoreDimensions, weights: ScorerWeights = WEIGHTS): number {
+  const available: Array<[number, number]> = [
+    [weights.tradeability, dims.tradeability],
+    [weights.liquidity, dims.liquidity],
+    [weights.volatility, dims.volatility ?? NaN],
+    [weights.ttr, dims.ttr],
+    [weights.dataQuality, dims.dataQuality ?? NaN],
+  ].filter(([, v]) => !isNaN(v) && v != null) as Array<[number, number]>;
+  const sumW = available.reduce((s, [w]) => s + w, 0);
+  if (sumW === 0) return 0;
+  return available.reduce((s, [w, v]) => s + w * v, 0) / sumW;
+}
+```
+
+Note: look at the actual current implementation to preserve its null-handling logic — just add the `weights` parameter.
+
+**Step 3: Write failing tests**
+
+Add to `packages/data-collector/src/services/MarketScorer.test.ts`:
+```typescript
+describe('compositeScore with custom weights', () => {
+  it('uses provided weights instead of defaults', () => {
+    const dims: ScoreDimensions = {
+      tradeability: 1.0,
+      liquidity: 0.0,
+      volatility: null,
+      ttr: 0.0,
+      dataQuality: null,
+    };
+    // With default weights: tradeability=0.30 dominates over ttr=0.15 with nulls removed
+    // With custom weights: tradeability=0.0 → score should be 0
+    const customWeights: ScorerWeights = {
+      tradeability: 0.0,
+      liquidity: 1.0,
+      volatility: 0.20,
+      ttr: 0.15,
+      dataQuality: 0.10,
+    };
+    expect(MarketScorer.compositeScore(dims, customWeights)).toBe(0);
+  });
+
+  it('falls back to default weights when no weights provided', () => {
+    const dims: ScoreDimensions = {
+      tradeability: 1.0, liquidity: 0.0, volatility: null, ttr: 0.0, dataQuality: null,
+    };
+    const withDefault = MarketScorer.compositeScore(dims);
+    const withExplicit = MarketScorer.compositeScore(dims, WEIGHTS);
+    expect(withDefault).toBe(withExplicit);
+  });
+});
+```
+
+**Step 4: Run tests**
+
+```bash
+pnpm test --filter data-collector
+```
+Expected: new tests FAIL (compositeScore doesn't accept weights yet)
+
+**Step 5: Implement the change**
+
+Make the edit to `MarketScorer.ts` as described in Step 2. Preserve all existing behavior — only change the signature and replace hardcoded `WEIGHTS` references inside `compositeScore` with the parameter.
+
+**Step 6: Run tests again**
+
+```bash
+pnpm test --filter data-collector
+```
+Expected: all tests PASS
+
+**Step 7: Commit**
+
+```bash
+git add packages/data-collector/src/database/init/007_scorer_weights.sql \
+        packages/data-collector/src/services/MarketScorer.ts \
+        packages/data-collector/src/services/MarketScorer.test.ts
+git commit -m "feat: add scorer_weights table and compositeScore accepts custom weights"
+```
+
+---
+
+### Task 2: `MarketScorer.loadWeights()` + `scoreAllMarkets` uses DB weights
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketScorer.ts`
+- Test: `packages/data-collector/src/services/MarketScorer.test.ts`
+
+**Step 1: Write failing test for loadWeights fallback**
+
+In `MarketScorer.test.ts`, add a test that mocks `query` to throw and expects the hardcoded defaults:
+```typescript
+import { vi } from 'vitest';
+import * as connection from '../database/connection.js';
+
+describe('loadWeights', () => {
+  it('returns hardcoded WEIGHTS when DB query fails', async () => {
+    vi.spyOn(connection, 'query').mockRejectedValueOnce(new Error('DB down'));
+    const weights = await MarketScorer.loadWeights();
+    expect(weights.tradeability).toBe(WEIGHTS.tradeability);
+    expect(weights.liquidity).toBe(WEIGHTS.liquidity);
+    expect(weights.ttr).toBe(WEIGHTS.ttr);
+    vi.restoreAllMocks();
+  });
+
+  it('returns hardcoded WEIGHTS when scorer_weights table is empty', async () => {
+    vi.spyOn(connection, 'query').mockResolvedValueOnce({ rows: [], rowCount: 0 } as any);
+    const weights = await MarketScorer.loadWeights();
+    expect(weights.tradeability).toBe(WEIGHTS.tradeability);
+    vi.restoreAllMocks();
+  });
+});
+```
+
+**Step 2: Run tests**
+
+```bash
+pnpm test --filter data-collector
+```
+Expected: FAIL with "loadWeights is not a function"
+
+**Step 3: Implement `loadWeights` static method**
+
+Add to `MarketScorer` class (before `scoreAllMarkets`):
+```typescript
+static async loadWeights(): Promise<ScorerWeights> {
+  try {
+    const result = await query<{
+      tradeability: number;
+      liquidity: number;
+      volatility: number;
+      ttr: number;
+      data_quality: number;
+    }>(
+      `SELECT tradeability, liquidity, volatility, ttr, data_quality
+       FROM scorer_weights
+       ORDER BY id DESC LIMIT 1`,
+    );
+    if (result.rows.length > 0) {
+      const r = result.rows[0];
+      return {
+        tradeability: r.tradeability,
+        liquidity: r.liquidity,
+        volatility: r.volatility,
+        ttr: r.ttr,
+        dataQuality: r.data_quality,
+      };
+    }
+  } catch {
+    // Table may not exist yet — fall through to defaults
+  }
+  return { ...WEIGHTS };
+}
+```
+
+**Step 4: Update `scoreAllMarkets` to load weights from DB**
+
+At the start of `scoreAllMarkets()`, after the logger call, add:
+```typescript
+const weights = await MarketScorer.loadWeights();
+const NORM = weights.tradeability + weights.liquidity + weights.ttr;
+```
+
+Then replace all `WEIGHTS.tradeability`, `WEIGHTS.liquidity`, `WEIGHTS.ttr` in the Pass 1 SQL template literals with `weights.tradeability`, `weights.liquidity`, `weights.ttr`.
+
+In Pass 2, change the `compositeScore` call to pass weights:
+```typescript
+const score = MarketScorer.compositeScore({
+  tradeability,
+  liquidity,
+  volatility,
+  ttr,
+  dataQuality,
+}, weights);
+```
+
+**Step 5: Run tests**
+
+```bash
+pnpm test --filter data-collector
+```
+Expected: all tests PASS
+
+**Step 6: Commit**
+
+```bash
+git add packages/data-collector/src/services/MarketScorer.ts \
+        packages/data-collector/src/services/MarketScorer.test.ts
+git commit -m "feat: MarketScorer loads dimension weights from DB (fallback to hardcoded)"
+```
+
+---
+
+### Task 3: `ScorerWeightOptimizer` service
+
+**Files:**
+- Create: `packages/data-collector/src/services/ScorerWeightOptimizer.ts`
+- Create: `packages/data-collector/src/services/ScorerWeightOptimizer.test.ts`
+
+**Step 1: Write failing tests**
+
+Create `packages/data-collector/src/services/ScorerWeightOptimizer.test.ts`:
+```typescript
+import { describe, it, expect } from 'vitest';
+import { pearsonCorrelation, computeObjective, MIN_TRADES } from './ScorerWeightOptimizer.js';
+import type { ScorerWeights } from './MarketScorer.js';
+
+describe('pearsonCorrelation', () => {
+  it('returns 1.0 for perfectly correlated series', () => {
+    expect(pearsonCorrelation([1, 2, 3, 4], [2, 4, 6, 8])).toBeCloseTo(1.0);
+  });
+
+  it('returns -1.0 for perfectly inversely correlated series', () => {
+    expect(pearsonCorrelation([1, 2, 3], [3, 2, 1])).toBeCloseTo(-1.0);
+  });
+
+  it('returns 0 for constant series (no variance)', () => {
+    expect(pearsonCorrelation([1, 1, 1], [1, 2, 3])).toBe(0);
+  });
+});
+
+describe('computeObjective', () => {
+  const weights: ScorerWeights = {
+    tradeability: 0.30, liquidity: 0.25, volatility: 0.20, ttr: 0.15, dataQuality: 0.10,
+  };
+
+  it('returns correlation of recomputed scores with pnl', () => {
+    const trades = [
+      { dims: { tradeability: 1.0, liquidity: 0.8, ttr: 0.9, volatility: null, dataQuality: null }, pnl: 10 },
+      { dims: { tradeability: 0.1, liquidity: 0.1, ttr: 0.2, volatility: null, dataQuality: null }, pnl: -5 },
+      { dims: { tradeability: 0.8, liquidity: 0.7, ttr: 0.8, volatility: null, dataQuality: null }, pnl: 7 },
+    ];
+    const result = computeObjective(weights, trades);
+    expect(result).toBeGreaterThan(0); // high-score trades have positive pnl
+    expect(result).toBeLessThanOrEqual(1);
+  });
+
+  it('returns 0 when all pnl are identical (no variance)', () => {
+    const trades = [
+      { dims: { tradeability: 0.5, liquidity: 0.5, ttr: 0.5, volatility: null, dataQuality: null }, pnl: 5 },
+      { dims: { tradeability: 0.8, liquidity: 0.8, ttr: 0.8, volatility: null, dataQuality: null }, pnl: 5 },
+    ];
+    expect(computeObjective(weights, trades)).toBe(0);
+  });
+});
+
+describe('MIN_TRADES', () => {
+  it('is 30', () => {
+    expect(MIN_TRADES).toBe(30);
+  });
+});
+```
+
+**Step 2: Run tests**
+
+```bash
+pnpm test --filter data-collector
+```
+Expected: FAIL with import errors (file not created yet)
+
+**Step 3: Implement `ScorerWeightOptimizer.ts`**
+
+Create `packages/data-collector/src/services/ScorerWeightOptimizer.ts`:
+```typescript
+import { pino } from 'pino';
+import { query } from '../database/connection.js';
+import { MarketScorer, WEIGHTS, type ScorerWeights, type ScoreDimensions } from './MarketScorer.js';
+
+const logger = pino({ name: 'ScorerWeightOptimizer' });
+
+export const MIN_TRADES = 30;
+const N_TRIALS = 300;
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface ClosedTrade {
+  dims: ScoreDimensions;
+  pnl: number;
+}
+
+// ── Pure helpers (exported for testing) ────────────────────────────────────
+
+export function pearsonCorrelation(xs: number[], ys: number[]): number {
+  const n = xs.length;
+  if (n === 0) return 0;
+  const mx = xs.reduce((a, b) => a + b, 0) / n;
+  const my = ys.reduce((a, b) => a + b, 0) / n;
+  const num = xs.reduce((s, x, i) => s + (x - mx) * (ys[i] - my), 0);
+  const dx = Math.sqrt(xs.reduce((s, x) => s + (x - mx) ** 2, 0));
+  const dy = Math.sqrt(ys.reduce((s, y) => s + (y - my) ** 2, 0));
+  if (dx === 0 || dy === 0) return 0;
+  return num / (dx * dy);
+}
+
+export function computeObjective(weights: ScorerWeights, trades: ClosedTrade[]): number {
+  const scores = trades.map((t) => MarketScorer.compositeScore(t.dims, weights));
+  const pnls = trades.map((t) => t.pnl);
+  return pearsonCorrelation(scores, pnls);
+}
+
+// ── Random-search optimizer ────────────────────────────────────────────────
+
+function randomWeights(): ScorerWeights {
+  // Sample 3 positive floats for the dims we can optimize (ttr, tradeability, liquidity)
+  // volatility and dataQuality stay at current defaults
+  const r = () => Math.random() * 0.6 + 0.05; // uniform [0.05, 0.65]
+  return {
+    tradeability: r(),
+    liquidity:    r(),
+    volatility:   WEIGHTS.volatility,
+    ttr:          r(),
+    dataQuality:  WEIGHTS.dataQuality,
+  };
+}
+
+// ── DB helpers ─────────────────────────────────────────────────────────────
+
+async function loadClosedTrades(): Promise<ClosedTrade[]> {
+  const result = await query<{
+    score_dimensions_at_entry: Record<string, number | null>;
+    realized_pnl: string;
+  }>(
+    `SELECT score_dimensions_at_entry, realized_pnl
+     FROM paper_positions
+     WHERE closed_at IS NOT NULL
+       AND score_dimensions_at_entry IS NOT NULL
+       AND realized_pnl IS NOT NULL`,
+  );
+  return result.rows.map((r) => {
+    const d = r.score_dimensions_at_entry;
+    return {
+      dims: {
+        tradeability: d.tradeability ?? 0,
+        liquidity:    d.liquidity    ?? 0,
+        volatility:   d.volatility   ?? null,
+        ttr:          d.ttr          ?? 0,
+        dataQuality:  d.dataQuality  ?? null,
+      },
+      pnl: parseFloat(r.realized_pnl),
+    };
+  });
+}
+
+async function saveWeights(weights: ScorerWeights, meta: { nTrades: number; nTrials: number; bestValue: number }): Promise<void> {
+  await query(
+    `UPDATE scorer_weights
+     SET tradeability = $1, liquidity = $2, volatility = $3, ttr = $4, data_quality = $5,
+         n_trades = $6, n_trials = $7, best_value = $8, updated_at = NOW()
+     WHERE id = (SELECT id FROM scorer_weights ORDER BY id DESC LIMIT 1)`,
+    [
+      weights.tradeability, weights.liquidity, weights.volatility,
+      weights.ttr, weights.dataQuality,
+      meta.nTrades, meta.nTrials, meta.bestValue,
+    ],
+  );
+}
+
+// ── Main entry point ───────────────────────────────────────────────────────
+
+export async function optimizeScorerWeights(): Promise<void> {
+  const trades = await loadClosedTrades();
+  logger.info({ n: trades.length }, 'Loaded closed trades for scorer weight optimization');
+
+  if (trades.length < MIN_TRADES) {
+    logger.info({ n: trades.length, required: MIN_TRADES }, 'Not enough trades — skipping optimization');
+    return;
+  }
+
+  let bestValue = -Infinity;
+  let bestWeights: ScorerWeights = { ...WEIGHTS };
+
+  for (let i = 0; i < N_TRIALS; i++) {
+    const candidate = randomWeights();
+    const value = computeObjective(candidate, trades);
+    if (value > bestValue) {
+      bestValue = value;
+      bestWeights = candidate;
+    }
+  }
+
+  logger.info({ bestValue, bestWeights }, 'Optimization complete');
+
+  await saveWeights(bestWeights, { nTrades: trades.length, nTrials: N_TRIALS, bestValue });
+  logger.info('Scorer weights updated in DB');
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+pnpm test --filter data-collector
+```
+Expected: all tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/data-collector/src/services/ScorerWeightOptimizer.ts \
+        packages/data-collector/src/services/ScorerWeightOptimizer.test.ts
+git commit -m "feat: add ScorerWeightOptimizer with Pearson correlation objective"
+```
+
+---
+
+### Task 4: Wire optimizer into data-collector scheduler as weekly job
+
+**Files:**
+- Modify: `packages/data-collector/src/services/Scheduler.ts` (or wherever jobs are registered)
+
+**Step 1: Find where jobs are registered**
+
+```bash
+grep -r "sync-markets\|prune-zombies\|addJob\|schedule" packages/data-collector/src --include="*.ts" -l
+```
+
+Open the Scheduler file and read how existing jobs are registered (the `sync-markets` job runs at `:17` hourly — follow the same pattern).
+
+**Step 2: Add the weekly job**
+
+In the scheduler file, import `optimizeScorerWeights`:
+```typescript
+import { optimizeScorerWeights } from './ScorerWeightOptimizer.js';
+```
+
+Add the job (after existing jobs):
+```typescript
+// Every Monday at 03:17 UTC — optimize MarketScorer dimension weights
+scheduler.addJob('optimize-scorer-weights', '17 3 * * 1', async () => {
+  await optimizeScorerWeights();
+});
+```
+
+(Adjust the `addJob` call to match the actual API used by the existing jobs.)
+
+**Step 3: Run tests**
+
+```bash
+pnpm test
+```
+Expected: all 447+ tests pass
+
+**Step 4: Commit**
+
+```bash
+git add packages/data-collector/src/services/Scheduler.ts
+git commit -m "feat: run scorer weight optimization weekly (Mon 03:17 UTC)"
+```
+
+---
+
+### Task 5: Apply migration to VM + verify
+
+**Step 1: Push to remote**
+
+```bash
+gh auth switch --user JaviMaligno
+git push origin main
+```
+
+Wait for CI deploy to complete:
+```bash
+gh run watch $(gh run list --limit 1 --json databaseId --jq '.[0].databaseId') --exit-status
+```
+
+**Step 2: Apply migration manually to VM**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="
+docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+CREATE TABLE IF NOT EXISTS scorer_weights (
+  id SERIAL PRIMARY KEY,
+  tradeability FLOAT NOT NULL DEFAULT 0.30,
+  liquidity FLOAT NOT NULL DEFAULT 0.25,
+  volatility FLOAT NOT NULL DEFAULT 0.20,
+  ttr FLOAT NOT NULL DEFAULT 0.15,
+  data_quality FLOAT NOT NULL DEFAULT 0.10,
+  n_trades INT, n_trials INT, best_value FLOAT,
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+INSERT INTO scorer_weights (tradeability, liquidity, volatility, ttr, data_quality)
+SELECT 0.30, 0.25, 0.20, 0.15, 0.10
+WHERE NOT EXISTS (SELECT 1 FROM scorer_weights);
+\""
+```
+
+**Step 3: Verify table created and seeded**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="
+docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+SELECT tradeability, liquidity, volatility, ttr, data_quality, updated_at FROM scorer_weights;\""
+```
+
+Expected:
+```
+ tradeability | liquidity | volatility |  ttr  | data_quality |          updated_at
+--------------+-----------+------------+-------+--------------+-------------------------------
+         0.30 |      0.25 |       0.20 |  0.15 |         0.10 | 2026-03-19 ...
+```
+
+**Step 4: Verify containers restarted and MarketScorer loads from DB**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="
+docker logs polymarket-data-collector --tail=50 | grep -i 'scorer\|weight\|pass 1\|scoring'"
+```
+
+Expected to see: scoring log line (at next :17) with no errors. If the table exists and has a row, `loadWeights` returns DB values (same as defaults for now).
+
+**Step 5: Confirm next scoring run uses DB weights**
+
+After the :17 scoring run:
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="
+docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+SELECT COUNT(*), MAX(time) FROM market_score_history;\""
+```
+
+Expected: `MAX(time)` updated to current hour :17. ✅
+
+**Step 6: Commit any final fixes, then done.**
+
+---
+
+## Notes for Phase 3 (future)
+
+- Capture `volatility` and `dataQuality` at entry by running the price_history LATERAL JOIN in `openPosition()` — this would let the optimizer tune all 5 weights.
+- Upgrade random search to Optuna (call existing Render optimizer endpoint) once >100 trades available.
+- Add `scorer_weights_history` hypertable to track weight evolution over time.
+- Consider using Spearman instead of Pearson correlation once outlier PnL values become a concern.

--- a/docs/plans/2026-03-19-score-history.md
+++ b/docs/plans/2026-03-19-score-history.md
@@ -1,0 +1,487 @@
+# Score History Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Capture market score at trade entry and persist hourly score snapshots so Phase 2.5 (Optuna weight optimization) has the data it needs.
+
+**Architecture:** Three changes: (1) SQL migration adds `market_score_at_entry` + `score_dimensions_at_entry` to `paper_positions` and creates `market_score_history` hypertable; (2) `MarketScorer.scoreAllMarkets()` writes a snapshot of tracked + top-50 cold markets after each scoring run; (3) `AutoSignalExecutor.openPosition()` queries the markets table and stores the composite score + 3 cheap dimensions (tradeability, liquidity, ttr) in the position row at the moment of entry.
+
+**Tech Stack:** TypeScript, PostgreSQL/TimescaleDB, no new packages.
+
+---
+
+### Task 1: Migration SQL
+
+**Files:**
+- Create: `packages/data-collector/src/database/init/006_score_history.sql`
+
+**Step 1: Write the migration**
+
+```sql
+-- Score capture on positions (for Optuna Phase 2.5)
+ALTER TABLE paper_positions
+  ADD COLUMN IF NOT EXISTS market_score_at_entry FLOAT,
+  ADD COLUMN IF NOT EXISTS score_dimensions_at_entry JSONB;
+
+-- market_score_history: hourly snapshots of tracked + top-50 cold markets
+CREATE TABLE IF NOT EXISTS market_score_history (
+  time                  TIMESTAMPTZ  NOT NULL,
+  condition_id          VARCHAR      NOT NULL,
+  tracking_status       VARCHAR(10),
+  market_score          FLOAT,
+  score_tradeability    FLOAT,
+  score_liquidity       FLOAT,
+  score_ttr             FLOAT,
+  score_volatility      FLOAT,
+  score_data_quality    FLOAT,
+  current_price_yes     FLOAT,
+  volume_24h            FLOAT
+);
+
+SELECT create_hypertable('market_score_history', 'time',
+  chunk_time_interval => INTERVAL '7 days',
+  if_not_exists => TRUE
+);
+
+-- Retention: 90 days is enough for Optuna
+SELECT add_retention_policy('market_score_history', INTERVAL '90 days', if_not_exists => TRUE);
+
+-- Compress chunks older than 7 days
+ALTER TABLE market_score_history SET (
+  timescaledb.compress,
+  timescaledb.compress_orderby = 'time DESC',
+  timescaledb.compress_segmentby = 'condition_id'
+);
+SELECT add_compression_policy('market_score_history', INTERVAL '7 days', if_not_exists => TRUE);
+
+CREATE INDEX IF NOT EXISTS idx_msh_condition_time
+  ON market_score_history (condition_id, time DESC);
+```
+
+**Step 2: Apply manually to VM** (init scripts don't re-run)
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "docker exec -i polymarket-timescaledb psql -U polymarket -d polymarket_trading" \
+  < packages/data-collector/src/database/init/006_score_history.sql
+```
+
+Verify:
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \
+  \"SELECT column_name FROM information_schema.columns WHERE table_name='paper_positions' AND column_name LIKE 'score%'; SELECT hypertable_name FROM timescaledb_information.hypertables WHERE hypertable_name='market_score_history';\""
+```
+
+Expected: rows for `market_score_at_entry`, `score_dimensions_at_entry`, and `market_score_history`.
+
+**Step 3: Commit**
+
+```bash
+git add packages/data-collector/src/database/init/006_score_history.sql
+git commit -m "feat: add score history migration (paper_positions + market_score_history hypertable)"
+```
+
+---
+
+### Task 2: MarketScorer — write to market_score_history
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketScorer.ts`
+
+**Context:** `scoreAllMarkets()` already has `enrichUpdates` built during the Pass 2 loop (lines 281–312). Each element has `conditionId` and `score`. We need to extend it with dimension data and then insert all tracked + top-50 cold into `market_score_history`.
+
+**Step 1: Extend the enrichUpdates type and data collection**
+
+In `scoreAllMarkets()`, change the `enrichUpdates` array type (line 281) and extend each push in the loop to include dimensions and market data:
+
+Old type:
+```typescript
+const enrichUpdates: Array<{ conditionId: string; score: number }> = [];
+```
+
+New type:
+```typescript
+const enrichUpdates: Array<{
+  conditionId: string;
+  score: number;
+  tradeability: number;
+  liquidity: number;
+  ttr: number;
+  volatility: number | null;
+  dataQuality: number | null;
+  currentPriceYes: number | null;
+  volume24h: number | null;
+}> = [];
+```
+
+And at the `enrichUpdates.push(...)` call (line 311), change to:
+```typescript
+enrichUpdates.push({
+  conditionId: row.condition_id,
+  score,
+  tradeability,
+  liquidity,
+  ttr,
+  volatility,
+  dataQuality,
+  currentPriceYes: row.current_price_yes != null ? Number(row.current_price_yes) : null,
+  volume24h: row.volume_24h != null ? Number(row.volume_24h) : null,
+});
+```
+
+**Step 2: Add private method `writeScoreHistory`**
+
+After `batchUpdateScores`, add a new private method:
+
+```typescript
+private async writeScoreHistory(
+  tracked: Array<{
+    conditionId: string;
+    score: number;
+    tradeability: number;
+    liquidity: number;
+    ttr: number;
+    volatility: number | null;
+    dataQuality: number | null;
+    currentPriceYes: number | null;
+    volume24h: number | null;
+  }>,
+): Promise<void> {
+  // Top 50 cold markets by score (no dimension breakdown — Pass 1 SQL doesn't return them)
+  const coldResult = await query<{
+    condition_id: string;
+    market_score: number | null;
+    current_price_yes: number | null;
+    volume_24h: number | null;
+  }>(`
+    SELECT condition_id, market_score, current_price_yes, volume_24h
+    FROM   markets
+    WHERE  is_active = true
+      AND  is_resolved = false
+      AND  tracking_status = 'cold'
+      AND  market_score > 0
+    ORDER  BY market_score DESC
+    LIMIT  50
+  `);
+
+  const now = new Date();
+
+  // Build rows: tracked (with dimensions) + cold top-50 (dimensions null)
+  const trackedRows = tracked.map((u) => ({
+    time: now,
+    condition_id: u.conditionId,
+    tracking_status: null as string | null, // enriched separately
+    market_score: u.score,
+    score_tradeability: u.tradeability,
+    score_liquidity: u.liquidity,
+    score_ttr: u.ttr,
+    score_volatility: u.volatility,
+    score_data_quality: u.dataQuality,
+    current_price_yes: u.currentPriceYes,
+    volume_24h: u.volume24h,
+  }));
+
+  const coldRows = coldResult.rows.map((r) => ({
+    time: now,
+    condition_id: r.condition_id,
+    tracking_status: 'cold' as string | null,
+    market_score: r.market_score != null ? Number(r.market_score) : null,
+    score_tradeability: null as number | null,
+    score_liquidity: null as number | null,
+    score_ttr: null as number | null,
+    score_volatility: null as number | null,
+    score_data_quality: null as number | null,
+    current_price_yes: r.current_price_yes != null ? Number(r.current_price_yes) : null,
+    volume_24h: r.volume_24h != null ? Number(r.volume_24h) : null,
+  }));
+
+  const all = [...trackedRows, ...coldRows];
+  if (all.length === 0) return;
+
+  // Single multi-row INSERT
+  const values = all
+    .map((_, i) => {
+      const base = i * 11;
+      return `($${base+1},$${base+2},$${base+3},$${base+4},$${base+5},$${base+6},$${base+7},$${base+8},$${base+9},$${base+10},$${base+11})`;
+    })
+    .join(', ');
+
+  const params = all.flatMap((r) => [
+    r.time, r.condition_id, r.tracking_status,
+    r.market_score, r.score_tradeability, r.score_liquidity, r.score_ttr,
+    r.score_volatility, r.score_data_quality, r.current_price_yes, r.volume_24h,
+  ]);
+
+  await query(
+    `INSERT INTO market_score_history
+       (time, condition_id, tracking_status, market_score,
+        score_tradeability, score_liquidity, score_ttr,
+        score_volatility, score_data_quality, current_price_yes, volume_24h)
+     VALUES ${values}`,
+    params,
+  );
+
+  logger.info({ tracked: trackedRows.length, cold: coldRows.length }, 'Score history written');
+}
+```
+
+**Step 3: Call writeScoreHistory from scoreAllMarkets**
+
+After `await this.batchUpdateScores(enrichUpdates);` and before `const enriched = enrichUpdates.length;`, add:
+
+```typescript
+// Write score history snapshot (fire-and-forget — don't block scoring)
+this.writeScoreHistory(enrichUpdates).catch((err) =>
+  logger.warn({ err }, 'writeScoreHistory failed — non-critical'),
+);
+```
+
+**Step 4: Run build and tests**
+
+```bash
+cd C:\Users\Usuario\GitHub\polymarket-trader
+pnpm build
+npx vitest --run packages/data-collector
+```
+
+Expected: clean build, all tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add packages/data-collector/src/services/MarketScorer.ts
+git commit -m "feat: write hourly score snapshots to market_score_history"
+```
+
+---
+
+### Task 3: repositories.ts — add score fields to PaperPosition
+
+**Files:**
+- Modify: `packages/dashboard/src/database/repositories.ts`
+
+**Context:** `PaperPosition` type is around line 310. The `upsert` INSERT is at line 329. The ON CONFLICT update must NOT overwrite `market_score_at_entry` if it's already set (position updates happen throughout the life of a position).
+
+**Step 1: Add fields to PaperPosition type**
+
+Find the `PaperPosition` interface (around line 305) and add:
+```typescript
+market_score_at_entry?: number | null;
+score_dimensions_at_entry?: Record<string, unknown> | null;
+```
+
+**Step 2: Update INSERT in upsert()**
+
+Change the INSERT column list to include the new fields:
+```sql
+INSERT INTO paper_positions
+ (market_id, token_id, side, size, avg_entry_price, current_price,
+  unrealized_pnl, unrealized_pnl_pct, realized_pnl, stop_loss, take_profit,
+  opened_at, signal_type, metadata, market_score_at_entry, score_dimensions_at_entry)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+ON CONFLICT (market_id, token_id) DO UPDATE SET
+  ...existing fields...,
+  market_score_at_entry = COALESCE(paper_positions.market_score_at_entry, EXCLUDED.market_score_at_entry),
+  score_dimensions_at_entry = COALESCE(paper_positions.score_dimensions_at_entry, EXCLUDED.score_dimensions_at_entry)
+```
+
+`COALESCE(existing, new)` means: keep the original entry value if already set, only write on first insert.
+
+Add `position.market_score_at_entry ?? null` and `position.score_dimensions_at_entry ? JSON.stringify(position.score_dimensions_at_entry) : null` to the params array.
+
+**Step 3: Run build and tests**
+
+```bash
+pnpm build
+npx vitest --run packages/dashboard
+```
+
+**Step 4: Commit**
+
+```bash
+git add packages/dashboard/src/database/repositories.ts
+git commit -m "feat: add market_score_at_entry and score_dimensions_at_entry to PaperPosition"
+```
+
+---
+
+### Task 4: AutoSignalExecutor — capture score at entry
+
+**Files:**
+- Modify: `packages/dashboard/src/services/AutoSignalExecutor.ts`
+
+**Context:** `openPosition()` starts at line 338. At line 474, it calls `paperPositionsRepo.upsert()`. We need to add a markets query just before that upsert, compute 3 dimensions inline, and pass them.
+
+**Step 1: Add markets query before the upsert (around line 471)**
+
+Between the capital check (line 416) and the signal prediction recording (line 421), add:
+
+```typescript
+// Fetch market score for entry capture (non-critical — don't fail trade if missing)
+let marketScoreAtEntry: number | null = null;
+let scoreDimensionsAtEntry: Record<string, unknown> | null = null;
+try {
+  const mktResult = await query<{
+    market_score: string | null;
+    current_price_yes: string | null;
+    volume_24h: string | null;
+    spread: string | null;
+    end_date: string | null;
+  }>(
+    `SELECT market_score, current_price_yes, volume_24h, spread, end_date
+     FROM   markets
+     WHERE  condition_id = $1`,
+    [signal.marketId],
+  );
+  if (mktResult.rows.length > 0) {
+    const m = mktResult.rows[0];
+    marketScoreAtEntry = m.market_score != null ? Number(m.market_score) : null;
+
+    // Compute 3 cheap dimensions inline (mirrors MarketScorer static methods)
+    const price = m.current_price_yes != null ? Number(m.current_price_yes) : null;
+    const vol = m.volume_24h != null ? Number(m.volume_24h) : null;
+    const sprd = m.spread != null ? Number(m.spread) : null;
+    const endDate = m.end_date ? new Date(m.end_date) : null;
+
+    const tradeability = computeTradeability(price);
+    const liquidity = computeLiquidity(vol, sprd);
+    const ttr = computeTtr(endDate);
+
+    scoreDimensionsAtEntry = { tradeability, liquidity, ttr, volatility: null, dataQuality: null };
+  }
+} catch (err) {
+  // Non-critical — trade proceeds without score capture
+}
+```
+
+**Step 2: Add the 3 inline helper functions** (module-level, before the class)
+
+```typescript
+function clamp01(v: number): number { return Math.min(1, Math.max(0, v)); }
+
+function computeTradeability(price: number | null): number {
+  if (price === null) return 0;
+  if (price < 0.05 || price > 0.95) return 0;
+  if (price >= 0.45 && price <= 0.55) return 0;
+  if (price >= 0.15 && price <= 0.40) return 1.0;
+  if (price >= 0.60 && price <= 0.85) return 1.0;
+  if (price >= 0.05 && price < 0.15) return clamp01((price - 0.05) / 0.10);
+  if (price > 0.40 && price < 0.45) return clamp01((0.45 - price) / 0.05);
+  if (price > 0.55 && price < 0.60) return clamp01((price - 0.55) / 0.05);
+  if (price > 0.85 && price <= 0.95) return clamp01((0.95 - price) / 0.10);
+  return 0;
+}
+
+const MAX_VOLUME_REF = 30_000_000;
+function computeLiquidity(volume: number | null, spread: number | null): number {
+  if (volume === null || volume <= 0) return 0;
+  const raw = clamp01(Math.log(volume) / Math.log(MAX_VOLUME_REF));
+  return spread !== null && spread > 0.03 ? raw * 0.5 : raw;
+}
+
+function computeTtr(endDate: Date | null): number {
+  if (endDate === null) return 0.5;
+  const days = (endDate.getTime() - Date.now()) / 86_400_000;
+  if (days <= 0) return 0;
+  if (days < 1) return 0.1;
+  if (days <= 7) return 0.1 + 0.9 * (days - 1) / 6;
+  if (days <= 60) return 1.0;
+  if (days <= 180) return 1.0 - 0.5 * (days - 60) / 120;
+  return 0.5;
+}
+```
+
+**Step 3: Pass the score fields into the upsert call (line 474)**
+
+```typescript
+await paperPositionsRepo.upsert({
+  market_id: signal.marketId,
+  token_id: signal.tokenId,
+  side: signal.direction === 'long' ? 'long' : 'short',
+  size: shares,
+  avg_entry_price: signal.price,
+  current_price: signal.price,
+  unrealized_pnl: 0,
+  opened_at: new Date(),
+  signal_type: signal.signalId,
+  market_score_at_entry: marketScoreAtEntry,
+  score_dimensions_at_entry: scoreDimensionsAtEntry ?? undefined,
+});
+```
+
+**Step 4: Run build and tests**
+
+```bash
+pnpm build
+npx vitest --run packages/dashboard
+```
+
+**Step 5: Commit and push**
+
+```bash
+git add packages/dashboard/src/services/AutoSignalExecutor.ts
+git commit -m "feat: capture market_score_at_entry and score dimensions when opening position"
+git push origin main
+```
+
+---
+
+### Task 5: VM deploy and verify
+
+**Step 1: Wait for CI to build and deploy** (or force manually if needed)
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "cd /home/Usuario/polymarket-trader && git pull origin main && \
+   docker compose -f docker-compose.gcp.yml pull && \
+   docker compose -f docker-compose.gcp.yml up -d --remove-orphans"
+```
+
+**Step 2: Verify migration columns exist**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \
+  \"SELECT column_name, data_type FROM information_schema.columns WHERE table_name='paper_positions' AND column_name LIKE '%score%';\""
+```
+
+Expected: `market_score_at_entry | double precision`, `score_dimensions_at_entry | jsonb`
+
+**Step 3: Verify market_score_history exists and is a hypertable**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \
+  \"SELECT hypertable_name, num_chunks FROM timescaledb_information.hypertables WHERE hypertable_name='market_score_history';\""
+```
+
+**Step 4: After next scoring run (:17), verify rows were written**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \
+  \"SELECT COUNT(*), MAX(time), AVG(market_score) FROM market_score_history WHERE time > NOW() - INTERVAL '2 hours';\""
+```
+
+**Step 5: After next trade, verify score was captured**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \
+  \"SELECT market_id, market_score_at_entry, score_dimensions_at_entry FROM paper_positions WHERE market_score_at_entry IS NOT NULL ORDER BY opened_at DESC LIMIT 5;\""
+```
+
+---
+
+## Summary
+
+| Task | What it does | Package |
+|------|-------------|---------|
+| 1 | SQL migration: new columns + hypertable | data-collector (migration) |
+| 2 | MarketScorer writes hourly snapshots | data-collector |
+| 3 | PaperPosition type + upsert updated | dashboard |
+| 4 | Score captured at trade entry | dashboard |
+| 5 | VM deploy + verification | ops |
+
+**Data lost without this**: every trade opened before this is deployed has no score history. Each day of delay = data lost forever.

--- a/docs/plans/2026-03-20-phase2-feedback-loop.md
+++ b/docs/plans/2026-03-20-phase2-feedback-loop.md
@@ -1,0 +1,430 @@
+# Phase 2: Category Feedback Loop Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Multiply market scores by a learned performance prior per category (crypto_intraday, crypto_daily, event_short, event_long), so categories that produce profitable trades get boosted (+50% max) and unprofitable ones get penalized (-50% max).
+
+**Architecture:** A `MarketPerformanceTracker` service in data-collector queries closed trades grouped by `markets.market_type`, computes Sharpe ratio per category, derives a prior via sigmoid, and writes it to a `category_performance` table. MarketScorer reads these priors and multiplies `score × prior` in both Pass 1 (SQL) and Pass 2 (enrichment). A daily cron job triggers the recomputation.
+
+**Tech Stack:** TypeScript, PostgreSQL, vitest, existing `query()` from `packages/data-collector/src/database/connection.ts`.
+
+---
+
+## Context
+
+- `markets.market_type` column (`VARCHAR(20)`) is populated by `MarketClassifier` (in dashboard package) via regex/Haiku. Values: `crypto_intraday`, `crypto_daily`, `event_short`, `event_long`. Some markets have `NULL` market_type (unclassified).
+- `paper_positions` has `market_id` (= `markets.id`), `realized_pnl`, `closed_at`.
+- Prior formula (corrected from design doc): `prior = 0.5 + sigmoid(sharpe × 2)`, bounded [0.5, 1.5]. At sharpe=0 → prior=1.0 (neutral). Design doc wrote `0.5 + 0.5 × sigmoid(...)` but that gives 0.75 at sharpe=0, contradicting the comment "neutral → 1.0".
+- Categories with <5 closed trades use default prior 1.0.
+- `MarketScorer.scoreAllMarkets()` already loads weights from DB at the start. Priors follow the same pattern.
+
+---
+
+### Task 1: Migration `008_category_performance.sql`
+
+**Files:**
+- Create: `packages/data-collector/src/database/init/008_category_performance.sql`
+
+**Step 1: Create the migration file**
+
+```sql
+-- 008_category_performance.sql
+-- Stores per-category performance metrics and computed priors.
+-- MarketPerformanceTracker writes here daily; MarketScorer reads priors at scoring time.
+CREATE TABLE IF NOT EXISTS category_performance (
+  market_type  VARCHAR(20) PRIMARY KEY,
+  win_rate     FLOAT,
+  avg_pnl      FLOAT,
+  sharpe_ratio FLOAT,
+  n_trades     INT NOT NULL DEFAULT 0,
+  prior        FLOAT NOT NULL DEFAULT 1.0,
+  updated_at   TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Seed with default priors for the 4 known categories
+INSERT INTO category_performance (market_type, prior) VALUES
+  ('crypto_intraday', 1.0),
+  ('crypto_daily', 1.0),
+  ('event_short', 1.0),
+  ('event_long', 1.0)
+ON CONFLICT (market_type) DO NOTHING;
+```
+
+**Step 2: Commit**
+
+```bash
+git add packages/data-collector/src/database/init/008_category_performance.sql
+git commit -m "feat: add category_performance table for Phase 2 feedback loop"
+```
+
+---
+
+### Task 2: `MarketPerformanceTracker` service
+
+**Files:**
+- Create: `packages/data-collector/src/services/MarketPerformanceTracker.ts`
+- Create: `packages/data-collector/src/services/MarketPerformanceTracker.test.ts`
+
+**Step 1: Write failing tests**
+
+Create `packages/data-collector/src/services/MarketPerformanceTracker.test.ts`:
+```typescript
+import { describe, it, expect } from 'vitest';
+import { computePrior, MIN_CATEGORY_TRADES } from './MarketPerformanceTracker.js';
+
+describe('computePrior', () => {
+  it('returns 1.0 for sharpe = 0 (neutral)', () => {
+    expect(computePrior(0)).toBeCloseTo(1.0);
+  });
+
+  it('returns ~0.5 for very negative sharpe', () => {
+    expect(computePrior(-10)).toBeCloseTo(0.5, 1);
+  });
+
+  it('returns ~1.5 for very positive sharpe', () => {
+    expect(computePrior(10)).toBeCloseTo(1.5, 1);
+  });
+
+  it('is bounded to [0.5, 1.5]', () => {
+    expect(computePrior(-100)).toBeGreaterThanOrEqual(0.5);
+    expect(computePrior(100)).toBeLessThanOrEqual(1.5);
+  });
+
+  it('is monotonically increasing', () => {
+    expect(computePrior(-1)).toBeLessThan(computePrior(0));
+    expect(computePrior(0)).toBeLessThan(computePrior(1));
+  });
+});
+
+describe('MIN_CATEGORY_TRADES', () => {
+  it('is 5', () => {
+    expect(MIN_CATEGORY_TRADES).toBe(5);
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cd C:/Users/Usuario/GitHub/polymarket-trader && pnpm test --filter data-collector 2>&1 | tail -15
+```
+
+**Step 3: Implement `MarketPerformanceTracker.ts`**
+
+```typescript
+import { pino } from 'pino';
+import { query } from '../database/connection.js';
+
+const logger = pino({ name: 'MarketPerformanceTracker' });
+
+export const MIN_CATEGORY_TRADES = 5;
+
+// ── Pure helpers (exported for testing) ────────────────────────────────────
+
+/** prior = 0.5 + sigmoid(sharpe × 2), bounded [0.5, 1.5] */
+export function computePrior(sharpe: number): number {
+  const sigmoid = 1 / (1 + Math.exp(-sharpe * 2));
+  return Math.min(1.5, Math.max(0.5, 0.5 + sigmoid));
+}
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface CategoryStats {
+  market_type: string;
+  n_trades: number;
+  win_rate: number;
+  avg_pnl: number;
+  sharpe_ratio: number;
+}
+
+// ── Main entry point ───────────────────────────────────────────────────────
+
+export async function updateCategoryPriors(): Promise<void> {
+  const result = await query<{
+    market_type: string;
+    n_trades: string;
+    win_rate: string;
+    avg_pnl: string;
+    sharpe_ratio: string;
+  }>(`
+    SELECT m.market_type,
+           COUNT(*)::text AS n_trades,
+           AVG(CASE WHEN p.realized_pnl > 0 THEN 1.0 ELSE 0.0 END)::text AS win_rate,
+           AVG(p.realized_pnl)::text AS avg_pnl,
+           CASE WHEN STDDEV(p.realized_pnl) > 0
+                THEN (AVG(p.realized_pnl) / STDDEV(p.realized_pnl))::text
+                ELSE '0' END AS sharpe_ratio
+    FROM paper_positions p
+    JOIN markets m ON p.market_id = m.id
+    WHERE p.closed_at IS NOT NULL
+      AND p.realized_pnl IS NOT NULL
+      AND m.market_type IS NOT NULL
+    GROUP BY m.market_type
+  `);
+
+  logger.info({ categories: result.rows.length }, 'Computed category performance');
+
+  for (const row of result.rows) {
+    const nTrades = parseInt(row.n_trades, 10);
+    const sharpe = parseFloat(row.sharpe_ratio);
+    const prior = nTrades >= MIN_CATEGORY_TRADES ? computePrior(sharpe) : 1.0;
+
+    await query(
+      `INSERT INTO category_performance (market_type, win_rate, avg_pnl, sharpe_ratio, n_trades, prior, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, NOW())
+       ON CONFLICT (market_type) DO UPDATE SET
+         win_rate = $2, avg_pnl = $3, sharpe_ratio = $4, n_trades = $5, prior = $6, updated_at = NOW()`,
+      [row.market_type, parseFloat(row.win_rate), parseFloat(row.avg_pnl), sharpe, nTrades, prior],
+    );
+
+    logger.info({ market_type: row.market_type, nTrades, sharpe: sharpe.toFixed(3), prior: prior.toFixed(3) },
+      'Updated category prior');
+  }
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+pnpm test 2>&1 | tail -10
+```
+
+**Step 5: Commit**
+
+```bash
+git add packages/data-collector/src/services/MarketPerformanceTracker.ts \
+        packages/data-collector/src/services/MarketPerformanceTracker.test.ts
+git commit -m "feat: add MarketPerformanceTracker with category-level Sharpe priors"
+```
+
+---
+
+### Task 3: MarketScorer loads and applies category priors
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketScorer.ts`
+- Test: `packages/data-collector/src/services/MarketScorer.test.ts`
+
+**Step 1: Write failing tests**
+
+Add to `MarketScorer.test.ts`:
+```typescript
+describe('loadCategoryPriors', () => {
+  it('returns empty map when DB query throws', async () => {
+    vi.spyOn(connection, 'query').mockRejectedValueOnce(new Error('DB down'));
+    const priors = await MarketScorer.loadCategoryPriors();
+    expect(priors.size).toBe(0);
+    vi.restoreAllMocks();
+  });
+
+  it('returns map of market_type → prior from DB', async () => {
+    vi.spyOn(connection, 'query').mockResolvedValueOnce({
+      rows: [
+        { market_type: 'crypto_daily', prior: 1.2 },
+        { market_type: 'event_short', prior: 0.8 },
+      ],
+      rowCount: 2,
+    } as any);
+    const priors = await MarketScorer.loadCategoryPriors();
+    expect(priors.get('crypto_daily')).toBeCloseTo(1.2);
+    expect(priors.get('event_short')).toBeCloseTo(0.8);
+    expect(priors.get('unknown_type')).toBeUndefined();
+    vi.restoreAllMocks();
+  });
+});
+```
+
+**Step 2: Run tests — expect failure**
+
+**Step 3: Implement `loadCategoryPriors` static method**
+
+Add to `MarketScorer` class:
+```typescript
+static async loadCategoryPriors(): Promise<Map<string, number>> {
+  try {
+    const result = await query<{ market_type: string; prior: number }>(
+      `SELECT market_type, prior FROM category_performance WHERE n_trades >= 5`,
+    );
+    const map = new Map<string, number>();
+    for (const row of result.rows) {
+      map.set(row.market_type, row.prior);
+    }
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+```
+
+**Step 4: Wire priors into `scoreAllMarkets()`**
+
+At the start of `scoreAllMarkets()`, after `loadWeights()`:
+```typescript
+const categoryPriors = await MarketScorer.loadCategoryPriors();
+```
+
+In Pass 1 SQL, multiply by prior using a LEFT JOIN:
+```sql
+UPDATE markets SET market_score = (
+  ... existing formula ...
+) / ${NORM} * COALESCE(cp.prior, 1.0)
+FROM category_performance cp
+WHERE cp.market_type = markets.market_type
+  AND markets.is_active = true
+  AND markets.is_resolved = false
+  AND markets.clob_token_id_yes IS NOT NULL
+```
+
+IMPORTANT: The current Pass 1 SQL uses a plain WHERE clause. Adding the JOIN changes the structure. Read the current SQL carefully and adapt. Markets with `NULL` market_type or no matching `category_performance` row should get `prior = 1.0` (no effect). This may require restructuring the UPDATE to use a subquery or CTE instead of a direct FROM join.
+
+Alternative (simpler): Apply priors as a separate Pass 1b after Pass 1:
+```sql
+UPDATE markets SET market_score = market_score * COALESCE(
+  (SELECT prior FROM category_performance WHERE market_type = markets.market_type),
+  1.0
+)
+WHERE is_active = true AND is_resolved = false AND clob_token_id_yes IS NOT NULL
+```
+
+In Pass 2 enrichment, apply the prior to the compositeScore result:
+```typescript
+const prior = categoryPriors.get(row.market_type) ?? 1.0;
+const score = MarketScorer.compositeScore({ tradeability, liquidity, volatility, ttr, dataQuality }, weights) * prior;
+```
+
+Also add `m.market_type` to the Pass 2 SELECT and the trackedResult type. Thread `market_type` through the enrichUpdates type (add to `EnrichUpdate` interface).
+
+**Step 5: Run tests**
+
+```bash
+pnpm test 2>&1 | tail -10
+```
+
+**Step 6: Commit**
+
+```bash
+git add packages/data-collector/src/services/MarketScorer.ts \
+        packages/data-collector/src/services/MarketScorer.test.ts
+git commit -m "feat: MarketScorer loads and applies category performance priors"
+```
+
+---
+
+### Task 4: Wire into Scheduler as daily job
+
+**Files:**
+- Modify: `packages/data-collector/src/services/Scheduler.ts`
+
+**Step 1: Add the daily job**
+
+Import `updateCategoryPriors`:
+```typescript
+import { updateCategoryPriors } from './MarketPerformanceTracker.js';
+```
+
+Add job definition in constructor (after existing jobs):
+```typescript
+this.defineJob('compute-market-priors', '45 2 * * *', this.computeMarketPriors.bind(this));
+```
+
+Add case in `runJob` switch:
+```typescript
+case 'compute-market-priors':
+  await this.computeMarketPriors();
+  break;
+```
+
+Add private handler method:
+```typescript
+/**
+ * Compute category performance priors from closed trade outcomes.
+ * Updates category_performance table; MarketScorer reads priors at next scoring run.
+ * Daily at 02:45 UTC.
+ */
+private async computeMarketPriors(): Promise<void> {
+  await updateCategoryPriors();
+}
+```
+
+**Step 2: Run tests**
+
+```bash
+pnpm test 2>&1 | tail -10
+```
+
+**Step 3: Commit**
+
+```bash
+git add packages/data-collector/src/services/Scheduler.ts
+git commit -m "feat: run category prior computation daily at 02:45 UTC"
+```
+
+---
+
+### Task 5: Apply migration to VM + verify
+
+**Step 1: Push to remote**
+
+```bash
+gh auth switch --user JaviMaligno
+git push origin main
+```
+
+Wait for CI deploy.
+
+**Step 2: Apply migration manually to VM**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="
+docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+CREATE TABLE IF NOT EXISTS category_performance (
+  market_type  VARCHAR(20) PRIMARY KEY,
+  win_rate     FLOAT,
+  avg_pnl      FLOAT,
+  sharpe_ratio FLOAT,
+  n_trades     INT NOT NULL DEFAULT 0,
+  prior        FLOAT NOT NULL DEFAULT 1.0,
+  updated_at   TIMESTAMPTZ DEFAULT NOW()
+);
+INSERT INTO category_performance (market_type, prior) VALUES
+  ('crypto_intraday', 1.0),
+  ('crypto_daily', 1.0),
+  ('event_short', 1.0),
+  ('event_long', 1.0)
+ON CONFLICT (market_type) DO NOTHING;
+\""
+```
+
+**Step 3: Verify table**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="
+docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+SELECT * FROM category_performance;\""
+```
+
+**Step 4: Verify containers healthy + job registered**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="
+docker logs polymarket-data-collector --since 5m 2>&1 | grep -i 'compute-market-priors\|category'"
+```
+
+**Step 5: Verify scoring uses priors after next :17 run**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="
+docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+SELECT market_type, prior, n_trades, updated_at FROM category_performance;\""
+```
+
+Initially all priors should be 1.0 (default). After the first 02:45 UTC run, categories with ≥5 trades will get computed priors.
+
+---
+
+## Notes
+
+- The prior formula was corrected from the design doc: `0.5 + sigmoid(sharpe × 2)` instead of `0.5 + 0.5 × sigmoid(...)`. The original formula gives 0.75 at neutral sharpe, not 1.0.
+- Categories with `NULL` market_type or <5 trades get prior 1.0 (no effect).
+- The prior is intentionally bounded [0.5, 1.5] — feedback adjusts ±50%, never dominates the base score.
+- Phase 2.5 (already deployed) can later optimize the prior bounds and sigmoid factor via Optuna.

--- a/docs/plans/2026-03-20-real-trading-integration-design.md
+++ b/docs/plans/2026-03-20-real-trading-integration-design.md
@@ -1,0 +1,265 @@
+# Real Trading Integration Design
+
+**Date**: 2026-03-20
+**Status**: Approved
+**Goal**: Enable automated real trading on Polymarket while maintaining paper trading as fallback
+
+## Overview
+
+Integrate real order execution via Polymarket's CLOB API into the existing paper trading system. The system operates in dual mode — every trade is recorded in the existing tables, with an `execution_mode` field distinguishing real from paper. When real funds run out or the user disables real trading, the system degrades gracefully to paper trading without interruption.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                 AutoSignalExecutor               │
+│            (lógica actual sin cambios)           │
+├─────────────────────────────────────────────────┤
+│              ExecutionRouter (NUEVO)             │
+│  ┌──────────────┐    ┌───────────────────────┐  │
+│  │ PaperExecutor │    │ RealExecutor (NUEVO)  │  │
+│  │ (actual)      │    │ @polymarket/clob-client│  │
+│  └──────────────┘    └───────────────────────┘  │
+├─────────────────────────────────────────────────┤
+│              WalletMonitor (NUEVO)               │
+│  - Consulta balance USDC en Polygon cada 5min   │
+│  - Notifica fondos bajos via Slack               │
+│  - Degradación automática a paper                │
+├─────────────────────────────────────────────────┤
+│           Tablas existentes + campo nuevo         │
+│  paper_trades.execution_mode = 'paper' | 'real'  │
+│  paper_positions.execution_mode = 'paper'|'real'  │
+│  trading_config.real_trading_enabled (hot toggle) │
+└─────────────────────────────────────────────────┘
+```
+
+### Principle
+
+The `AutoSignalExecutor` does not change. A new `ExecutionRouter` sits between the executor and the trade recording layer, deciding whether each trade should also be sent to Polymarket's CLOB. The `RealExecutor` wraps `@polymarket/clob-client` for signing and submitting orders. The `WalletMonitor` watches the wallet balance and can disable real trading automatically.
+
+## Components
+
+### 1. ExecutionRouter
+
+Decides execution mode per trade based on priority chain:
+
+```typescript
+class ExecutionRouter {
+  async execute(trade: TradeIntent): Promise<TradeResult> {
+    const mode = await this.resolveMode();
+
+    if (mode === 'dry_run') {
+      const payload = await this.realExecutor.buildOrder(trade);
+      logger.info({ payload }, 'DRY RUN — order built but not sent');
+      return { ...this.paperExecute(trade), execution_mode: 'paper' };
+    }
+
+    if (mode === 'real') {
+      const result = await this.realExecutor.execute(trade);
+      return { ...result, execution_mode: 'real' };
+    }
+
+    return { ...this.paperExecute(trade), execution_mode: 'paper' };
+  }
+
+  // Priority: hot toggle > balance check > env var
+  private async resolveMode(): Promise<'real' | 'paper' | 'dry_run'> {
+    const config = await this.getConfig(); // trading_config table
+    if (!config.real_trading_enabled) return 'paper';
+
+    const balance = this.walletMonitor.getCachedBalance();
+    if (balance < config.min_balance_threshold) return 'paper';
+
+    if (config.dry_run) return 'dry_run';
+
+    return 'real';
+  }
+}
+```
+
+### 2. RealExecutor
+
+Wraps `@polymarket/clob-client`:
+
+- **Startup**: Loads private key from GCP Secret Manager, initializes CLOB client with wallet signer
+- **execute()**: Builds limit order at best available price with slippage tolerance, signs it, submits to CLOB
+- **Retries**: 1 retry on network timeout, no retry on CLOB errors (insufficient balance, market closed)
+- **Dry-run**: Builds and signs order but does not submit; logs full payload
+- **Slippage**: Configurable `MAX_SLIPPAGE` (default 0.02). For "market orders", submits limit order at best price + slippage
+
+### 3. WalletMonitor
+
+```typescript
+class WalletMonitor {
+  private cachedBalance: number;
+  private readonly checkInterval = 5 * 60 * 1000; // 5 minutes
+
+  async check(): Promise<void> {
+    const balance = await this.getUSDCBalance(); // ethers.js read-only RPC call
+    this.cachedBalance = balance;
+
+    if (balance < this.minBalanceThreshold) {
+      await this.setRealTradingEnabled(false);
+      this.notify('funds_low', { balance, threshold: this.minBalanceThreshold });
+    } else if (balance < this.warningThreshold) {
+      this.notify('funds_warning', { balance });
+    }
+  }
+}
+```
+
+**Notifications** via existing Slack webhook:
+- `funds_warning`: Informative — balance approaching threshold
+- `funds_low`: Action taken — switched to paper trading automatically
+- `mode_change`: Audit — mode changed by user or system
+
+**Re-activation**: When user deposits more USDC, WalletMonitor detects it but does NOT re-enable real trading automatically. User must re-enable manually via API.
+
+**Thresholds**: Calculated from historical paper trading data:
+- `min_balance_threshold`: Based on average cost of 2-3 trades from paper trading history
+- `warning_threshold`: 2x min_balance_threshold
+
+## Database Changes
+
+### Modified tables (columns added)
+
+```sql
+ALTER TABLE paper_trades ADD COLUMN execution_mode VARCHAR(10) DEFAULT 'paper';
+ALTER TABLE paper_positions ADD COLUMN execution_mode VARCHAR(10) DEFAULT 'paper';
+```
+
+### New entries in trading_config (existing table)
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| real_trading_enabled | boolean | false | Hot toggle for real trading |
+| real_trading_dry_run | boolean | false | Build+sign orders without submitting |
+| min_balance_threshold | numeric | (from data) | Minimum USDC balance for real trading |
+| warning_balance_threshold | numeric | (from data) | Warning notification threshold |
+| max_slippage | numeric | 0.02 | Slippage tolerance for limit orders |
+| wallet_address | text | null | Polygon wallet address (public) |
+
+No new tables created.
+
+### API Endpoints
+
+```
+POST /api/trading/mode
+  { "real_trading_enabled": true }     → enable real trading
+  { "real_trading_enabled": false }    → switch to paper
+  { "real_trading_dry_run": true }     → enable dry-run mode
+
+GET /api/trading/mode
+  → { mode: "real"|"paper"|"dry_run", balance: 142.50, wallet_address, ... }
+
+GET /api/wallet/status
+  → { address, balance, last_checked, min_threshold, warning_threshold }
+```
+
+Mode changes are logged with timestamp in trading_config for audit.
+
+## Security
+
+- **Private key**: Stored in GCP Secret Manager (free tier, up to 6 versions). Never on disk.
+- **Dedicated wallet**: New wallet created specifically for the bot. Not reused from personal wallets.
+- **Kill switch**: `POST /api/trading/mode { "real_trading_enabled": false }` stops real trading immediately. Open positions on Polymarket persist and can be closed manually on their website.
+- **No auto-reactivation**: Real trading never turns itself back on after being disabled.
+
+## Testing Strategy
+
+### Layer 1: Unit tests (mock CLOB client)
+- ExecutionRouter correctly delegates to RealExecutor vs PaperExecutor
+- WalletMonitor degrades to paper when balance drops
+- Hot toggle respected
+- Mode priority chain works correctly
+- Notifications fire at correct thresholds
+
+### Layer 2: Integration tests (dry-run mode)
+- RealExecutor builds and signs real orders without submitting
+- Logs show exact payload that would be sent to CLOB
+- Wallet connection works, balance reads correctly
+- Run for at least 24h in production to verify stability
+- Checklist:
+  - [ ] Orders reference correct token IDs
+  - [ ] Prices within expected range
+  - [ ] Sizes match position sizing logic
+  - [ ] Slippage tolerance applied correctly
+  - [ ] Signatures valid
+
+### Layer 3: Live test (minimal capital)
+- Deposit $5-10 USDC on Polygon
+- Enable real trading
+- Wait for 1 trade to execute
+- Verify:
+  - [ ] Order visible on Polymarket
+  - [ ] Wallet balance decreased correctly
+  - [ ] Trade recorded in DB with `execution_mode='real'`
+  - [ ] Position created in DB
+- Close position (wait for signal or manual)
+- Verify:
+  - [ ] USDC returned to wallet
+  - [ ] Position closed in DB with realized PnL
+  - [ ] Full cycle complete
+
+## Onboarding: Paper to Real
+
+### Phase 0 — Setup (once)
+1. Create dedicated Polygon wallet for the bot (new keypair, do not reuse personal wallet)
+2. Store private key in GCP Secret Manager (`polymarket-bot-private-key`)
+3. Configure `wallet_address` in trading_config
+4. Deploy updated code with ExecutionRouter, RealExecutor, WalletMonitor
+5. Install dependencies: `@polymarket/clob-client`
+
+### Phase 1 — Dry-run
+1. Set `real_trading_dry_run = true` via API
+2. Monitor logs for 24h+ — verify orders are built correctly
+3. Run through dry-run checklist above
+4. Fix any issues found
+
+### Phase 2 — Minimal live test
+1. Deposit $5-10 USDC to wallet on Polygon
+2. Set `real_trading_dry_run = false`, `real_trading_enabled = true`
+3. Wait for 1 complete trade cycle (open + close)
+4. Run through live test checklist above
+5. If any issues: disable real trading, investigate, fix, repeat
+
+### Phase 3 — Gradual production
+1. Deposit initial capital (amount based on paper trading performance and comfort level)
+2. Thresholds auto-calculated from historical trade data
+3. Monitor first week closely — dashboard shows real vs paper trades
+4. Adjust thresholds and slippage based on real execution experience
+
+### Emergency — Kill switch
+- `POST /api/trading/mode { "real_trading_enabled": false }` — immediate stop
+- Open positions on Polymarket persist — close manually on their website if needed
+- System continues in paper trading mode — no data loss, optimization continues
+
+## Resource Impact
+
+- **VM**: One additional HTTP call per real trade (CLOB order submission) — negligible
+- **WalletMonitor**: One RPC call every 5 minutes to Polygon — negligible
+- **Database**: Two new VARCHAR columns, no new tables — negligible
+- **Memory**: CLOB client + ethers signer in memory — ~10-20MB additional
+- **GCP Secret Manager**: 1 API call on service startup — free tier
+
+## Dependencies
+
+| Package | Purpose | Already in project? |
+|---------|---------|-------------------|
+| `@polymarket/clob-client` | CLOB order submission | No — add to dashboard |
+| `ethers` | Wallet signing + USDC balance check | Yes (data-collector) |
+| `@google-cloud/secret-manager` | Private key retrieval | No — add to dashboard |
+
+## Funding Flow
+
+```
+User's bank (EUR/GBP/USD)
+  → Crypto exchange (Coinbase/Kraken/etc) — manual
+  → Buy USDC
+  → Send to bot's Polygon wallet
+  → Bot trades via CLOB API
+  → Profits stay in wallet (auto-reinvested)
+  → Withdraw: send USDC back to exchange → bank — manual
+```
+
+Funding and withdrawal are manual (Option A). The system notifies when funds are low but never auto-purchases USDC.

--- a/docs/plans/2026-03-20-real-trading-integration-plan.md
+++ b/docs/plans/2026-03-20-real-trading-integration-plan.md
@@ -1,0 +1,1494 @@
+# Real Trading Integration — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable automated real trading on Polymarket via CLOB API while maintaining paper trading as fallback with graceful degradation.
+
+**Architecture:** An `ExecutionRouter` sits between `AutoSignalExecutor` and trade recording. It delegates to `RealExecutor` (CLOB API) or paper execution based on a hot toggle + wallet balance. A `WalletMonitor` watches USDC balance and auto-degrades to paper. Private key stored in GCP Secret Manager.
+
+**Tech Stack:** `@polymarket/clob-client`, `ethers` (already in project), `@google-cloud/secret-manager`, Slack webhook (existing `SLACK_WEBHOOK_URL`)
+
+**Design doc:** `docs/plans/2026-03-20-real-trading-integration-design.md`
+
+---
+
+### Task 1: Install Dependencies & Database Schema
+
+**Files:**
+- Modify: `packages/dashboard/package.json`
+- Modify: `packages/data-collector/src/database/init/002_signals_tracking.sql`
+
+**Step 1: Install new dependencies**
+
+Run:
+```bash
+cd packages/dashboard && pnpm add @polymarket/clob-client @google-cloud/secret-manager
+```
+
+Note: `ethers` is already available via `@polymarket-trader/data-collector`. Check if `@polymarket/clob-client` bundles it — if so, no extra ethers install needed. If not:
+```bash
+pnpm add ethers@^6
+```
+
+**Step 2: Add execution_mode columns to SQL schema**
+
+In `002_signals_tracking.sql`, after the `paper_trades` CREATE TABLE, add:
+
+```sql
+-- Real trading support
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'paper_trades' AND column_name = 'execution_mode'
+  ) THEN
+    ALTER TABLE paper_trades ADD COLUMN execution_mode VARCHAR(10) DEFAULT 'paper';
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'paper_positions' AND column_name = 'execution_mode'
+  ) THEN
+    ALTER TABLE paper_positions ADD COLUMN execution_mode VARCHAR(10) DEFAULT 'paper';
+  END IF;
+END $$;
+```
+
+**Step 3: Add default trading_config entries for real trading**
+
+In same file, after existing INSERT INTO trading_config:
+
+```sql
+INSERT INTO trading_config (key, value, description) VALUES
+  ('real_trading_enabled', 'false', 'Hot toggle for real trading execution'),
+  ('real_trading_dry_run', 'false', 'Build+sign orders without submitting to CLOB'),
+  ('wallet_address', 'null', 'Polygon wallet address for real trading'),
+  ('min_balance_threshold', 'null', 'Minimum USDC balance to keep real trading active'),
+  ('warning_balance_threshold', 'null', 'USDC balance warning notification threshold'),
+  ('max_slippage', '0.02', 'Maximum slippage tolerance for limit orders')
+ON CONFLICT (key) DO NOTHING;
+```
+
+**Step 4: Commit**
+
+```bash
+git add packages/dashboard/package.json packages/data-collector/src/database/init/002_signals_tracking.sql pnpm-lock.yaml
+git commit -m "feat: add dependencies and schema for real trading integration"
+```
+
+---
+
+### Task 2: NotificationService (Slack Webhook)
+
+**Files:**
+- Create: `packages/dashboard/src/services/NotificationService.ts`
+- Create: `packages/dashboard/src/services/__tests__/NotificationService.test.ts`
+
+**Step 1: Write the failing test**
+
+```typescript
+// packages/dashboard/src/services/__tests__/NotificationService.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotificationService } from '../NotificationService.js';
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({ ok: true });
+    service = new NotificationService('https://hooks.slack.com/test');
+  });
+
+  it('sends funds_warning notification', async () => {
+    await service.notify('funds_warning', { balance: 85, threshold: 100 });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://hooks.slack.com/test',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+    expect(body.text).toContain('Warning');
+    expect(body.text).toContain('85');
+  });
+
+  it('sends funds_low notification with mode change', async () => {
+    await service.notify('funds_low', { balance: 23, threshold: 50 });
+
+    const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+    expect(body.text).toContain('paper');
+    expect(body.text).toContain('23');
+  });
+
+  it('sends mode_change notification', async () => {
+    await service.notify('mode_change', { from: 'paper', to: 'real', by: 'user' });
+
+    const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+    expect(body.text).toContain('real');
+  });
+
+  it('does not throw if webhook URL is not configured', async () => {
+    const noWebhook = new NotificationService('');
+    await expect(noWebhook.notify('funds_warning', { balance: 10 })).resolves.not.toThrow();
+  });
+
+  it('does not throw if fetch fails', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error('network'));
+    await expect(service.notify('funds_warning', { balance: 10 })).resolves.not.toThrow();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && npx vitest run src/services/__tests__/NotificationService.test.ts`
+Expected: FAIL — cannot find `../NotificationService.js`
+
+**Step 3: Write minimal implementation**
+
+```typescript
+// packages/dashboard/src/services/NotificationService.ts
+import pino from 'pino';
+
+const logger = pino({ name: 'NotificationService' });
+
+type NotificationType = 'funds_warning' | 'funds_low' | 'mode_change' | 'trade_real' | 'error';
+
+interface NotificationPayload {
+  balance?: number;
+  threshold?: number;
+  from?: string;
+  to?: string;
+  by?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+export class NotificationService {
+  constructor(private readonly slackWebhookUrl: string) {}
+
+  async notify(type: NotificationType, payload: NotificationPayload): Promise<void> {
+    if (!this.slackWebhookUrl) {
+      logger.debug({ type }, 'No webhook URL configured, skipping notification');
+      return;
+    }
+
+    const text = this.formatMessage(type, payload);
+
+    try {
+      await fetch(this.slackWebhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+      });
+      logger.info({ type }, 'Notification sent');
+    } catch (err) {
+      logger.error({ err, type }, 'Failed to send notification');
+    }
+  }
+
+  private formatMessage(type: NotificationType, p: NotificationPayload): string {
+    switch (type) {
+      case 'funds_warning':
+        return `⚠️ *Warning: Low USDC balance* — $${p.balance} (threshold: $${p.threshold}). Consider depositing more funds.`;
+      case 'funds_low':
+        return `🔴 *Funds critically low* — $${p.balance} (min: $${p.threshold}). Switching to paper trading.`;
+      case 'mode_change':
+        return `🔄 *Trading mode changed*: ${p.from} → ${p.to} (by: ${p.by})`;
+      case 'trade_real':
+        return `💰 *Real trade executed* — ${p.message}`;
+      case 'error':
+        return `❌ *Trading error* — ${p.message}`;
+      default:
+        return `ℹ️ ${type}: ${JSON.stringify(p)}`;
+    }
+  }
+}
+
+let instance: NotificationService | null = null;
+
+export function getNotificationService(): NotificationService {
+  if (!instance) {
+    instance = new NotificationService(process.env.SLACK_WEBHOOK_URL || '');
+  }
+  return instance;
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd packages/dashboard && npx vitest run src/services/__tests__/NotificationService.test.ts`
+Expected: PASS (all 5 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/src/services/NotificationService.ts packages/dashboard/src/services/__tests__/NotificationService.test.ts
+git commit -m "feat: add NotificationService with Slack webhook for trading alerts"
+```
+
+---
+
+### Task 3: WalletMonitor
+
+**Files:**
+- Create: `packages/dashboard/src/services/WalletMonitor.ts`
+- Create: `packages/dashboard/src/services/__tests__/WalletMonitor.test.ts`
+
+**Step 1: Write the failing test**
+
+```typescript
+// packages/dashboard/src/services/__tests__/WalletMonitor.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WalletMonitor } from '../WalletMonitor.js';
+
+// Mock dependencies
+const mockNotify = vi.fn();
+const mockSetConfig = vi.fn();
+const mockGetBalance = vi.fn();
+
+describe('WalletMonitor', () => {
+  let monitor: WalletMonitor;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockNotify.mockResolvedValue(undefined);
+    mockSetConfig.mockResolvedValue(undefined);
+
+    monitor = new WalletMonitor({
+      getUSDCBalance: mockGetBalance,
+      notify: mockNotify,
+      setRealTradingEnabled: mockSetConfig,
+      minBalanceThreshold: 50,
+      warningThreshold: 100,
+      checkIntervalMs: 1000, // fast for tests
+    });
+  });
+
+  it('returns cached balance', async () => {
+    mockGetBalance.mockResolvedValue(200);
+    await monitor.check();
+    expect(monitor.getCachedBalance()).toBe(200);
+  });
+
+  it('does nothing when balance is above warning threshold', async () => {
+    mockGetBalance.mockResolvedValue(200);
+    await monitor.check();
+    expect(mockNotify).not.toHaveBeenCalled();
+    expect(mockSetConfig).not.toHaveBeenCalled();
+  });
+
+  it('sends warning when balance below warning threshold but above min', async () => {
+    mockGetBalance.mockResolvedValue(75);
+    await monitor.check();
+    expect(mockNotify).toHaveBeenCalledWith('funds_warning', expect.objectContaining({ balance: 75 }));
+    expect(mockSetConfig).not.toHaveBeenCalled();
+  });
+
+  it('disables real trading and notifies when balance below min threshold', async () => {
+    mockGetBalance.mockResolvedValue(30);
+    await monitor.check();
+    expect(mockSetConfig).toHaveBeenCalledWith(false);
+    expect(mockNotify).toHaveBeenCalledWith('funds_low', expect.objectContaining({ balance: 30 }));
+  });
+
+  it('does not send duplicate warnings within cooldown', async () => {
+    mockGetBalance.mockResolvedValue(75);
+    await monitor.check();
+    await monitor.check();
+    // Only one warning notification
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles balance check errors gracefully', async () => {
+    mockGetBalance.mockRejectedValue(new Error('RPC timeout'));
+    await expect(monitor.check()).resolves.not.toThrow();
+    expect(monitor.getCachedBalance()).toBe(0); // safe default
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && npx vitest run src/services/__tests__/WalletMonitor.test.ts`
+Expected: FAIL — cannot find `../WalletMonitor.js`
+
+**Step 3: Write minimal implementation**
+
+```typescript
+// packages/dashboard/src/services/WalletMonitor.ts
+import pino from 'pino';
+
+const logger = pino({ name: 'WalletMonitor' });
+
+export interface WalletMonitorConfig {
+  getUSDCBalance: () => Promise<number>;
+  notify: (type: string, payload: Record<string, unknown>) => Promise<void>;
+  setRealTradingEnabled: (enabled: boolean) => Promise<void>;
+  minBalanceThreshold: number;
+  warningThreshold: number;
+  checkIntervalMs?: number;
+}
+
+export class WalletMonitor {
+  private cachedBalance = 0;
+  private lastWarningAt = 0;
+  private lastLowAt = 0;
+  private readonly warningCooldownMs = 30 * 60 * 1000; // 30 min
+  private intervalHandle: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private readonly config: WalletMonitorConfig) {}
+
+  getCachedBalance(): number {
+    return this.cachedBalance;
+  }
+
+  async check(): Promise<void> {
+    try {
+      this.cachedBalance = await this.config.getUSDCBalance();
+    } catch (err) {
+      logger.error({ err }, 'Failed to check USDC balance');
+      this.cachedBalance = 0;
+      return;
+    }
+
+    const now = Date.now();
+
+    if (this.cachedBalance < this.config.minBalanceThreshold) {
+      if (now - this.lastLowAt > this.warningCooldownMs) {
+        await this.config.setRealTradingEnabled(false);
+        await this.config.notify('funds_low', {
+          balance: this.cachedBalance,
+          threshold: this.config.minBalanceThreshold,
+        });
+        this.lastLowAt = now;
+      }
+      return;
+    }
+
+    if (this.cachedBalance < this.config.warningThreshold) {
+      if (now - this.lastWarningAt > this.warningCooldownMs) {
+        await this.config.notify('funds_warning', {
+          balance: this.cachedBalance,
+          threshold: this.config.warningThreshold,
+        });
+        this.lastWarningAt = now;
+      }
+    }
+  }
+
+  start(): void {
+    const intervalMs = this.config.checkIntervalMs ?? 5 * 60 * 1000;
+    logger.info({ intervalMs }, 'WalletMonitor started');
+    this.intervalHandle = setInterval(() => this.check(), intervalMs);
+    // Initial check
+    this.check().catch(() => {});
+  }
+
+  stop(): void {
+    if (this.intervalHandle) {
+      clearInterval(this.intervalHandle);
+      this.intervalHandle = null;
+    }
+  }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd packages/dashboard && npx vitest run src/services/__tests__/WalletMonitor.test.ts`
+Expected: PASS (all 6 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/src/services/WalletMonitor.ts packages/dashboard/src/services/__tests__/WalletMonitor.test.ts
+git commit -m "feat: add WalletMonitor with balance checking and auto-degradation"
+```
+
+---
+
+### Task 4: RealExecutor
+
+**Files:**
+- Create: `packages/dashboard/src/services/RealExecutor.ts`
+- Create: `packages/dashboard/src/services/__tests__/RealExecutor.test.ts`
+
+**Step 1: Write the failing test**
+
+```typescript
+// packages/dashboard/src/services/__tests__/RealExecutor.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RealExecutor, type OrderIntent, type OrderResult } from '../RealExecutor.js';
+
+// Mock the CLOB client
+const mockPostOrder = vi.fn();
+const mockCreateOrder = vi.fn();
+const mockClobClient = {
+  createOrder: mockCreateOrder,
+  postOrder: mockPostOrder,
+};
+
+describe('RealExecutor', () => {
+  let executor: RealExecutor;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockCreateOrder.mockResolvedValue({ id: 'order-123', signed: true });
+    mockPostOrder.mockResolvedValue({
+      orderID: 'order-123',
+      status: 'matched',
+      transactionsHashes: ['0xabc'],
+    });
+
+    executor = new RealExecutor({
+      clobClient: mockClobClient as any,
+      maxSlippage: 0.02,
+      dryRun: false,
+    });
+  });
+
+  it('builds and submits a BUY order', async () => {
+    const intent: OrderIntent = {
+      tokenId: 'token-yes-123',
+      side: 'BUY',
+      price: 0.65,
+      size: 100,
+    };
+
+    const result = await executor.execute(intent);
+
+    expect(mockCreateOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tokenID: 'token-yes-123',
+        side: 'BUY',
+        price: 0.65,
+        size: 100,
+      })
+    );
+    expect(mockPostOrder).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(result.orderId).toBe('order-123');
+  });
+
+  it('builds and submits a SELL order', async () => {
+    const intent: OrderIntent = {
+      tokenId: 'token-yes-123',
+      side: 'SELL',
+      price: 0.80,
+      size: 50,
+    };
+
+    const result = await executor.execute(intent);
+
+    expect(mockCreateOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        side: 'SELL',
+        price: 0.80,
+        size: 50,
+      })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('in dry-run mode, builds but does not submit', async () => {
+    executor = new RealExecutor({
+      clobClient: mockClobClient as any,
+      maxSlippage: 0.02,
+      dryRun: true,
+    });
+
+    const intent: OrderIntent = {
+      tokenId: 'token-yes-123',
+      side: 'BUY',
+      price: 0.65,
+      size: 100,
+    };
+
+    const result = await executor.execute(intent);
+
+    expect(mockCreateOrder).toHaveBeenCalled();
+    expect(mockPostOrder).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(result.dryRun).toBe(true);
+  });
+
+  it('handles CLOB rejection gracefully', async () => {
+    mockPostOrder.mockRejectedValue(new Error('Insufficient balance'));
+
+    const intent: OrderIntent = {
+      tokenId: 'token-yes-123',
+      side: 'BUY',
+      price: 0.65,
+      size: 100,
+    };
+
+    const result = await executor.execute(intent);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Insufficient balance');
+  });
+
+  it('retries once on network timeout', async () => {
+    mockPostOrder
+      .mockRejectedValueOnce(new Error('ETIMEDOUT'))
+      .mockResolvedValueOnce({
+        orderID: 'order-123',
+        status: 'matched',
+        transactionsHashes: ['0xabc'],
+      });
+
+    const intent: OrderIntent = {
+      tokenId: 'token-yes-123',
+      side: 'BUY',
+      price: 0.65,
+      size: 100,
+    };
+
+    const result = await executor.execute(intent);
+
+    expect(mockPostOrder).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(true);
+  });
+
+  it('does not retry on non-network errors', async () => {
+    mockPostOrder.mockRejectedValue(new Error('Market closed'));
+
+    const intent: OrderIntent = {
+      tokenId: 'token-yes-123',
+      side: 'BUY',
+      price: 0.65,
+      size: 100,
+    };
+
+    await executor.execute(intent);
+    expect(mockPostOrder).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && npx vitest run src/services/__tests__/RealExecutor.test.ts`
+Expected: FAIL — cannot find `../RealExecutor.js`
+
+**Step 3: Write minimal implementation**
+
+```typescript
+// packages/dashboard/src/services/RealExecutor.ts
+import pino from 'pino';
+
+const logger = pino({ name: 'RealExecutor' });
+
+export interface OrderIntent {
+  tokenId: string;
+  side: 'BUY' | 'SELL';
+  price: number;
+  size: number;
+}
+
+export interface OrderResult {
+  success: boolean;
+  orderId?: string;
+  transactionHash?: string;
+  executedPrice?: number;
+  executedSize?: number;
+  error?: string;
+  dryRun?: boolean;
+}
+
+interface RealExecutorConfig {
+  clobClient: any; // ClobClient from @polymarket/clob-client
+  maxSlippage: number;
+  dryRun: boolean;
+}
+
+const RETRYABLE_ERRORS = ['ETIMEDOUT', 'ECONNRESET', 'ECONNREFUSED', 'socket hang up'];
+
+function isRetryable(err: Error): boolean {
+  return RETRYABLE_ERRORS.some(code => err.message.includes(code));
+}
+
+export class RealExecutor {
+  private readonly client: any;
+  private readonly maxSlippage: number;
+  private readonly dryRun: boolean;
+
+  constructor(config: RealExecutorConfig) {
+    this.client = config.clobClient;
+    this.maxSlippage = config.maxSlippage;
+    this.dryRun = config.dryRun;
+  }
+
+  async execute(intent: OrderIntent): Promise<OrderResult> {
+    try {
+      // Build the signed order
+      const orderParams = {
+        tokenID: intent.tokenId,
+        side: intent.side,
+        price: intent.price,
+        size: intent.size,
+      };
+
+      logger.info({ orderParams, dryRun: this.dryRun }, 'Building CLOB order');
+
+      const signedOrder = await this.client.createOrder(orderParams);
+
+      if (this.dryRun) {
+        logger.info({ signedOrder }, 'DRY RUN — order signed but not submitted');
+        return { success: true, dryRun: true, orderId: signedOrder.id };
+      }
+
+      // Submit to CLOB with retry
+      const response = await this.submitWithRetry(signedOrder);
+
+      logger.info({ response }, 'Order submitted to CLOB');
+
+      return {
+        success: true,
+        orderId: response.orderID,
+        transactionHash: response.transactionsHashes?.[0],
+      };
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      logger.error({ err, intent }, 'Failed to execute real order');
+      return { success: false, error };
+    }
+  }
+
+  private async submitWithRetry(signedOrder: any, attempt = 0): Promise<any> {
+    try {
+      return await this.client.postOrder(signedOrder);
+    } catch (err) {
+      if (attempt === 0 && err instanceof Error && isRetryable(err)) {
+        logger.warn({ err }, 'Retrying order submission after network error');
+        return this.submitWithRetry(signedOrder, 1);
+      }
+      throw err;
+    }
+  }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd packages/dashboard && npx vitest run src/services/__tests__/RealExecutor.test.ts`
+Expected: PASS (all 6 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/src/services/RealExecutor.ts packages/dashboard/src/services/__tests__/RealExecutor.test.ts
+git commit -m "feat: add RealExecutor wrapping Polymarket CLOB client"
+```
+
+---
+
+### Task 5: ExecutionRouter
+
+**Files:**
+- Create: `packages/dashboard/src/services/ExecutionRouter.ts`
+- Create: `packages/dashboard/src/services/__tests__/ExecutionRouter.test.ts`
+
+**Step 1: Write the failing test**
+
+```typescript
+// packages/dashboard/src/services/__tests__/ExecutionRouter.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ExecutionRouter } from '../ExecutionRouter.js';
+
+const mockRealExecute = vi.fn();
+const mockGetCachedBalance = vi.fn();
+const mockGetConfig = vi.fn();
+const mockNotify = vi.fn();
+
+describe('ExecutionRouter', () => {
+  let router: ExecutionRouter;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockGetCachedBalance.mockReturnValue(500);
+    mockGetConfig.mockResolvedValue({
+      real_trading_enabled: true,
+      real_trading_dry_run: false,
+      min_balance_threshold: 50,
+    });
+    mockRealExecute.mockResolvedValue({
+      success: true,
+      orderId: 'order-123',
+    });
+    mockNotify.mockResolvedValue(undefined);
+
+    router = new ExecutionRouter({
+      realExecutor: { execute: mockRealExecute } as any,
+      getCachedBalance: mockGetCachedBalance,
+      getConfig: mockGetConfig,
+      notify: mockNotify,
+    });
+  });
+
+  it('routes to real executor when enabled and funded', async () => {
+    const result = await router.execute({
+      tokenId: 'token-123',
+      side: 'BUY',
+      price: 0.65,
+      size: 100,
+    });
+
+    expect(mockRealExecute).toHaveBeenCalled();
+    expect(result.execution_mode).toBe('real');
+  });
+
+  it('routes to paper when real trading disabled', async () => {
+    mockGetConfig.mockResolvedValue({
+      real_trading_enabled: false,
+      real_trading_dry_run: false,
+      min_balance_threshold: 50,
+    });
+
+    const result = await router.execute({
+      tokenId: 'token-123',
+      side: 'BUY',
+      price: 0.65,
+      size: 100,
+    });
+
+    expect(mockRealExecute).not.toHaveBeenCalled();
+    expect(result.execution_mode).toBe('paper');
+  });
+
+  it('routes to paper when balance below threshold', async () => {
+    mockGetCachedBalance.mockReturnValue(30);
+
+    const result = await router.execute({
+      tokenId: 'token-123',
+      side: 'BUY',
+      price: 0.65,
+      size: 100,
+    });
+
+    expect(mockRealExecute).not.toHaveBeenCalled();
+    expect(result.execution_mode).toBe('paper');
+  });
+
+  it('routes to dry_run when configured', async () => {
+    mockGetConfig.mockResolvedValue({
+      real_trading_enabled: true,
+      real_trading_dry_run: true,
+      min_balance_threshold: 50,
+    });
+
+    const result = await router.execute({
+      tokenId: 'token-123',
+      side: 'BUY',
+      price: 0.65,
+      size: 100,
+    });
+
+    expect(mockRealExecute).toHaveBeenCalled();
+    expect(result.execution_mode).toBe('dry_run');
+  });
+
+  it('falls back to paper if real execution fails', async () => {
+    mockRealExecute.mockResolvedValue({ success: false, error: 'CLOB down' });
+
+    const result = await router.execute({
+      tokenId: 'token-123',
+      side: 'BUY',
+      price: 0.65,
+      size: 100,
+    });
+
+    expect(result.execution_mode).toBe('paper');
+    expect(mockNotify).toHaveBeenCalledWith('error', expect.objectContaining({ message: expect.stringContaining('CLOB') }));
+  });
+
+  it('reports current mode via getMode()', async () => {
+    const mode = await router.getMode();
+    expect(mode).toBe('real');
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && npx vitest run src/services/__tests__/ExecutionRouter.test.ts`
+Expected: FAIL — cannot find `../ExecutionRouter.js`
+
+**Step 3: Write minimal implementation**
+
+```typescript
+// packages/dashboard/src/services/ExecutionRouter.ts
+import pino from 'pino';
+import type { OrderIntent, OrderResult } from './RealExecutor.js';
+
+const logger = pino({ name: 'ExecutionRouter' });
+
+export type ExecutionMode = 'real' | 'paper' | 'dry_run';
+
+export interface ExecutionResult {
+  execution_mode: ExecutionMode;
+  realOrderResult?: OrderResult;
+}
+
+interface TradingModeConfig {
+  real_trading_enabled: boolean;
+  real_trading_dry_run: boolean;
+  min_balance_threshold: number;
+}
+
+interface ExecutionRouterDeps {
+  realExecutor: { execute: (intent: OrderIntent) => Promise<OrderResult> };
+  getCachedBalance: () => number;
+  getConfig: () => Promise<TradingModeConfig>;
+  notify: (type: string, payload: Record<string, unknown>) => Promise<void>;
+}
+
+export class ExecutionRouter {
+  constructor(private readonly deps: ExecutionRouterDeps) {}
+
+  async getMode(): Promise<ExecutionMode> {
+    return this.resolveMode();
+  }
+
+  async execute(intent: OrderIntent): Promise<ExecutionResult> {
+    const mode = await this.resolveMode();
+
+    if (mode === 'paper') {
+      return { execution_mode: 'paper' };
+    }
+
+    // Both 'real' and 'dry_run' go through the real executor
+    // (RealExecutor handles dry_run internally based on its own config)
+    const result = await this.deps.realExecutor.execute(intent);
+
+    if (!result.success) {
+      logger.warn({ error: result.error, intent }, 'Real execution failed, falling back to paper');
+      await this.deps.notify('error', {
+        message: `Real order failed: ${result.error}. Trade recorded as paper.`,
+      });
+      return { execution_mode: 'paper', realOrderResult: result };
+    }
+
+    logger.info({ mode, orderId: result.orderId }, 'Real execution succeeded');
+    return {
+      execution_mode: mode === 'dry_run' ? 'dry_run' : 'real',
+      realOrderResult: result,
+    };
+  }
+
+  private async resolveMode(): Promise<ExecutionMode> {
+    try {
+      const config = await this.deps.getConfig();
+
+      if (!config.real_trading_enabled) return 'paper';
+
+      const balance = this.deps.getCachedBalance();
+      if (balance < config.min_balance_threshold) return 'paper';
+
+      if (config.real_trading_dry_run) return 'dry_run';
+
+      return 'real';
+    } catch (err) {
+      logger.error({ err }, 'Failed to resolve execution mode, defaulting to paper');
+      return 'paper';
+    }
+  }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd packages/dashboard && npx vitest run src/services/__tests__/ExecutionRouter.test.ts`
+Expected: PASS (all 6 tests)
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/src/services/ExecutionRouter.ts packages/dashboard/src/services/__tests__/ExecutionRouter.test.ts
+git commit -m "feat: add ExecutionRouter for real/paper/dry-run mode selection"
+```
+
+---
+
+### Task 6: Integrate ExecutionRouter into AutoSignalExecutor
+
+**Files:**
+- Modify: `packages/dashboard/src/services/AutoSignalExecutor.ts`
+- Create: `packages/dashboard/src/services/__tests__/AutoSignalExecutor.realtrading.test.ts`
+
+**Context:** The AutoSignalExecutor currently records trades directly to paper_trades and paper_positions. We need to:
+1. Call ExecutionRouter before recording (for entry trades)
+2. Call ExecutionRouter before PositionClosingService (for exit trades)
+3. Tag all trades with `execution_mode`
+
+**Step 1: Write the failing integration test**
+
+```typescript
+// packages/dashboard/src/services/__tests__/AutoSignalExecutor.realtrading.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// This test verifies that AutoSignalExecutor passes execution_mode through
+// to paper_trades and paper_positions records.
+// Full integration test — requires mocking the DB repos.
+
+describe('AutoSignalExecutor real trading integration', () => {
+  it('tags trade as real when ExecutionRouter returns real', async () => {
+    // This test will be implemented after reading the exact openPosition code
+    // to understand the trade recording call signature
+    expect(true).toBe(true); // placeholder
+  });
+
+  it('tags trade as paper when ExecutionRouter returns paper', async () => {
+    expect(true).toBe(true); // placeholder
+  });
+
+  it('includes execution_mode in paper_positions upsert', async () => {
+    expect(true).toBe(true); // placeholder
+  });
+});
+```
+
+Note: The actual integration tests here will need careful mocking of DB repos. The implementer should:
+1. Read `AutoSignalExecutor.ts` lines 550-665 (openPosition) and lines 667-765 (closePosition) in full
+2. Identify exactly where `paperTradesRepo.create()` and `paperPositionsRepo.upsert()` are called
+3. Add `execution_mode` to those calls
+4. Add ExecutionRouter call before the DB writes
+
+**Step 2: Modify AutoSignalExecutor**
+
+Key changes needed in `AutoSignalExecutor.ts`:
+
+1. **Import ExecutionRouter** (near line 23):
+   ```typescript
+   import { getExecutionRouter, type ExecutionMode } from './ExecutionRouter.js';
+   ```
+
+2. **In openPosition() (around line 550-630)**: Before recording the trade, call:
+   ```typescript
+   const execResult = await getExecutionRouter().execute({
+     tokenId: position.token_id,
+     side: 'BUY',
+     price: executedPrice,
+     size: positionSize,
+   });
+   const executionMode = execResult.execution_mode;
+   ```
+   Then pass `execution_mode: executionMode` to both `paperTradesRepo.create()` and `paperPositionsRepo.upsert()`.
+
+3. **In closePosition() (around line 723)**: Before calling PositionClosingService, call:
+   ```typescript
+   const execResult = await getExecutionRouter().execute({
+     tokenId: position.token_id,
+     side: 'SELL',
+     price: exitPrice,
+     size: position.size,
+   });
+   ```
+   Pass `execution_mode` through to PositionClosingService (requires adding the field to `ClosePositionParams`).
+
+**Important:** The implementer MUST read the full openPosition and closePosition methods before making changes. The line numbers above are approximate — the actual insertion points depend on current code state.
+
+**Step 3: Run existing tests to verify nothing breaks**
+
+Run: `cd packages/dashboard && npx vitest run`
+Expected: All existing tests PASS
+
+**Step 4: Commit**
+
+```bash
+git add packages/dashboard/src/services/AutoSignalExecutor.ts
+git commit -m "feat: wire ExecutionRouter into AutoSignalExecutor for real trade execution"
+```
+
+---
+
+### Task 7: API Endpoints for Hot Toggle
+
+**Files:**
+- Modify: `packages/dashboard/src/api/routes.ts`
+- Create: `packages/dashboard/src/api/__tests__/trading-mode.test.ts`
+
+**Step 1: Write the failing test**
+
+```typescript
+// packages/dashboard/src/api/__tests__/trading-mode.test.ts
+import { describe, it, expect, vi } from 'vitest';
+
+// Route handler tests — verify the handler logic
+// (testing actual HTTP would require Fastify test helpers)
+
+describe('GET /api/trading/mode', () => {
+  it('returns current mode, balance, and config', () => {
+    // Test the handler function directly
+    expect(true).toBe(true); // placeholder — implement after reading routes.ts structure
+  });
+});
+
+describe('POST /api/trading/mode', () => {
+  it('updates real_trading_enabled in trading_config', () => {
+    expect(true).toBe(true); // placeholder
+  });
+
+  it('sends mode_change notification', () => {
+    expect(true).toBe(true); // placeholder
+  });
+
+  it('rejects invalid mode values', () => {
+    expect(true).toBe(true); // placeholder
+  });
+});
+
+describe('GET /api/wallet/status', () => {
+  it('returns wallet address, balance, thresholds', () => {
+    expect(true).toBe(true); // placeholder
+  });
+});
+```
+
+**Step 2: Add routes**
+
+The implementer should read `packages/dashboard/src/api/routes.ts` to understand the existing route registration pattern, then add:
+
+```typescript
+// GET /api/trading/mode
+fastify.get('/api/trading/mode', async () => {
+  const config = await tradingConfigRepo.getAll();
+  const balance = getWalletMonitor()?.getCachedBalance() ?? null;
+  const mode = await getExecutionRouter().getMode();
+  return {
+    mode,
+    real_trading_enabled: config.real_trading_enabled ?? false,
+    real_trading_dry_run: config.real_trading_dry_run ?? false,
+    balance,
+    wallet_address: config.wallet_address ?? null,
+  };
+});
+
+// POST /api/trading/mode
+fastify.post('/api/trading/mode', async (request) => {
+  const body = request.body as Record<string, unknown>;
+  const previousConfig = await tradingConfigRepo.getAll();
+
+  if (body.real_trading_enabled !== undefined) {
+    await tradingConfigRepo.set('real_trading_enabled', body.real_trading_enabled);
+  }
+  if (body.real_trading_dry_run !== undefined) {
+    await tradingConfigRepo.set('real_trading_dry_run', body.real_trading_dry_run);
+  }
+
+  const newMode = await getExecutionRouter().getMode();
+  const prevMode = previousConfig.real_trading_enabled ? 'real' : 'paper';
+
+  if (newMode !== prevMode) {
+    await getNotificationService().notify('mode_change', {
+      from: prevMode,
+      to: newMode,
+      by: 'user',
+    });
+  }
+
+  return { mode: newMode, success: true };
+});
+
+// GET /api/wallet/status
+fastify.get('/api/wallet/status', async () => {
+  const config = await tradingConfigRepo.getAll();
+  const balance = getWalletMonitor()?.getCachedBalance() ?? null;
+  return {
+    address: config.wallet_address ?? null,
+    balance,
+    last_checked: new Date().toISOString(),
+    min_threshold: config.min_balance_threshold ?? null,
+    warning_threshold: config.warning_balance_threshold ?? null,
+  };
+});
+```
+
+**Step 3: Protect POST endpoints with existing API key auth**
+
+The existing routes already use API key auth for POST endpoints. Follow the same pattern.
+
+**Step 4: Run tests**
+
+Run: `cd packages/dashboard && npx vitest run`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/src/api/routes.ts packages/dashboard/src/api/__tests__/trading-mode.test.ts
+git commit -m "feat: add API endpoints for trading mode hot toggle and wallet status"
+```
+
+---
+
+### Task 8: GCP Secret Manager Integration
+
+**Files:**
+- Create: `packages/dashboard/src/services/SecretManager.ts`
+- Create: `packages/dashboard/src/services/__tests__/SecretManager.test.ts`
+
+**Step 1: Write the failing test**
+
+```typescript
+// packages/dashboard/src/services/__tests__/SecretManager.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { loadPrivateKey } from '../SecretManager.js';
+
+vi.mock('@google-cloud/secret-manager', () => ({
+  SecretManagerServiceClient: vi.fn().mockImplementation(() => ({
+    accessSecretVersion: vi.fn().mockResolvedValue([
+      { payload: { data: Buffer.from('0xdeadbeefprivatekey') } }
+    ]),
+  })),
+}));
+
+describe('SecretManager', () => {
+  it('loads private key from GCP Secret Manager', async () => {
+    const key = await loadPrivateKey('projects/my-project/secrets/polymarket-bot-key/versions/latest');
+    expect(key).toBe('0xdeadbeefprivatekey');
+  });
+
+  it('falls back to env var if secret name not configured', async () => {
+    process.env.POLYGON_PRIVATE_KEY = '0xfallback';
+    const key = await loadPrivateKey('');
+    expect(key).toBe('0xfallback');
+    delete process.env.POLYGON_PRIVATE_KEY;
+  });
+
+  it('throws if no key available', async () => {
+    await expect(loadPrivateKey('')).rejects.toThrow();
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd packages/dashboard && npx vitest run src/services/__tests__/SecretManager.test.ts`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+```typescript
+// packages/dashboard/src/services/SecretManager.ts
+import pino from 'pino';
+
+const logger = pino({ name: 'SecretManager' });
+
+export async function loadPrivateKey(secretName: string): Promise<string> {
+  // Try GCP Secret Manager first
+  if (secretName) {
+    try {
+      const { SecretManagerServiceClient } = await import('@google-cloud/secret-manager');
+      const client = new SecretManagerServiceClient();
+      const [version] = await client.accessSecretVersion({ name: secretName });
+      const key = version.payload?.data?.toString();
+      if (key) {
+        logger.info('Private key loaded from GCP Secret Manager');
+        return key;
+      }
+    } catch (err) {
+      logger.error({ err }, 'Failed to load from GCP Secret Manager, trying env var');
+    }
+  }
+
+  // Fallback to env var (for local development / testing)
+  const envKey = process.env.POLYGON_PRIVATE_KEY;
+  if (envKey) {
+    logger.info('Private key loaded from POLYGON_PRIVATE_KEY env var');
+    return envKey;
+  }
+
+  throw new Error('No private key available. Configure GCP Secret Manager or POLYGON_PRIVATE_KEY env var.');
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd packages/dashboard && npx vitest run src/services/__tests__/SecretManager.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/src/services/SecretManager.ts packages/dashboard/src/services/__tests__/SecretManager.test.ts
+git commit -m "feat: add SecretManager for loading private key from GCP or env"
+```
+
+---
+
+### Task 9: Service Initialization (Wiring It All Together)
+
+**Files:**
+- Modify: `packages/dashboard/src/server.ts`
+
+**Context:** This task wires all new services into the startup sequence. The implementer MUST read `server.ts` first to understand the existing initialization order.
+
+**Step 1: Add initialization after existing service setup**
+
+After the existing service initialization (around where `getPolymarketService().start()` is called), add:
+
+```typescript
+// Real trading services (initialized but not active unless configured)
+import { loadPrivateKey } from './services/SecretManager.js';
+import { RealExecutor } from './services/RealExecutor.js';
+import { ExecutionRouter } from './services/ExecutionRouter.js';
+import { WalletMonitor } from './services/WalletMonitor.js';
+import { getNotificationService } from './services/NotificationService.js';
+import { tradingConfigRepo } from './database/repositories.js';
+
+async function initializeRealTrading(): Promise<void> {
+  const config = await tradingConfigRepo.getAll();
+  const walletAddress = config.wallet_address as string;
+
+  if (!walletAddress) {
+    logger.info('No wallet configured — real trading disabled');
+    return;
+  }
+
+  try {
+    const secretName = process.env.GCP_SECRET_NAME || '';
+    const privateKey = await loadPrivateKey(secretName);
+
+    // Initialize CLOB client
+    // NOTE: The exact ClobClient constructor may vary — check @polymarket/clob-client docs
+    const { ClobClient } = await import('@polymarket/clob-client');
+    const clobClient = new ClobClient(
+      process.env.CLOB_API_URL || 'https://clob.polymarket.com',
+      137, // Polygon chainId
+      privateKey
+    );
+
+    const dryRun = config.real_trading_dry_run === true;
+    const maxSlippage = (config.max_slippage as number) ?? 0.02;
+
+    const realExecutor = new RealExecutor({ clobClient, maxSlippage, dryRun });
+
+    // Initialize WalletMonitor
+    const { ethers } = await import('ethers');
+    const provider = new ethers.JsonRpcProvider(process.env.POLYGON_RPC_URL || 'https://polygon-rpc.com');
+    const USDC_ADDRESS = '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174'; // USDC on Polygon
+    const usdcAbi = ['function balanceOf(address) view returns (uint256)'];
+    const usdcContract = new ethers.Contract(USDC_ADDRESS, usdcAbi, provider);
+
+    const minBalance = (config.min_balance_threshold as number) ?? 50;
+    const warningBalance = (config.warning_balance_threshold as number) ?? minBalance * 2;
+
+    const walletMonitor = new WalletMonitor({
+      getUSDCBalance: async () => {
+        const balance = await usdcContract.balanceOf(walletAddress);
+        return Number(ethers.formatUnits(balance, 6)); // USDC has 6 decimals
+      },
+      notify: (type, payload) => getNotificationService().notify(type as any, payload),
+      setRealTradingEnabled: async (enabled) => {
+        await tradingConfigRepo.set('real_trading_enabled', enabled);
+      },
+      minBalanceThreshold: minBalance,
+      warningThreshold: warningBalance,
+    });
+
+    // Initialize ExecutionRouter
+    const executionRouter = new ExecutionRouter({
+      realExecutor,
+      getCachedBalance: () => walletMonitor.getCachedBalance(),
+      getConfig: async () => {
+        const cfg = await tradingConfigRepo.getAll();
+        return {
+          real_trading_enabled: cfg.real_trading_enabled === true,
+          real_trading_dry_run: cfg.real_trading_dry_run === true,
+          min_balance_threshold: (cfg.min_balance_threshold as number) ?? 50,
+        };
+      },
+      notify: (type, payload) => getNotificationService().notify(type as any, payload),
+    });
+
+    // Store as singletons (export getter functions from respective modules)
+    // The implementer should add setInstance/getInstance pattern to ExecutionRouter and WalletMonitor
+
+    walletMonitor.start();
+    logger.info({ walletAddress, dryRun }, 'Real trading services initialized');
+  } catch (err) {
+    logger.error({ err }, 'Failed to initialize real trading — running in paper-only mode');
+  }
+}
+
+// Call during startup (non-blocking — failure doesn't prevent paper trading)
+await initializeRealTrading();
+```
+
+**Step 2: Run full test suite**
+
+Run: `cd packages/dashboard && npx vitest run`
+Expected: All PASS
+
+**Step 3: Commit**
+
+```bash
+git add packages/dashboard/src/server.ts
+git commit -m "feat: wire real trading services into server startup"
+```
+
+---
+
+### Task 10: Calculate Initial Thresholds from Historical Data
+
+**Files:**
+- Create: `scripts/calculate-trading-thresholds.js`
+
+**Step 1: Write the script**
+
+```javascript
+// scripts/calculate-trading-thresholds.js
+// Calculates initial min_balance_threshold and warning_balance_threshold
+// from paper trading history.
+//
+// Usage: NODE_TLS_REJECT_UNAUTHORIZED=0 DATABASE_URL="..." node scripts/calculate-trading-thresholds.js
+
+const { Pool } = require('pg');
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+async function main() {
+  // Average trade cost (executed_size * executed_price) for buy trades
+  const avgCost = await pool.query(`
+    SELECT
+      AVG(value_usd) as avg_trade_cost,
+      PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY value_usd) as p75_trade_cost,
+      MAX(value_usd) as max_trade_cost,
+      COUNT(*) as total_trades
+    FROM paper_trades
+    WHERE side = 'buy'
+    AND time > NOW() - INTERVAL '14 days'
+  `);
+
+  // Average number of trades per day
+  const dailyTrades = await pool.query(`
+    SELECT
+      AVG(daily_count) as avg_daily_trades,
+      MAX(daily_count) as max_daily_trades
+    FROM (
+      SELECT DATE(time) as day, COUNT(*) as daily_count
+      FROM paper_trades
+      WHERE side = 'buy'
+      AND time > NOW() - INTERVAL '14 days'
+      GROUP BY DATE(time)
+    ) daily
+  `);
+
+  // Average concurrent open positions
+  const avgPositions = await pool.query(`
+    SELECT
+      AVG(size * avg_entry_price) as avg_position_value,
+      COUNT(*) as current_open
+    FROM paper_positions
+    WHERE closed_at IS NULL
+  `);
+
+  const stats = avgCost.rows[0];
+  const daily = dailyTrades.rows[0];
+  const positions = avgPositions.rows[0];
+
+  const avgTradeCost = parseFloat(stats.avg_trade_cost) || 50;
+  const p75TradeCost = parseFloat(stats.p75_trade_cost) || 75;
+  const avgDailyTrades = parseFloat(daily.avg_daily_trades) || 5;
+
+  // min_balance = enough for 2-3 average trades (buffer to avoid constant degradation)
+  const minBalance = Math.ceil(p75TradeCost * 3);
+  // warning = enough for ~1 day of trading
+  const warningBalance = Math.ceil(p75TradeCost * avgDailyTrades);
+
+  console.log('=== Paper Trading Statistics (last 14 days) ===');
+  console.log(`Total buy trades: ${stats.total_trades}`);
+  console.log(`Average trade cost: $${parseFloat(stats.avg_trade_cost).toFixed(2)}`);
+  console.log(`P75 trade cost: $${parseFloat(stats.p75_trade_cost).toFixed(2)}`);
+  console.log(`Max trade cost: $${parseFloat(stats.max_trade_cost).toFixed(2)}`);
+  console.log(`Average daily trades: ${parseFloat(daily.avg_daily_trades).toFixed(1)}`);
+  console.log(`Max daily trades: ${daily.max_daily_trades}`);
+  console.log(`Current open positions: ${positions.current_open}`);
+  console.log(`Average position value: $${parseFloat(positions.avg_position_value || 0).toFixed(2)}`);
+  console.log('');
+  console.log('=== Recommended Thresholds ===');
+  console.log(`min_balance_threshold: $${minBalance} (covers ~3 trades at P75 cost)`);
+  console.log(`warning_balance_threshold: $${warningBalance} (covers ~1 day of trading)`);
+  console.log('');
+  console.log('To apply these thresholds:');
+  console.log(`  curl -X POST http://localhost:3001/api/trading/mode -H "Content-Type: application/json" \\`);
+  console.log(`    -d '{"min_balance_threshold": ${minBalance}, "warning_balance_threshold": ${warningBalance}}'`);
+
+  await pool.end();
+}
+
+main().catch(err => {
+  console.error('Error:', err);
+  process.exit(1);
+});
+```
+
+**Step 2: Test locally**
+
+Run: `NODE_TLS_REJECT_UNAUTHORIZED=0 DATABASE_URL="..." node scripts/calculate-trading-thresholds.js`
+Expected: Outputs statistics and recommended thresholds
+
+**Step 3: Commit**
+
+```bash
+git add scripts/calculate-trading-thresholds.js
+git commit -m "feat: add script to calculate balance thresholds from paper trading history"
+```
+
+---
+
+### Task 11: Going-Live Documentation
+
+**Files:**
+- Create: `docs/going-live.md`
+
+**Step 1: Write the guide**
+
+Write `docs/going-live.md` with the complete onboarding flow from the design document (Section 5). Include:
+
+1. Prerequisites checklist (wallet, GCP Secret Manager, env vars)
+2. Phase 0: Setup (create wallet, store key, configure)
+3. Phase 1: Dry-run (enable, monitor 24h, checklist)
+4. Phase 2: Minimal live test ($5-10, verify cycle)
+5. Phase 3: Gradual production (deposit, thresholds, monitor)
+6. Emergency: Kill switch
+7. Common issues / troubleshooting
+8. Environment variables reference table
+
+Include exact commands for each step. The reader should be able to follow this without any other context.
+
+**Step 2: Commit**
+
+```bash
+git add docs/going-live.md
+git commit -m "docs: add going-live guide for transitioning from paper to real trading"
+```
+
+---
+
+## Task Summary
+
+| Task | Component | Estimated Steps | Dependencies |
+|------|-----------|-----------------|--------------|
+| 1 | Dependencies & Schema | 4 | None |
+| 2 | NotificationService | 5 | None |
+| 3 | WalletMonitor | 5 | Task 2 |
+| 4 | RealExecutor | 5 | Task 1 |
+| 5 | ExecutionRouter | 5 | Tasks 3, 4 |
+| 6 | AutoSignalExecutor integration | 4 | Task 5 |
+| 7 | API endpoints (hot toggle) | 5 | Tasks 5, 2 |
+| 8 | GCP Secret Manager | 5 | None |
+| 9 | Server initialization | 3 | Tasks 2-8 |
+| 10 | Threshold calculation script | 3 | None |
+| 11 | Going-live documentation | 2 | All above |
+
+**Parallelizable:** Tasks 1, 2, 4, 8, 10 can all start independently.
+
+**Critical path:** 1 → 4 → 5 → 6 → 9 → 11

--- a/docs/plans/2026-03-21-demo-frontend-plan.md
+++ b/docs/plans/2026-03-21-demo-frontend-plan.md
@@ -1,0 +1,543 @@
+# Demo Frontend Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the dashboard frontend work with real VM data for a 5-10 min demo video recording.
+
+**Architecture:** React 19 + Vite SPA connects to live API at 34.148.24.147:3001. Local dev only (Vercel stretch goal). Overview tab must look great with real data. Hide broken features.
+
+**Tech Stack:** React 19, Vite 7, Tailwind CSS 4, Recharts 3, TanStack React Query 5
+
+---
+
+### Task 1: Get Frontend Running Locally
+
+**Files:**
+- Modify: `packages/dashboard/frontend/.env` (create if not exists)
+- Read: `packages/dashboard/frontend/package.json`
+
+**Step 1: Install dependencies**
+
+```bash
+cd packages/dashboard/frontend && npm install
+```
+
+**Step 2: Create .env file for local dev**
+
+Create `packages/dashboard/frontend/.env`:
+```
+VITE_API_URL=http://34.148.24.147:3001
+VITE_WS_URL=ws://34.148.24.147:3001/ws
+```
+
+No API key needed for GET requests (auth only required for POST).
+
+**Step 3: Start dev server**
+
+```bash
+cd packages/dashboard/frontend && npm run dev
+```
+
+Expected: Vite dev server starts on http://localhost:5173. May show TypeScript or runtime errors — that's fine, we'll fix them in subsequent tasks.
+
+**Step 4: Check for build errors**
+
+```bash
+cd packages/dashboard/frontend && npx tsc --noEmit
+```
+
+Note all errors for the next task.
+
+**Step 5: Verify API connectivity**
+
+Open browser devtools Network tab, check if requests to `http://34.148.24.147:3001/api/status` return data. If CORS error, we'll fix in Task 2.
+
+---
+
+### Task 2: Fix Build Errors and API Connectivity
+
+**Files:**
+- Modify: `packages/dashboard/frontend/src/lib/api.ts` (if fetch wrapper needs fixes)
+- Modify: `packages/dashboard/frontend/src/types/api.ts` (if types need updating)
+- Possibly modify: `packages/dashboard/src/api/server.ts` (if CORS needs fixing)
+
+**Step 1: Fix any TypeScript compilation errors from Task 1**
+
+Common issues to expect:
+- Import path issues
+- Type mismatches with newer library versions
+- Missing type definitions
+
+Fix each error. Run `npx tsc --noEmit` after each fix until clean.
+
+**Step 2: Test API connectivity in browser**
+
+Open http://localhost:5173 and check Network tab:
+- If CORS error: backend already has `origin: '*'` so this should work. If not, SSH to VM and check CORS_ORIGIN env var in docker-compose.gcp.yml
+- If connection refused: verify VM firewall allows port 3001 (it should — dashboard is already exposed)
+- If 401: only POST requests need auth, GET should work without API key
+
+**Step 3: Verify data loads in console**
+
+Open browser console. The Dashboard component calls `Promise.all([api.getStatus(), api.getPositions(), api.getAlerts(10), api.getPerformance()])` on mount. Check that at least `getStatus()` returns valid data.
+
+**Step 4: Commit**
+
+```bash
+git add packages/dashboard/frontend/.env packages/dashboard/frontend/package-lock.json
+git commit -m "chore: configure frontend for local dev with VM API"
+```
+
+Note: .env has no secrets (just public VM IP), safe to commit. If preferred, add to .gitignore instead.
+
+---
+
+### Task 3: Fix Dashboard Overview Data Mapping
+
+The Dashboard expects a `DashboardState` type from `/api/status`, but the backend response may not match exactly. Also, some data is better sourced from `/api/paper/account`.
+
+**Files:**
+- Modify: `packages/dashboard/frontend/src/components/Dashboard.tsx`
+- Modify: `packages/dashboard/frontend/src/lib/api.ts`
+- Modify: `packages/dashboard/frontend/src/types/api.ts`
+
+**Step 1: Add paper account API call**
+
+In `api.ts`, there's already `getPaperTradingStatus()` pointing to `/api/paper-trading/status`. Add or verify a function for the paper account:
+
+```typescript
+getPaperAccount: async () => fetchApi<PaperAccount>('/api/paper/account'),
+```
+
+Add the `PaperAccount` type to `types/api.ts`:
+
+```typescript
+export interface PaperAccount {
+  initial_capital: number;
+  current_capital: number;
+  available_capital: number;
+  total_realized_pnl: number;
+  total_unrealized_pnl: number;
+  total_fees_paid: number;
+  max_drawdown: number;
+  peak_equity: number;
+  total_trades: number;
+  winning_trades: number;
+  losing_trades: number;
+  win_rate: number;
+  updated_at: string;
+}
+```
+
+**Step 2: Update Dashboard to use paper account data**
+
+In Dashboard.tsx, add `api.getPaperAccount()` to the initial `Promise.all`. Use it to populate the stat cards with accurate data:
+
+- **Total Equity**: `paperAccount.current_capital` (this is the real number from DB)
+- **Total P&L**: `paperAccount.total_realized_pnl`
+- **Win Rate**: `paperAccount.win_rate` (note: backend returns 0-100, not 0-1)
+- **Total Trades**: `paperAccount.total_trades`
+
+The `/api/status` endpoint returns calculated values from the trading system's in-memory state, which may be stale or zero after restarts. The paper account DB values are the source of truth.
+
+**Step 3: Fix stat card display**
+
+Ensure the 4 top-level stat cards show:
+1. **Total Equity**: `formatCurrency(paperAccount.current_capital)` with trend based on PnL sign
+2. **Total P&L**: `formatCurrency(paperAccount.total_realized_pnl)` with percentage `(pnl/initial * 100)`
+3. **Win Rate**: `paperAccount.win_rate.toFixed(1) + '%'` (already 0-100 from backend)
+4. **Open Positions**: from status or positions array length
+
+**Step 4: Handle loading/error states gracefully**
+
+If any API call fails, show what we have rather than an error screen. Use optional chaining and fallback values:
+
+```typescript
+const equity = paperAccount?.current_capital ?? state?.equity ?? 0;
+const totalPnl = paperAccount?.total_realized_pnl ?? state?.totalPnl ?? 0;
+```
+
+**Step 5: Verify in browser**
+
+Load http://localhost:5173 — stat cards should show real numbers ($12,493, +$2,498, etc.)
+
+**Step 6: Commit**
+
+```bash
+git add packages/dashboard/frontend/src/
+git commit -m "feat: connect dashboard overview to paper account real data"
+```
+
+---
+
+### Task 4: Connect Equity Curve to Real Data
+
+The equity chart in Dashboard.tsx uses HARDCODED dummy data. Must connect to real API.
+
+**Files:**
+- Modify: `packages/dashboard/frontend/src/components/Dashboard.tsx`
+- Modify: `packages/dashboard/frontend/src/lib/api.ts`
+- Modify: `packages/dashboard/frontend/src/types/api.ts`
+
+**Step 1: Add equity curve API function**
+
+In `api.ts`, add or verify:
+
+```typescript
+getEquityCurve: async (days: number = 30) =>
+  fetchApi<EquityCurvePoint[]>('/api/portfolio/equity-curve?days=' + days),
+```
+
+Add type to `types/api.ts`:
+
+```typescript
+export interface EquityCurvePoint {
+  timestamp: string;
+  value: number;
+}
+```
+
+Note: The backend returns `{ points: [...], drawdowns: [...] }` from the equity curve endpoint. The frontend may need to extract `.points` — check actual response shape and adjust.
+
+**Step 2: Fetch equity curve data on mount**
+
+Add to the `Promise.all` in Dashboard.tsx:
+
+```typescript
+api.getEquityCurve(30)
+```
+
+Store in state: `equityCurve: EquityCurvePoint[]`
+
+**Step 3: Replace hardcoded chart data**
+
+Find the hardcoded `chartData` array in Dashboard.tsx and replace with:
+
+```typescript
+const chartData = equityCurve.map(point => ({
+  date: new Date(point.timestamp).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+  value: point.value,
+}));
+```
+
+**Step 4: Handle empty equity curve**
+
+If no data or API fails, show a message like "Collecting equity data..." instead of an empty chart.
+
+**Step 5: Verify chart shows real data**
+
+The chart should show the equity progression from ~$10,000 to ~$12,500 over time.
+
+**Important**: If `/api/portfolio/equity-curve` returns empty (no snapshots in DB), we may need to fall back to `/api/paper/account` data and construct a minimal curve, or ensure the backend has `paper_account_equity_daily` data. Check by hitting the endpoint directly: `curl http://34.148.24.147:3001/api/portfolio/equity-curve?days=30`
+
+**Step 6: Commit**
+
+```bash
+git add packages/dashboard/frontend/src/
+git commit -m "feat: connect equity curve chart to real historical data"
+```
+
+---
+
+### Task 5: Fix Positions and Trades Display
+
+**Files:**
+- Modify: `packages/dashboard/frontend/src/components/Dashboard.tsx`
+- Modify: `packages/dashboard/frontend/src/types/api.ts`
+
+**Step 1: Check positions API response**
+
+The frontend `Position` type expects: `marketId`, `outcome`, `size`, `avgEntryPrice`, `currentPrice`, `unrealizedPnl`, `realizedPnl`, `openedAt`.
+
+The backend `/api/paper-positions` returns: `market_id`, `token_id`, `side`, `size`, `entry_price`, `current_price`, `unrealized_pnl`, etc. (snake_case).
+
+Either:
+a) Map snake_case to camelCase in the API call, OR
+b) Update the frontend types to use snake_case
+
+Option (a) is cleaner — add a mapper in api.ts.
+
+**Step 2: Use paper-positions endpoint**
+
+The Dashboard calls `api.getPositions()` which hits `/api/positions`. This is the trading engine's in-memory positions, which may be empty after restart. Switch to `/api/paper-positions` which reads from DB:
+
+```typescript
+getPositions: async () => {
+  const raw = await fetchApi<any[]>('/api/paper-positions');
+  return raw.map(p => ({
+    marketId: p.market_id,
+    outcome: p.side === 'long' ? 'YES' : 'NO',
+    size: p.size,
+    avgEntryPrice: p.entry_price,
+    currentPrice: p.current_price ?? p.entry_price,
+    unrealizedPnl: p.unrealized_pnl ?? 0,
+    realizedPnl: p.realized_pnl ?? 0,
+    openedAt: p.entry_time,
+  }));
+},
+```
+
+**Step 3: Show market question instead of market ID**
+
+The positions table shows `marketId` which is a long hash. For the demo, showing the market question is much better. If the position doesn't include the question, we can either:
+a) Join from `/api/polymarket/markets` data, or
+b) Truncate the market ID to first 8 chars as fallback
+
+Prefer (a) if data is available.
+
+**Step 4: Verify positions display**
+
+Load the dashboard. If positions are open, they should show in the table with readable names, entry/current prices, and PnL colored green/red.
+
+If no positions are currently open (issue #40 says 0 open positions), that's fine — the table should show an empty state message like "No open positions".
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/frontend/src/
+git commit -m "feat: connect positions table to paper positions with proper field mapping"
+```
+
+---
+
+### Task 6: Add Performance Metrics from Real Data
+
+**Files:**
+- Modify: `packages/dashboard/frontend/src/components/Dashboard.tsx`
+
+**Step 1: Check /api/analytics/performance response**
+
+Hit the endpoint: `curl http://34.148.24.147:3001/api/analytics/performance`
+
+If it returns empty/error (likely if analytics service depends on in-memory state), fall back to computing from paper account:
+
+```typescript
+const metrics = performance ?? {
+  sharpeRatio: 0,
+  maxDrawdown: paperAccount?.max_drawdown ?? 0,
+  winRate: (paperAccount?.win_rate ?? 0) / 100, // convert 0-100 to 0-1
+  profitFactor: paperAccount?.winning_trades && paperAccount?.losing_trades
+    ? paperAccount.winning_trades / paperAccount.losing_trades : 0,
+  totalTrades: paperAccount?.total_trades ?? 0,
+  volatility: 0,
+};
+```
+
+**Step 2: Display performance metrics grid**
+
+The 6 metric cards should show:
+1. **Sharpe Ratio**: from performance or "N/A"
+2. **Max Drawdown**: `formatPercent(maxDrawdown)` — remember to check if it's already 0-1 or 0-100
+3. **Win Rate**: `formatPercent(winRate)`
+4. **Profit Factor**: `formatNumber(profitFactor, 2)`
+5. **Total Trades**: `formatNumber(totalTrades, 0)`
+6. **Volatility**: from performance or "N/A"
+
+**Step 3: Verify metrics display**
+
+At minimum, win rate (~34.57%), max drawdown (~1.15%), and total trades (~162) should show real values.
+
+**Step 4: Commit**
+
+```bash
+git add packages/dashboard/frontend/src/
+git commit -m "feat: display real performance metrics with paper account fallback"
+```
+
+---
+
+### Task 7: Hide Broken Features and Polish UI
+
+**Files:**
+- Modify: `packages/dashboard/frontend/src/components/Dashboard.tsx`
+
+**Step 1: Conditionally hide Backtest tab**
+
+The Backtest tab is not needed for the demo. Hide it:
+
+```typescript
+// In the tab buttons, remove or hide the Backtest button
+// Only show Overview and Automation tabs
+```
+
+Or simply remove the tab button. Keep the component code but don't render the tab trigger.
+
+**Step 2: Review Automation tab**
+
+Check if AutomationPanel works by visiting the tab. It polls `/api/automation/status`, `/api/signals/status`, `/api/polymarket/status`. These should work since the services are running on the VM.
+
+If it works: keep it — showing start/stop controls is impressive for the demo.
+If it errors: hide the tab too, keep only Overview.
+
+**Step 3: Hide "Today's P&L" if not available**
+
+`todayPnl` from `/api/status` depends on in-memory tracking which resets on restart. If it shows $0 while total PnL is $2,498, it's confusing. Either:
+- Replace with a different useful metric (e.g., "Fees Paid", "Total Return %")
+- Show it but mark as "since restart"
+
+**Step 4: Clean up the alerts section**
+
+If `/api/alerts` returns empty (likely), either:
+- Hide the alerts section entirely
+- Show a "No recent alerts" message
+
+**Step 5: Polish risk metrics bars**
+
+The exposure and drawdown progress bars should show real data from `/api/status`. Verify they display correctly (drawdown 1.15% should show a tiny bar).
+
+**Step 6: Add subtle branding**
+
+Add a small text at the bottom or top: "Polymarket Trading System — Paper Trading Mode" to make it clear in the video what this is.
+
+**Step 7: Verify full Overview tab**
+
+Walk through the entire Overview tab and confirm:
+- [ ] Stat cards show real numbers
+- [ ] Equity curve shows real progression
+- [ ] Performance metrics show real values
+- [ ] Positions table works (even if empty)
+- [ ] No error states visible
+- [ ] No broken/empty sections
+
+**Step 8: Commit**
+
+```bash
+git add packages/dashboard/frontend/src/
+git commit -m "feat: polish dashboard for demo — hide broken features, clean empty states"
+```
+
+---
+
+### Task 8: Add "Claude is Watching" Indicator (Optional Enhancement)
+
+**Files:**
+- Modify: `packages/dashboard/frontend/src/components/Dashboard.tsx`
+- Modify: `packages/dashboard/frontend/src/lib/api.ts`
+
+**Step 1: Determine data source**
+
+Option A: Fetch latest GitHub issue from the auto-review via GitHub API (adds external dependency)
+Option B: Add a simple static indicator that links to the GitHub issues page
+Option C: Show last auto-review timestamp from a simple file/endpoint on the VM
+
+Recommend Option B for simplicity — a small card or badge:
+
+```tsx
+<div className="flex items-center gap-2 px-3 py-1.5 bg-purple-900/30 border border-purple-700/50 rounded-lg text-sm">
+  <div className="w-2 h-2 bg-purple-400 rounded-full animate-pulse" />
+  <span className="text-purple-300">Auto-Review Active</span>
+  <span className="text-purple-500">· Daily at 08:00 UTC</span>
+</div>
+```
+
+Place this in the Dashboard header, next to the connection status indicator.
+
+**Step 2: Make it link to GitHub issues**
+
+Wrap in an anchor tag:
+```tsx
+<a href="https://github.com/JaviMaligno/polymarket-trader/issues?q=is%3Aissue+label%3Adaily-review"
+   target="_blank" rel="noopener noreferrer"
+   className="hover:bg-purple-900/50 transition-colors ...">
+```
+
+**Step 3: Verify it looks good**
+
+The purple badge should complement the dark theme and be visible but not dominating.
+
+**Step 4: Commit**
+
+```bash
+git add packages/dashboard/frontend/src/
+git commit -m "feat: add Claude auto-review indicator to dashboard header"
+```
+
+---
+
+### Task 9: Final Testing and Recording Prep
+
+**Files:** None (testing only)
+
+**Step 1: Full page test**
+
+1. Start frontend: `cd packages/dashboard/frontend && npm run dev`
+2. Open http://localhost:5173
+3. Verify Overview tab loads with real data
+4. Verify Automation tab shows service statuses (if kept)
+5. Click through all visible UI elements
+6. Check browser console for errors — fix any that appear
+
+**Step 2: Test at recording resolution**
+
+Set browser to a clean state:
+- No bookmarks bar
+- No extensions visible
+- Zoom level that makes the dashboard readable on video (try 90% or 100%)
+- Window size ~1920x1080 or 1280x720
+
+**Step 3: Prepare browser tabs for recording**
+
+1. Tab 1: Dashboard (http://localhost:5173)
+2. Tab 2: GitHub Issue #40 (https://github.com/JaviMaligno/polymarket-trader/issues/40)
+3. Tab 3: GitHub PR #41 (https://github.com/JaviMaligno/polymarket-trader/pull/41)
+
+**Step 4: Test screen recording setup**
+
+Record a 30-second test with Loom/OBS to verify:
+- Dashboard is visible and readable
+- Webcam circle is positioned and not covering important UI
+- Audio is clear
+
+---
+
+### Task 10 (Stretch): Deploy to Vercel
+
+**Files:**
+- Create: `packages/dashboard/frontend/vercel.json`
+
+**Step 1: Create vercel.json**
+
+```json
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "vite"
+}
+```
+
+**Step 2: Deploy**
+
+```bash
+cd packages/dashboard/frontend
+npx vercel --prod
+```
+
+Set environment variables in Vercel dashboard:
+- `VITE_API_URL=http://34.148.24.147:3001`
+- `VITE_WS_URL=ws://34.148.24.147:3001/ws`
+
+**Step 3: Test CORS**
+
+If CORS fails from Vercel domain, update `CORS_ORIGIN` env var on the VM to include the Vercel URL, or keep it as `*`.
+
+**Step 4: Verify**
+
+Open the Vercel URL and confirm all data loads correctly.
+
+---
+
+## Priority Order
+
+1. **Tasks 1-2**: Get it running (foundation)
+2. **Tasks 3-4**: Real data in stat cards + equity curve (visual impact)
+3. **Tasks 5-6**: Positions + metrics (completeness)
+4. **Task 7**: Hide broken stuff, polish (demo-ready)
+5. **Task 8**: "Claude is watching" badge (wow factor)
+6. **Task 9**: Recording prep (final)
+7. **Task 10**: Vercel (stretch)
+
+## Critical Unknowns to Resolve Early
+
+1. Does `/api/portfolio/equity-curve` return data? If no snapshots exist, the chart will be empty — may need to seed data or use alternative endpoint.
+2. Does `/api/analytics/performance` work or is it in-memory only? If in-memory, need paper account fallback.
+3. Are there any open positions right now? Issue #40 says 0 — positions table may be empty during recording.

--- a/docs/plans/2026-03-24-system-audit-fixes-design.md
+++ b/docs/plans/2026-03-24-system-audit-fixes-design.md
@@ -1,0 +1,161 @@
+# System Audit Fixes — 2026-03-24
+
+## Context
+
+Independent review of the auto-review (issue #47) found 15 issues across 3 severity levels that the auto-review missed. Most critically, the reported 190% return ($19K PnL) is phantom — real cash profit is ~$426. Root cause: `realized_pnl` accumulates across position re-opens via upsert.
+
+## Findings Summary
+
+### Critical
+1. **Phantom PnL**: upsert preserves `realized_pnl` across re-opens → PnL accumulates across cycles
+2. **Port 5432 brute force**: 36,544 auth failures/24h, open to internet
+3. **Race condition**: concurrent signals can double-debit capital for same market
+
+### High
+4. `available_capital` not locked when opening positions
+5. OOM Kill on data-collector (60 MiB limit) → 2 restarts/24h
+6. 21 DB connection timeouts cascading to StopLoss, CircuitBreaker, RiskManager
+7. Daily PnL check mixes equity (snapshot) with cash (current_capital) → spurious halts
+
+### Medium
+8. Only 2/5 signal weights loaded on startup (missing OFI, MLOFI, Hawkes)
+9. Render Optuna returning 500 errors on trials
+10. 4 markets with empty `token_id` sent to CLOB API
+11. 10 markets marked active with price data 3-25 weeks old
+12. `checkDayReset()` not awaited in RiskManager
+
+### Low
+13. SignalLearning always "0 signals, 0 adjusted" — non-functional
+14. Consecutive-loss counter resets on restart (not persisted)
+15. Drawdown check uses env var `INITIAL_CAPITAL`, not DB value
+
+## Execution Plan
+
+### Phase 1 — Immediate Security (today)
+
+**1. Restrict GCP firewall**
+
+Update `allow-postgres-render` rule to restrict source IPs to Render's egress ranges only. Currently allows `0.0.0.0/0`.
+
+```bash
+gcloud compute firewall-rules update allow-postgres-render \
+  --source-ranges="<render-egress-ips>" \
+  --description="PostgreSQL access restricted to Render egress IPs"
+```
+
+Future: close port entirely, move optimization inside VM (Phase B).
+
+**2. Increase data-collector memory limit**
+
+In `docker-compose.gcp.yml`, change memory limit from 60M to 150M. Dashboard-api uses 180M at 35% — there is headroom on the 1GB VM.
+
+### Phase 2 — Critical PnL Fix (today)
+
+**3. Eliminate upsert — always INSERT**
+
+Replace `ON CONFLICT (market_id, token_id) DO UPDATE` in `paperPositionsRepo.upsert()` with a plain INSERT. Add a partial unique index:
+
+```sql
+CREATE UNIQUE INDEX idx_one_open_position_per_token
+  ON paper_positions (market_id, token_id)
+  WHERE closed_at IS NULL;
+```
+
+This prevents two open positions on the same token at DB level while allowing multiple closed rows.
+
+**4. Atomic transaction**
+
+Wrap the position-opening flow in AutoSignalExecutor in a single DB transaction:
+
+```
+BEGIN
+  SELECT FROM paper_positions
+    WHERE market_id=$1 AND token_id=$2 AND closed_at IS NULL
+    FOR UPDATE
+  → if exists, ROLLBACK
+  UPDATE paper_account
+    SET available_capital = available_capital - $cost,
+        current_capital = current_capital - $cost
+  INSERT INTO paper_positions (...)
+COMMIT
+```
+
+This serializes concurrent signals for the same token. The second signal waits for the lock and sees the already-inserted position.
+
+**5. Account reset from real cash flows**
+
+Script to recalculate capital from `paper_trades` (source of truth for actual cash movement):
+
+```sql
+WITH flows AS (
+  SELECT
+    SUM(CASE WHEN side='sell' THEN amount ELSE -amount END) as net_cash,
+    SUM(fee) as total_fees
+  FROM paper_trades
+)
+UPDATE paper_account SET
+  current_capital = initial_capital + flows.net_cash,
+  available_capital = initial_capital + flows.net_cash,
+  total_realized_pnl = flows.net_cash + flows.total_fees,
+  total_fees_paid = flows.total_fees
+FROM flows;
+```
+
+### Phase 3 — Medium/Low Code Fixes
+
+**6. Fix `available_capital` locking**
+
+The atomic transaction from Phase 2 already debits both `current_capital` and `available_capital`. Verify `PositionClosingService` correctly restores both on close.
+
+**7. Daily PnL check — consistent metric**
+
+In `RiskManager.ts:219`, `dayStartEquity` is equity (from snapshot) but compared to `currentCapital` (cash only). Fix: change `PaperTradingService.recordSnapshot()` to store `current_capital` instead of `equity`, making the comparison cash-vs-cash.
+
+**8. Load all 5 signal weights on startup**
+
+In `server.ts:227-243`, add `ofi`, `mlofi`, and `hawkes` to the `weightMap`. Without this, optimizer results for these 3 signal types are silently ignored on restart.
+
+**9. Await `checkDayReset()`**
+
+In `RiskManager.ts:177`, add `await`. One-word fix.
+
+**10. Persist consecutive-loss counter**
+
+Store `consecutiveLosses` in `trading_config` table (same pattern as stop-loss cooldowns). Load on startup. Prevents restart from resetting the circuit breaker counter.
+
+### Phase 4 — Auto-Review Improvements
+
+**11. Expand `daily-review.sh` data collection**
+
+Add generic sections to the JSON output:
+
+- `container_health`: restart count, memory %, uptime, OOM kills from dmesg
+- `error_summary`: error count by service, grouped by category (DB timeout, API error, unhandled rejection)
+- `db_security`: FATAL count in TimescaleDB logs (detects auth attacks generically)
+- `disk_and_resources`: disk usage, active DB connections
+
+Principle: collect data the model can interpret, don't pre-diagnose.
+
+**12. Generalized SQL invariant checks**
+
+Add an `invariant_checks` section with PASS/FAIL queries:
+
+- `capital_consistency`: `|current_capital - (initial + net_cash_flows)| < $1`
+- `available_vs_locked`: `|available_capital - (current_capital - SUM(open costs))| < $1`
+- `pnl_crosscheck`: `|total_realized_pnl - net_cash_flows| < tolerance`
+- `no_zombies`: `COUNT(*) WHERE closed_at IS NOT NULL AND size > 0 = 0`
+- `no_orphaned_capital`: open positions must have corresponding locked capital
+
+These validate system invariants regardless of what specific bugs exist.
+
+**13. Weekly deep code review (later)**
+
+Separate workflow with code-reviewer agent. Design after Phases 1-3 complete.
+
+## Decisions
+
+- Upsert eliminated entirely (not just `realized_pnl = 0`) — cleaner data model
+- Account reset from cash flows, not clean slate — preserves trade history
+- Firewall restricted to Render IPs now, full closure later
+- Auto-review improvements are generic invariant checks, not overfitted to today's bugs
+- Snapshot stores cash not equity — simpler, avoids mixing metrics

--- a/docs/plans/2026-03-24-system-audit-fixes-plan.md
+++ b/docs/plans/2026-03-24-system-audit-fixes-plan.md
@@ -1,0 +1,860 @@
+# System Audit Fixes — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix 15 issues found by independent system audit, starting with security and phantom PnL, then code fixes and auto-review improvements.
+
+**Architecture:** Phase 1 is infra-only (firewall + docker-compose). Phase 2 rewrites position opening to use INSERT + transaction instead of upsert. Phase 3 is targeted code fixes. Phase 4 adds invariant checks to daily-review.sh.
+
+**Tech Stack:** TypeScript (Node.js), PostgreSQL/TimescaleDB, Docker Compose, GCP Firewall, Bash
+
+---
+
+### Task 1: Restrict GCP Firewall to Render IPs
+
+**Files:**
+- Modify: `docker-compose.gcp.yml` (port binding)
+
+**Step 1: Get Render's egress IPs and current firewall rule**
+
+Run:
+```bash
+gcloud compute firewall-rules describe allow-postgres-render --format="yaml(sourceRanges,direction,allowed)"
+```
+Expected: Shows `sourceRanges: ['0.0.0.0/0']`
+
+Then get the Render service's outbound IP:
+```bash
+# Check Render docs or the service's outbound IP
+curl -s https://polymarket-optimizer-server.onrender.com/health 2>/dev/null || echo "Check Render dashboard for static outbound IPs"
+```
+
+**Step 2: Update firewall rule to restrict source IPs**
+
+If Render provides static outbound IPs, use those. Otherwise, restrict to Render's Oregon region ranges. As a minimum, remove `0.0.0.0/0`:
+
+```bash
+gcloud compute firewall-rules update allow-postgres-render \
+  --source-ranges="<RENDER_IP_1>/32,<RENDER_IP_2>/32" \
+  --description="PostgreSQL access restricted to Render Optuna optimizer egress IPs"
+```
+
+If Render IPs are dynamic/unknown, bind TimescaleDB to localhost only as an interim measure — change `docker-compose.gcp.yml` port from `"5432:5432"` to `"127.0.0.1:5432:5432"`. This blocks all external access. Optuna would need an SSH tunnel or to run on the VM.
+
+**Step 3: Verify the firewall change**
+
+```bash
+gcloud compute firewall-rules describe allow-postgres-render --format="value(sourceRanges)"
+```
+Expected: Shows the restricted IP range, NOT `0.0.0.0/0`
+
+**Step 4: Commit**
+
+```bash
+git add docker-compose.gcp.yml
+git commit -m "fix: restrict port 5432 firewall to Render IPs only
+
+Closes active brute-force attack (36,544 auth failures/24h).
+Previously open to 0.0.0.0/0 for Render Optuna."
+```
+
+---
+
+### Task 2: Increase Data Collector Memory Limit
+
+**Files:**
+- Modify: `docker-compose.gcp.yml:88-93`
+
+**Step 1: Update memory limits**
+
+In `docker-compose.gcp.yml`, change the data-collector deploy resources:
+
+```yaml
+# Before:
+    deploy:
+      resources:
+        limits:
+          memory: 60M
+        reservations:
+          memory: 40M
+
+# After:
+    deploy:
+      resources:
+        limits:
+          memory: 150M
+        reservations:
+          memory: 60M
+```
+
+Also update the comment at top of file:
+```yaml
+# Before:
+# Memory budget: TimescaleDB 350M + Data Collector 60M + Dashboard 180M = 590M
+
+# After:
+# Memory budget: TimescaleDB 350M + Data Collector 150M + Dashboard 180M = 680M
+```
+
+**Step 2: Verify total memory budget is under 1GB**
+
+350M + 150M + 180M = 680M. VM has 1GB. Linux overhead ~200M. Fits.
+
+**Step 3: Commit**
+
+```bash
+git add docker-compose.gcp.yml
+git commit -m "fix: increase data-collector memory limit 60M→150M
+
+OOM killer was hitting the container (2 restarts/24h).
+55% usage at 60M left no headroom for spikes."
+```
+
+---
+
+### Task 3: Deploy Phase 1 to VM
+
+**Step 1: Push changes and wait for CI/CD, or deploy manually**
+
+```bash
+git push origin main
+```
+
+Then SSH to VM and pull:
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="cd /home/Usuario/polymarket-trader && git pull && docker compose -f docker-compose.gcp.yml up -d --remove-orphans"
+```
+
+**Step 2: Verify containers are healthy**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="docker ps --format 'table {{.Names}}\t{{.Status}}'"
+```
+Expected: All 3 containers show "healthy"
+
+**Step 3: Verify data-collector memory**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="docker stats --no-stream --format '{{.Name}}: {{.MemUsage}}' polymarket-data-collector"
+```
+Expected: Shows `X MiB / 150 MiB` instead of old `/ 60 MiB`
+
+---
+
+### Task 4: Add Partial Unique Index for Open Positions
+
+**Files:**
+- Modify: `packages/dashboard/src/database/repositories.ts:339-384`
+- Modify: `packages/data-collector/src/database/init/001-schema.sql` (if index needs to be in init scripts)
+
+**Step 1: Create a migration SQL to add the partial unique index**
+
+The index needs to be created on the VM DB. Add it to the init script AND run it manually for existing DB.
+
+Add to the bottom of the init SQL (or create a new migration script):
+
+```sql
+-- Partial unique index: only one open position per (market_id, token_id)
+-- Allows multiple closed rows for the same pair
+CREATE UNIQUE INDEX IF NOT EXISTS idx_one_open_position_per_token
+  ON paper_positions (market_id, token_id)
+  WHERE closed_at IS NULL;
+```
+
+**Step 2: Run migration on VM**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"CREATE UNIQUE INDEX IF NOT EXISTS idx_one_open_position_per_token ON paper_positions (market_id, token_id) WHERE closed_at IS NULL;\""
+```
+
+Expected: `CREATE INDEX` (or notice if already exists)
+
+If it fails with "duplicate key", there are multiple open positions for the same token. Fix first:
+```sql
+-- Close duplicates keeping only the most recent
+UPDATE paper_positions SET closed_at = NOW(), size = 0
+WHERE id NOT IN (
+  SELECT DISTINCT ON (market_id, token_id) id
+  FROM paper_positions
+  WHERE closed_at IS NULL
+  ORDER BY market_id, token_id, opened_at DESC
+)
+AND closed_at IS NULL;
+```
+
+**Step 3: Commit**
+
+```bash
+git add packages/data-collector/src/database/init/
+git commit -m "feat: add partial unique index for one open position per token
+
+Prevents phantom PnL from upsert re-opens. Only one open position
+allowed per (market_id, token_id) at DB level."
+```
+
+---
+
+### Task 5: Replace Upsert with INSERT + Atomic Transaction
+
+**Files:**
+- Modify: `packages/dashboard/src/database/repositories.ts:338-434`
+- Modify: `packages/dashboard/src/services/AutoSignalExecutor.ts:360-370,640-690`
+- Test: `packages/dashboard/src/database/repositories.test.ts`
+
+**Step 1: Replace `paperPositionsRepo.upsert()` with `insert()`**
+
+In `packages/dashboard/src/database/repositories.ts`, replace the `upsert` method:
+
+```typescript
+export const paperPositionsRepo = {
+  /**
+   * Insert a new position. Relies on partial unique index
+   * idx_one_open_position_per_token to prevent duplicates.
+   */
+  async insert(position: PaperPosition): Promise<void> {
+    await query(
+      `INSERT INTO paper_positions
+       (market_id, token_id, side, size, avg_entry_price, current_price,
+        unrealized_pnl, unrealized_pnl_pct, realized_pnl, stop_loss, take_profit,
+        opened_at, signal_type, metadata, market_score_at_entry, score_dimensions_at_entry,
+        execution_mode)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+      [
+        position.market_id,
+        position.token_id,
+        position.side,
+        position.size,
+        position.avg_entry_price,
+        position.current_price,
+        position.unrealized_pnl,
+        position.unrealized_pnl_pct,
+        position.realized_pnl ?? 0,
+        position.stop_loss,
+        position.take_profit,
+        position.opened_at,
+        position.signal_type,
+        JSON.stringify(position.metadata ?? {}),
+        position.market_score_at_entry ?? null,
+        position.score_dimensions_at_entry != null ? JSON.stringify(position.score_dimensions_at_entry) : null,
+        position.execution_mode ?? 'paper',
+      ]
+    );
+  },
+```
+
+Keep the old `upsert` method but mark it `@deprecated` and have it call `insert()` internally as a shim if any other code still references it.
+
+**Step 2: Create `openPositionAtomically()` in repositories.ts**
+
+Add a new method that wraps the entire open-position flow in a transaction:
+
+```typescript
+  /**
+   * Atomically: check no open position exists → debit account → insert position.
+   * Uses SELECT FOR UPDATE to serialize concurrent opens on the same token.
+   * Returns false if position already exists (no-op).
+   */
+  async openPositionAtomically(
+    position: PaperPosition,
+    cost: number,
+    fee: number,
+  ): Promise<{ opened: boolean; reason?: string }> {
+    try {
+      return await transaction(async (client: PoolClient) => {
+        // Lock any existing open position for this token
+        const existing = await client.query(
+          `SELECT id FROM paper_positions
+           WHERE market_id = $1 AND token_id = $2 AND closed_at IS NULL
+           FOR UPDATE`,
+          [position.market_id, position.token_id]
+        );
+
+        if (existing.rows.length > 0) {
+          return { opened: false, reason: 'Position already open for this token' };
+        }
+
+        // Debit account atomically
+        const acctResult = await client.query(
+          `UPDATE paper_account SET
+            current_capital = current_capital - $1,
+            available_capital = available_capital - $1,
+            total_fees_paid = total_fees_paid + $2,
+            total_trades = total_trades + 1,
+            updated_at = NOW()
+          WHERE id = 1
+          RETURNING available_capital`,
+          [cost + fee, fee]
+        );
+
+        const newAvailable = parseFloat(acctResult.rows[0]?.available_capital ?? '0');
+        if (newAvailable < 0) {
+          // Insufficient capital — transaction will rollback
+          throw new Error(`Insufficient capital: available would be $${newAvailable.toFixed(2)}`);
+        }
+
+        // Insert position
+        await client.query(
+          `INSERT INTO paper_positions
+           (market_id, token_id, side, size, avg_entry_price, current_price,
+            unrealized_pnl, unrealized_pnl_pct, realized_pnl, stop_loss, take_profit,
+            opened_at, signal_type, metadata, market_score_at_entry, score_dimensions_at_entry,
+            execution_mode)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+          [
+            position.market_id,
+            position.token_id,
+            position.side,
+            position.size,
+            position.avg_entry_price,
+            position.current_price,
+            position.unrealized_pnl ?? 0,
+            position.unrealized_pnl_pct ?? 0,
+            0, // realized_pnl always starts at 0
+            position.stop_loss,
+            position.take_profit,
+            position.opened_at,
+            position.signal_type,
+            JSON.stringify(position.metadata ?? {}),
+            position.market_score_at_entry ?? null,
+            position.score_dimensions_at_entry != null
+              ? JSON.stringify(position.score_dimensions_at_entry)
+              : null,
+            position.execution_mode ?? 'paper',
+          ]
+        );
+
+        return { opened: true };
+      });
+    } catch (error: any) {
+      // Unique constraint violation = race condition caught by index
+      if (error.code === '23505') {
+        return { opened: false, reason: 'Position already open (unique constraint)' };
+      }
+      throw error;
+    }
+  },
+```
+
+**Step 3: Update AutoSignalExecutor to use `openPositionAtomically()`**
+
+In `packages/dashboard/src/services/AutoSignalExecutor.ts`, replace lines 641-689 (the account debit + upsert + reversal block) with:
+
+```typescript
+      // Open position atomically: check + debit + insert in one transaction
+      const openResult = await paperPositionsRepo.openPositionAtomically(
+        {
+          market_id: signal.marketId,
+          token_id: signal.tokenId,
+          side: signal.direction === 'long' ? 'long' : 'short',
+          size: actualShares,
+          avg_entry_price: actualPrice,
+          current_price: actualPrice,
+          unrealized_pnl: 0,
+          opened_at: new Date(),
+          signal_type: signal.signalId,
+          market_score_at_entry: marketScoreAtEntry,
+          score_dimensions_at_entry: scoreDimensionsAtEntry ?? undefined,
+          execution_mode: executionMode,
+        },
+        actualValue,
+        actualFee,
+      );
+
+      if (!openResult.opened) {
+        // Position already exists or insufficient capital — delete the trade record
+        try {
+          await query('DELETE FROM paper_trades WHERE id = $1', [trade.id]);
+        } catch (delError) {
+          console.error('Failed to delete orphaned trade:', delError);
+        }
+        return { executed: false, reason: openResult.reason || 'Position open failed' };
+      }
+```
+
+This replaces the separate debit → upsert → reversal pattern with a single atomic call. No reversal needed — if anything fails, the transaction rolls back.
+
+**Step 4: Also remove the pre-check on lines 360-372**
+
+The existing position check at lines 360-372 (`positions = await paperPositionsRepo.getAll(); existingPosition = ...`) is now redundant for open-detection since the transaction handles it. However, keep it because it's also used for:
+- Detecting existing positions to close (line 376: `isClosingExistingLong`)
+- Per-market concentration limit (line 391)
+
+So keep those lines but remove the early-return based on `existingPosition` for opens — the transaction handles that.
+
+**Step 5: Fix PositionClosingService PnL formula**
+
+In `packages/dashboard/src/services/PositionClosingService.ts:117`, change from additive to absolute:
+
+```typescript
+// Before (additive — accumulates across re-opens):
+realized_pnl = COALESCE(realized_pnl, 0) + $1,
+
+// After (absolute — each position is independent):
+realized_pnl = $1,
+```
+
+Since positions are no longer re-opened via upsert (each cycle creates a new row), each position's `realized_pnl` should reflect only its own cycle's PnL.
+
+**Step 6: Update existing tests**
+
+In `packages/dashboard/src/database/repositories.test.ts`, replace any calls to `paperPositionsRepo.upsert()` with `paperPositionsRepo.insert()`.
+
+In `packages/dashboard/src/services/AutoSignalExecutor.test.ts`, update mocks to expect `openPositionAtomically()` instead of `upsert()`.
+
+In `packages/dashboard/src/services/PositionClosingService.test.ts`, verify the test expects `realized_pnl = netPnl` (not additive).
+
+**Step 7: Run tests**
+
+```bash
+cd packages/dashboard && npx vitest run
+```
+Expected: All tests pass
+
+**Step 8: Commit**
+
+```bash
+git add packages/dashboard/src/database/repositories.ts packages/dashboard/src/services/AutoSignalExecutor.ts packages/dashboard/src/services/PositionClosingService.ts packages/dashboard/src/database/repositories.test.ts packages/dashboard/src/services/AutoSignalExecutor.test.ts packages/dashboard/src/services/PositionClosingService.test.ts
+git commit -m "fix: replace upsert with atomic INSERT + transaction for positions
+
+Fixes phantom PnL bug where realized_pnl accumulated across
+position re-opens via ON CONFLICT. Each position is now a fresh row.
+Transaction serializes concurrent opens with SELECT FOR UPDATE.
+PositionClosingService writes absolute PnL, not additive."
+```
+
+---
+
+### Task 6: Reset Account from Real Cash Flows
+
+**Step 1: Run the reset SQL on the VM**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+WITH flows AS (
+  SELECT
+    COALESCE(SUM(CASE WHEN side = 'sell' THEN amount ELSE -amount END), 0) as net_cash,
+    COALESCE(SUM(fee), 0) as total_fees
+  FROM paper_trades
+)
+UPDATE paper_account SET
+  current_capital = initial_capital + flows.net_cash,
+  available_capital = initial_capital + flows.net_cash
+    - COALESCE((SELECT SUM(size * avg_entry_price) FROM paper_positions WHERE closed_at IS NULL), 0),
+  total_realized_pnl = flows.net_cash + flows.total_fees,
+  total_fees_paid = flows.total_fees,
+  peak_equity = GREATEST(peak_equity, initial_capital + flows.net_cash),
+  updated_at = NOW()
+FROM flows
+WHERE paper_account.id = 1
+RETURNING current_capital, available_capital, total_realized_pnl, total_fees_paid;
+\""
+```
+
+**Step 2: Verify the reset**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+SELECT current_capital, available_capital, initial_capital, total_realized_pnl, total_fees_paid,
+  current_capital - (initial_capital + total_realized_pnl - total_fees_paid) as accounting_gap
+FROM paper_account LIMIT 1;
+\""
+```
+Expected: `accounting_gap` should be ~0 (or equal to open position cost if positions are open).
+
+---
+
+### Task 7: Fix Daily PnL Check — Consistent Metric
+
+**Files:**
+- Modify: `packages/dashboard/src/services/PaperTradingService.ts:255`
+- Modify: `packages/dashboard/src/services/RiskManager.ts:177,219`
+
+**Step 1: Fix snapshot to store cash, not equity**
+
+In `packages/dashboard/src/services/PaperTradingService.ts:255`:
+
+```typescript
+// Before:
+current_capital: equity,
+
+// After:
+current_capital: currentCapital,
+```
+
+This makes the snapshot's `current_capital` field actually store cash (current_capital from paper_account), not equity.
+
+**Step 2: Await checkDayReset()**
+
+In `packages/dashboard/src/services/RiskManager.ts:177`:
+
+```typescript
+// Before:
+this.checkDayReset();
+
+// After:
+await this.checkDayReset();
+```
+
+**Step 3: Fix daily PnL comparison to use equity consistently**
+
+In `packages/dashboard/src/services/RiskManager.ts:219-221`, since `dayStartEquity` now stores actual cash from snapshot, and `currentCapital` is also cash, the comparison is now cash-vs-cash. Both sides are on the same basis.
+
+No code change needed here — the fix in Step 1 aligns the data.
+
+**Step 4: Run tests**
+
+```bash
+cd packages/dashboard && npx vitest run -- RiskManager
+```
+Expected: Tests pass
+
+**Step 5: Commit**
+
+```bash
+git add packages/dashboard/src/services/PaperTradingService.ts packages/dashboard/src/services/RiskManager.ts
+git commit -m "fix: daily PnL check now compares cash-vs-cash consistently
+
+Snapshot was storing equity but RiskManager compared it to cash,
+causing spurious daily-loss halts when capital was deployed."
+```
+
+---
+
+### Task 8: Load All 5 Signal Weights on Startup
+
+**Files:**
+- Modify: `packages/dashboard/src/server.ts:227-242`
+
+**Step 1: Add missing signal types to weightMap**
+
+In `packages/dashboard/src/server.ts:227-230`:
+
+```typescript
+// Before:
+const weightMap: Record<string, string> = {
+  'combiner.momentumWeight': 'momentum',
+  'combiner.meanReversionWeight': 'mean_reversion',
+};
+
+// After:
+const weightMap: Record<string, string> = {
+  'combiner.momentumWeight': 'momentum',
+  'combiner.meanReversionWeight': 'mean_reversion',
+  'combiner.ofiWeight': 'ofi',
+  'combiner.mlofiWeight': 'mlofi',
+  'combiner.hawkesWeight': 'hawkes',
+};
+```
+
+**Step 2: Commit**
+
+```bash
+git add packages/dashboard/src/server.ts
+git commit -m "fix: load all 5 signal weights on startup, not just 2
+
+OFI, MLOFI, and Hawkes weights from optimizer were silently
+ignored on restart."
+```
+
+---
+
+### Task 9: Persist Consecutive-Loss Counter
+
+**Files:**
+- Modify: `packages/dashboard/src/services/CircuitBreakerService.ts:59,74-96,122-138`
+
+**Step 1: Load consecutive losses on startup**
+
+In `CircuitBreakerService.start()`, after the `CREATE TABLE IF NOT EXISTS` block (line 96), add:
+
+```typescript
+    // Load consecutive loss counter from DB
+    try {
+      const result = await query<{ value: string }>(
+        `SELECT value FROM trading_config WHERE key = 'consecutive_losses'`
+      );
+      if (result.rows[0]) {
+        this.consecutiveLosses = parseInt(result.rows[0].value, 10) || 0;
+        console.log(`[CircuitBreaker] Loaded consecutive losses from DB: ${this.consecutiveLosses}`);
+      }
+    } catch (err) {
+      // Non-critical
+    }
+```
+
+**Step 2: Persist on change**
+
+In the `onPositionClosed` handler (lines 123-138), after `this.consecutiveLosses++` and after `this.consecutiveLosses = 0`, add a persist call:
+
+```typescript
+// After incrementing or resetting:
+query(
+  `INSERT INTO trading_config (key, value, description, updated_at)
+   VALUES ('consecutive_losses', $1, 'Consecutive losing trades counter', NOW())
+   ON CONFLICT (key) DO UPDATE SET value = $1, updated_at = NOW()`,
+  [String(this.consecutiveLosses)]
+).catch(() => {}); // fire-and-forget, non-critical
+```
+
+**Step 3: Run tests**
+
+```bash
+cd packages/dashboard && npx vitest run -- CircuitBreaker
+```
+
+**Step 4: Commit**
+
+```bash
+git add packages/dashboard/src/services/CircuitBreakerService.ts
+git commit -m "fix: persist consecutive-loss counter across restarts
+
+Counter was in-memory only, resetting to 0 on restart.
+Now stored in trading_config table."
+```
+
+---
+
+### Task 10: Remove Deprecated `paperPositionsRepo.close()` and Fix `.get()`
+
+**Files:**
+- Modify: `packages/dashboard/src/database/repositories.ts:395-433`
+
+**Step 1: Fix `get()` to only return open positions**
+
+In `packages/dashboard/src/database/repositories.ts:395-401`:
+
+```typescript
+// Before:
+async get(marketId: string): Promise<PaperPosition | null> {
+  const result = await query<PaperPosition>(
+    'SELECT * FROM paper_positions WHERE market_id = $1',
+    [marketId]
+  );
+  return result.rows[0] ?? null;
+},
+
+// After:
+async get(marketId: string): Promise<PaperPosition | null> {
+  const result = await query<PaperPosition>(
+    'SELECT * FROM paper_positions WHERE market_id = $1 AND closed_at IS NULL',
+    [marketId]
+  );
+  return result.rows[0] ?? null;
+},
+```
+
+**Step 2: Check if `close()` is called anywhere**
+
+```bash
+grep -rn 'paperPositionsRepo.close' packages/dashboard/src/ --include='*.ts' | grep -v test | grep -v '.d.ts'
+```
+
+If no callers outside tests, delete the deprecated `close()` method entirely. If there are callers, they should use `PositionClosingService.close()` instead.
+
+**Step 3: Commit**
+
+```bash
+git add packages/dashboard/src/database/repositories.ts
+git commit -m "fix: paperPositionsRepo.get() now filters to open positions only
+
+Previously returned closed positions too, which could cause
+stale data issues for callers expecting only open positions."
+```
+
+---
+
+### Task 11: Add Invariant Checks to daily-review.sh
+
+**Files:**
+- Modify: `scripts/daily-review.sh`
+
+**Step 1: Add cash-flow crosscheck section (after line 234)**
+
+Add a new section `invariant_checks` with generalized SQL checks:
+
+```bash
+# 13b. Generalized invariant checks (PASS/FAIL)
+invariant_checks=$(query_one "
+  SELECT row_to_json(t) FROM (
+    SELECT
+      -- Cash flow crosscheck: account PnL vs actual trade flows
+      ABS(a.total_realized_pnl - COALESCE(flows.net_cash_plus_fees, 0)) < 1.0 AS pnl_matches_cashflows,
+      a.total_realized_pnl::float AS account_pnl,
+      COALESCE(flows.net_cash_plus_fees, 0)::float AS cashflow_pnl,
+      ABS(a.total_realized_pnl - COALESCE(flows.net_cash_plus_fees, 0))::float AS pnl_gap,
+
+      -- Available capital vs locked
+      ABS(a.available_capital - (a.current_capital - COALESCE(pos.open_cost, 0))) < 1.0 AS capital_lock_correct,
+      a.available_capital::float AS available,
+      a.current_capital::float AS current,
+      COALESCE(pos.open_cost, 0)::float AS open_cost,
+
+      -- Fee tracking
+      ABS(a.total_fees_paid - COALESCE(fees.actual_fees, 0)) < 1.0 AS fees_match,
+      a.total_fees_paid::float AS account_fees,
+      COALESCE(fees.actual_fees, 0)::float AS trade_fees
+    FROM paper_account a
+    LEFT JOIN (
+      SELECT SUM(CASE WHEN side = 'sell' THEN amount ELSE -amount END) + SUM(fee) AS net_cash_plus_fees
+      FROM paper_trades
+    ) flows ON true
+    LEFT JOIN (
+      SELECT SUM(size * avg_entry_price) AS open_cost
+      FROM paper_positions WHERE closed_at IS NULL
+    ) pos ON true
+    LEFT JOIN (
+      SELECT SUM(fee) AS actual_fees FROM paper_trades
+    ) fees ON true
+    LIMIT 1
+  ) t
+")
+```
+
+**Step 2: Add container restart counts and OOM check**
+
+```bash
+# 17b. Container restart counts and OOM events
+container_health="[]"
+if command -v docker &>/dev/null; then
+  restart_json=$(docker inspect --format='{"name":"{{.Name}}","restart_count":{{.RestartCount}},"started_at":"{{.State.StartedAt}}"}' $(docker ps -q) 2>/dev/null | jq -s '.' 2>/dev/null || echo "[]")
+
+  oom_events=$(dmesg 2>/dev/null | grep -ci 'oom\|killed process' || echo "0")
+
+  container_health=$(jq -n \
+    --argjson restarts "$restart_json" \
+    --argjson oom_count "$oom_events" \
+    '{"restarts": $restarts, "oom_kills_in_dmesg": $oom_count}')
+fi
+```
+
+**Step 3: Add DB security check**
+
+```bash
+# 17c. Database security (auth failure count)
+db_security="{}"
+if command -v docker &>/dev/null; then
+  fatal_count=$(docker logs polymarket-timescaledb --since 24h 2>&1 | grep -c "FATAL" 2>/dev/null || echo "0")
+  db_security=$(jq -n --argjson fatal_count "$fatal_count" '{"fatal_auth_failures_24h": $fatal_count}')
+fi
+```
+
+**Step 4: Add disk usage**
+
+```bash
+# 17d. Disk usage
+disk_usage="{}"
+disk_pct=$(df / --output=pcent 2>/dev/null | tail -1 | tr -d ' %' || echo "0")
+docker_size=$(du -sm /var/lib/docker/ 2>/dev/null | cut -f1 || echo "0")
+disk_usage=$(jq -n --argjson pct "$disk_pct" --argjson docker_mb "$docker_size" \
+  '{"root_usage_pct": $pct, "docker_size_mb": $docker_mb}')
+```
+
+**Step 5: Add new sections to the final jq assembly**
+
+Add to the `--argjson` list and the output object:
+```bash
+  --argjson invariant_checks "$invariant_checks" \
+  --argjson container_health "$container_health" \
+  --argjson db_security "$db_security" \
+  --argjson disk_usage "$disk_usage" \
+```
+
+And in the JSON body:
+```
+    invariant_checks: $invariant_checks,
+    container_health: $container_health,
+    db_security: $db_security,
+    disk_usage: $disk_usage,
+```
+
+**Step 6: Commit**
+
+```bash
+git add scripts/daily-review.sh
+git commit -m "feat: add generalized invariant checks to daily review
+
+- Cash-flow crosscheck (PnL vs actual trade flows)
+- Available capital vs locked in open positions
+- Fee tracking consistency
+- Container restart counts + OOM kill detection
+- DB security (FATAL auth failure count)
+- Disk usage monitoring"
+```
+
+---
+
+### Task 12: Update Auto-Review Prompt with Invariant Guidance
+
+**Files:**
+- Modify: `scripts/daily-review-prompt.md` (if exists)
+
+**Step 1: Add guidance about new sections**
+
+Add to the prompt instructions:
+
+```markdown
+## New Data Sections
+
+### invariant_checks
+Contains PASS/FAIL boolean flags for system invariants:
+- `pnl_matches_cashflows`: If false, account PnL diverges from actual trade cash flows — indicates phantom PnL
+- `capital_lock_correct`: If false, available_capital doesn't match current_capital minus open position costs
+- `fees_match`: If false, account fee tracking diverges from actual trade fees
+
+Any `false` value is a **BUG** — investigate immediately and include in report.
+
+### container_health
+- `oom_kills_in_dmesg > 0`: Kernel OOM killer has been active — find which container and recommend memory increase
+- Any container with `restart_count > 0`: Investigate why
+
+### db_security
+- `fatal_auth_failures_24h > 100`: Possible brute force attack on database port — flag as CRITICAL
+```
+
+**Step 2: Commit**
+
+```bash
+git add scripts/daily-review-prompt.md
+git commit -m "feat: update auto-review prompt with invariant check guidance
+
+Teaches the reviewer model how to interpret new invariant_checks,
+container_health, and db_security data sections."
+```
+
+---
+
+### Task 13: Final Verification
+
+**Step 1: Run full test suite**
+
+```bash
+cd packages/dashboard && npx vitest run
+```
+Expected: All tests pass
+
+**Step 2: Deploy to VM**
+
+```bash
+git push origin main
+# Wait for CI/CD or manual deploy
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="cd /home/Usuario/polymarket-trader && git pull && docker compose -f docker-compose.gcp.yml pull && docker compose -f docker-compose.gcp.yml up -d --remove-orphans"
+```
+
+**Step 3: Verify account reset is correct**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c 'SELECT current_capital, available_capital, total_realized_pnl, total_fees_paid FROM paper_account LIMIT 1;'"
+```
+
+**Step 4: Verify trading works with new code**
+
+Watch logs for ~5 minutes:
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="docker logs -f --tail=50 polymarket-dashboard-api 2>&1 | head -100"
+```
+
+Look for: signal generation, trade execution, no errors about `upsert` or position creation.
+
+**Step 5: Create GitHub issue for Phase B (future)**
+
+Create an issue for closing port 5432 entirely and moving Optuna inside the VM. Also for the weekly deep code review workflow.

--- a/docs/plans/2026-03-26-price-inversion-fix.md
+++ b/docs/plans/2026-03-26-price-inversion-fix.md
@@ -1,0 +1,405 @@
+# Price Inversion Fix — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Stop storing No token prices in `price_history`, fix the SignalEngine to only read Yes token prices, and clean up corrupted data.
+
+**Architecture:** Three ingestion paths write to `price_history`: ClobCollector (api source), ClobCollector snapshots, and DataCollectorService (collector source). Snapshots are correct (Yes-only). The other two write both Yes and No tokens. The SignalEngine reads by `market_id` without token filtering, mixing both token prices into signals. Fix all writers + add defense-in-depth filter on the reader.
+
+**Tech Stack:** TypeScript, PostgreSQL/TimescaleDB, Vitest
+
+---
+
+## Context for the Implementer
+
+### The Bug
+`price_history` stores both Yes and No token prices under the same `market_id`. Since No price ~ 1 - Yes price, the SignalEngine sees wild oscillations (e.g., 0.85 -> 0.15 -> 0.85) every few seconds. This corrupts ALL signals and produces phantom PnL.
+
+### The Invariant (from CLAUDE.md)
+> "price_history: Only stores Yes token prices. No token price = 1 - Yes price."
+
+### Affected Markets
+29 of ~40 tracked markets. ~$15k phantom PnL in last 7 days.
+
+### Three Ingestion Paths
+
+| Path | File | Method | Lines | Source col | Bug? |
+|------|------|--------|-------|-----------|------|
+| CLOB API bars | `packages/data-collector/src/collectors/ClobCollector.ts` | `syncAllMarketsPriceHistory()` | 565-625 | (none/NULL) | YES - syncs both tokens |
+| Snapshots | Same file | `snapshotCurrentPricesToHistory()` | 720-770 | `'snapshot'` | NO - Yes only |
+| Dashboard collector | `packages/dashboard/src/services/DataCollectorService.ts` | `saveSnapshot()` | 133-182 | `'collector'` | YES - saves all tokens |
+
+### Reader
+| Path | File | Method | Lines | Bug? |
+|------|------|--------|-------|------|
+| Signal generation | `packages/dashboard/src/services/SignalEngine.ts` | (inline query) | 463-469 | YES - no token_id filter |
+
+---
+
+## Task 1: Fix ClobCollector — Remove No Token Sync
+
+**Files:**
+- Modify: `packages/data-collector/src/collectors/ClobCollector.ts:591-620`
+
+**Step 1: Remove the No token sync block**
+
+In `syncAllMarketsPriceHistory()`, delete the block that syncs the No token (lines ~601-609). The code currently looks like:
+
+```typescript
+// Sync YES token
+const yesResult = await this.syncPriceHistoryToDb(
+  market.id,
+  market.clob_token_id_yes,
+  60
+);
+
+// Sync NO token if exists   <-- DELETE THIS BLOCK
+if (market.clob_token_id_no) {
+  const noResult = await this.syncPriceHistoryToDb(
+    market.id,
+    market.clob_token_id_no,
+    60
+  );
+}
+```
+
+Remove the entire `if (market.clob_token_id_no)` block and any references to `noResult` in the totals aggregation below it.
+
+**Step 2: Verify the data-collector builds**
+
+Run: `cd packages/data-collector && npx tsc --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add packages/data-collector/src/collectors/ClobCollector.ts
+git commit -m "fix: remove No token price sync from ClobCollector"
+```
+
+---
+
+## Task 2: Fix PolymarketService — Filter to Yes Token Only
+
+**Files:**
+- Modify: `packages/dashboard/src/services/PolymarketService.ts:564-587`
+
+**Step 1: Filter the pollMarkets loop to only push Yes token prices**
+
+The loop iterates over `updatedMarket.tokenIds` (both Yes and No). Change it to only process index 0 (Yes token) or filter by outcome name.
+
+Current code (lines 564-587):
+```typescript
+for (let i = 0; i < updatedMarket.tokenIds.length; i++) {
+  const price: PolymarketPrice = {
+    marketId: updatedMarket.id,
+    tokenId: updatedMarket.tokenIds[i],
+    outcome: updatedMarket.outcomes[i],
+    price: updatedMarket.outcomePrices[i],
+    // ...
+  };
+  this.prices.set(`${marketId}:${price.tokenId}`, price);
+  this.emit('price', price);
+  priceUpdates.push({ ... });
+}
+```
+
+**Fix approach**: The `outcomes` array is `['Yes', 'No']` for binary markets. Only push to `priceUpdates` when the outcome is `'Yes'`. Still emit price events for both (the in-memory price map may be used elsewhere), but only record Yes prices to the DB.
+
+```typescript
+for (let i = 0; i < updatedMarket.tokenIds.length; i++) {
+  const price: PolymarketPrice = {
+    marketId: updatedMarket.id,
+    tokenId: updatedMarket.tokenIds[i],
+    outcome: updatedMarket.outcomes[i],
+    price: updatedMarket.outcomePrices[i],
+    // ...
+  };
+  this.prices.set(`${marketId}:${price.tokenId}`, price);
+  this.emit('price', price);
+
+  // Only record Yes token prices to price_history (No = 1 - Yes, redundant)
+  if (updatedMarket.outcomes[i] === 'Yes') {
+    priceUpdates.push({ ... });
+  }
+}
+```
+
+**Important**: Verify the exact outcome string. Search the codebase for how `outcomes` is set — it might be `'Yes'`/`'No'` or something else. Check `PolymarketService.ts` where `outcomes` is populated from the API response.
+
+**Step 2: Verify dashboard builds**
+
+Run: `cd packages/dashboard && npx tsc --noEmit`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add packages/dashboard/src/services/PolymarketService.ts
+git commit -m "fix: only record Yes token prices to price_history from poll loop"
+```
+
+---
+
+## Task 3: Fix SignalEngine — Add token_id Filter (Defense in Depth)
+
+**Files:**
+- Modify: `packages/dashboard/src/services/SignalEngine.ts:463-469`
+
+**Step 1: Add token_id filter to the price_history query**
+
+Current query (lines 463-469):
+```sql
+SELECT time, open, high, low, close, volume, bid, ask, source
+FROM price_history
+WHERE market_id = $1
+ORDER BY time DESC
+LIMIT 100
+```
+
+Change to join with markets table to filter by Yes token:
+```sql
+SELECT ph.time, ph.open, ph.high, ph.low, ph.close, ph.volume, ph.bid, ph.ask, ph.source
+FROM price_history ph
+JOIN markets m ON ph.market_id = m.condition_id
+WHERE ph.market_id = $1
+  AND ph.token_id = m.clob_token_id_yes
+ORDER BY ph.time DESC
+LIMIT 100
+```
+
+**Alternative** (if the market object is already available with `clob_token_id_yes`): pass it as `$2` parameter to avoid the JOIN.
+
+Check what `market` object properties are available at the call site. If `market.clob_token_id_yes` exists, use:
+```sql
+SELECT time, open, high, low, close, volume, bid, ask, source
+FROM price_history
+WHERE market_id = $1 AND token_id = $2
+ORDER BY time DESC
+LIMIT 100
+```
+with params `[market.id, market.clob_token_id_yes]`.
+
+**Step 2: Verify there are no other price_history read queries without token filtering**
+
+Run: `grep -rn "FROM price_history" packages/dashboard/src/ packages/data-collector/src/`
+
+For each match, verify it either:
+- Filters by `token_id`, OR
+- Is used for aggregation where mixing tokens is expected (unlikely), OR
+- Needs the same fix
+
+**Step 3: Verify dashboard builds**
+
+Run: `cd packages/dashboard && npx tsc --noEmit`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add packages/dashboard/src/services/SignalEngine.ts
+git commit -m "fix: filter price_history by Yes token_id in SignalEngine"
+```
+
+---
+
+## Task 4: Fix Any Other price_history Readers
+
+**Files:**
+- Depends on Task 3 Step 2 findings
+
+**Step 1: Apply the same token_id filter to any other query found**
+
+Common locations to check:
+- `StopLossService.ts` — reads prices for exit decisions
+- `AutoSignalExecutor.ts` — reads current prices
+- `PositionClosingService.ts` — gets exit price
+- Backtesting code in `packages/backtest/`
+- Any dashboard API endpoint that returns price data
+
+For each: add `AND token_id = <yes_token_id>` or join with markets table.
+
+**Step 2: Build and commit**
+
+```bash
+npx tsc --noEmit  # from relevant package
+git add <modified files>
+git commit -m "fix: filter price_history by Yes token in all read paths"
+```
+
+---
+
+## Task 5: Run Tests
+
+**Step 1: Run unit tests**
+
+Run: `cd packages/dashboard && npx vitest run`
+Expected: All tests pass
+
+**Step 2: Run data-collector tests (if any)**
+
+Run: `cd packages/data-collector && npx vitest run 2>/dev/null || echo "No tests"`
+
+**Step 3: Fix any failures**
+
+If tests fail due to the changes, fix them. The most likely failures:
+- Tests that mock price_history queries may need updated SQL
+- Tests that assert on No token price data being present
+
+**Step 4: Commit fixes**
+
+```bash
+git add <files>
+git commit -m "fix: update tests for Yes-only price_history"
+```
+
+---
+
+## Task 6: Data Cleanup on VM
+
+**Step 1: SSH to VM and delete No token rows**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b
+```
+
+```sql
+-- First: count how many rows will be deleted
+SELECT COUNT(*) AS no_token_rows
+FROM price_history ph
+JOIN markets m ON ph.market_id = m.condition_id
+WHERE ph.token_id = m.clob_token_id_no;
+
+-- Delete No token rows
+DELETE FROM price_history ph
+USING markets m
+WHERE ph.market_id = m.condition_id
+  AND ph.token_id = m.clob_token_id_no;
+
+-- Verify: check for remaining inversions (should return 0)
+SELECT COUNT(*) FROM (
+  SELECT ph1.market_id
+  FROM price_history ph1
+  JOIN price_history ph2 ON ph1.market_id = ph2.market_id
+    AND ph2.time BETWEEN ph1.time AND ph1.time + INTERVAL '60 seconds'
+    AND ph2.time > ph1.time
+  WHERE ph1.time > NOW() - INTERVAL '6 hours'
+    AND ABS(ph1.close + ph2.close - 1.0) < 0.05
+  LIMIT 1
+) x;
+```
+
+**Step 2: Also clean up 'collector' source No token rows**
+
+The dashboard's DataCollectorService uses a different token_id mapping. Check:
+```sql
+-- Find rows where token_id is NOT the Yes token for that market
+SELECT COUNT(*) AS non_yes_rows
+FROM price_history ph
+JOIN markets m ON ph.market_id = m.condition_id
+WHERE ph.token_id != m.clob_token_id_yes
+  AND m.clob_token_id_yes IS NOT NULL;
+```
+
+Delete those too if count > 0.
+
+---
+
+## Task 7: Account Reset
+
+**Step 1: Reset account since PnL is unreliable**
+
+After deploying the fix and cleaning data:
+
+```sql
+-- Record current state before reset
+SELECT current_capital, available_capital, total_realized_pnl, peak_equity
+FROM paper_account WHERE id = 1;
+
+-- Close all open positions (they were opened on corrupt signals)
+UPDATE paper_positions SET closed_at = NOW(), size = 0
+WHERE closed_at IS NULL;
+
+-- Reset account
+UPDATE paper_account SET
+  current_capital = 10000,
+  available_capital = 10000,
+  total_realized_pnl = 0,
+  total_fees_paid = 0,
+  total_trades = 0,
+  winning_trades = 0,
+  losing_trades = 0,
+  max_drawdown = 0,
+  peak_equity = 10000,
+  updated_at = NOW()
+WHERE id = 1;
+```
+
+**Step 2: Update CLAUDE.md with reset info**
+
+Add to the "Account Reset History" section in `scripts/daily-review-prompt.md`:
+```
+- **2026-03-26**: Price inversion reset. price_history stored both Yes and No token prices,
+  corrupting all signals and producing phantom PnL. Cleaned data + reset to $10,000.
+```
+
+**Step 3: Update memory file `project_account_resets.md`**
+
+---
+
+## Task 8: Deploy and Verify
+
+**Step 1: Push branch, create PR**
+
+```bash
+git push -u origin fix/price-inversion
+gh pr create --title "fix: stop storing No token prices in price_history" \
+  --body-file pr-body.md --label "daily-review"
+```
+
+**Step 2: Deploy to VM**
+
+Either wait for CI/CD (if fixed) or deploy manually:
+```bash
+# Build locally
+cd packages/data-collector && npx tsc
+cd packages/dashboard && npx tsc
+
+# Copy to VM
+gcloud compute scp dist/ polymarket-vm:/tmp/fix-build/ --zone=us-east1-b
+# OR use docker build + push
+```
+
+**Step 3: Verify fix on VM**
+
+Wait 10 minutes for new data to accumulate, then:
+
+```sql
+-- Should return 0: no more inversions
+SELECT COUNT(*)
+FROM price_history ph1
+JOIN price_history ph2 ON ph1.market_id = ph2.market_id
+  AND ph2.time BETWEEN ph1.time AND ph1.time + INTERVAL '60 seconds'
+  AND ph2.time > ph1.time
+WHERE ph1.time > NOW() - INTERVAL '10 minutes'
+  AND ABS(ph1.close + ph2.close - 1.0) < 0.05;
+
+-- Should show only Yes token prices
+SELECT DISTINCT ph.token_id, m.clob_token_id_yes, m.clob_token_id_no,
+  CASE WHEN ph.token_id = m.clob_token_id_yes THEN 'YES' ELSE 'NO' END as token_type
+FROM price_history ph
+JOIN markets m ON ph.market_id = m.condition_id
+WHERE ph.time > NOW() - INTERVAL '10 minutes';
+```
+
+Expected: Only `YES` in `token_type` column.
+
+---
+
+## Post-Fix: Remaining Items (separate PRs/sessions)
+
+These are NOT part of this plan but should be done next:
+
+1. **CI/CD fix**: Change `GH_TOKEN` in `daily-trade-review-claude.yml` from `${{ github.token }}` to `${{ secrets.MERGE_PAT }}`
+2. **Optuna fix**: Remove `OPTIMIZER_URL` from docker-compose.gcp.yml or expose port 5432 on 0.0.0.0
+3. **Reviewer prompt**: Already updated in this session (scripts/daily-review-prompt.md)

--- a/docs/plans/2026-03-28-system-autoreview-improvements.md
+++ b/docs/plans/2026-03-28-system-autoreview-improvements.md
@@ -1,0 +1,276 @@
+# System & Auto-Review Improvements Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix DB timeouts, add cross-review trending to auto-review, and clean up pre-reset noise in invariant checks.
+
+**Architecture:** Four independent improvements — DB keepalive (code), review history tracking (shell script + prompt), fix verification in prompt, and reset-epoch filtering for invariant checks.
+
+**Tech Stack:** TypeScript (pg Pool), Bash (daily-review.sh), Markdown (prompt)
+
+---
+
+### Task 1: DB Connection Pool Keepalive
+
+**Problem:** 20 DB timeouts/day for 2+ days. Pool connections go stale because no keepalive is configured. Idle connections get dropped by Docker/kernel TCP stack, but pg Pool doesn't know until the next query attempt.
+
+**Files:**
+- Modify: `packages/dashboard/src/database/index.ts:67-73`
+- Modify: `packages/data-collector/src/database/connection.ts:17-26`
+
+**Step 1: Add keepalive to dashboard pool**
+
+In `packages/dashboard/src/database/index.ts`, update Pool config:
+
+```typescript
+pool = new Pool({
+  connectionString,
+  ssl: sslConfig,
+  max: config?.max ?? parseInt(process.env.DB_POOL_MAX || '5', 10),
+  idleTimeoutMillis: config?.idleTimeoutMillis ?? 30000,
+  connectionTimeoutMillis: config?.connectionTimeoutMillis ?? 10000,
+  keepAlive: true,
+  keepAliveInitialDelayMillis: 10000,
+});
+```
+
+**Step 2: Add keepalive to data-collector pool**
+
+In `packages/data-collector/src/database/connection.ts`, update Pool config:
+
+```typescript
+pool = new Pool({
+  connectionString,
+  max: maxConnections,
+  idleTimeoutMillis: 30000,
+  connectionTimeoutMillis: 10000,
+  keepAlive: true,
+  keepAliveInitialDelayMillis: 10000,
+  ssl: isCloudDb ? { rejectUnauthorized: false } : undefined,
+});
+```
+
+**Step 3: Run tests**
+
+```bash
+pnpm test
+```
+
+**Step 4: Commit**
+
+```bash
+git add packages/dashboard/src/database/index.ts packages/data-collector/src/database/connection.ts
+git commit -m "fix: add TCP keepalive to DB connection pools to prevent stale connections"
+```
+
+---
+
+### Task 2: Review History Tracking (Cross-Review Trending)
+
+**Problem:** Each auto-review is a snapshot. It can't detect "timeouts were 20 yesterday AND 20 today" or "tradeable market % dropped from 80% to 40% over 3 days."
+
+**Approach:** At the end of `daily-review.sh`, save key metrics to `/home/Usuario/polymarket-trader/review-history.json` on the VM. Each review run appends an entry. The prompt reads previous entries for trend comparison.
+
+**Files:**
+- Modify: `scripts/daily-review.sh` (add history save at end)
+- Modify: `scripts/daily-review-prompt.md` (add trending section)
+
+**Step 1: Add history save to daily-review.sh**
+
+At the end of `daily-review.sh` (before the final JSON output), add a section that saves key metrics:
+
+```bash
+# Save key metrics to review history for trending
+HISTORY_FILE="/home/Usuario/polymarket-trader/review-history.json"
+HISTORY_ENTRY=$(cat <<HISTEOF
+{
+  "date": "$(date -u +%Y-%m-%d)",
+  "capital": $(echo "$ACCOUNT" | jq '.current_capital // 0'),
+  "realized_pnl": $(echo "$ACCOUNT" | jq '.total_realized_pnl // 0'),
+  "drawdown_pct": $(echo "$ACCOUNT" | jq '.max_drawdown // 0'),
+  "open_positions": $(echo "$OPEN_POSITIONS" | jq 'length'),
+  "trades_24h": $(echo "$TRADES_SUMMARY" | jq '.total_trades // 0'),
+  "signals_1h": $(echo "$SIGNAL_FRESHNESS" | jq '.count_1h // 0'),
+  "active_markets": $(echo "$MARKET_INTEL" | jq '[.[] | select(.tracking_status == "active")] | .[0].count // 0' 2>/dev/null || echo 0),
+  "tradeable_market_pct": $(DB_QUERY "SELECT ROUND(COUNT(*) FILTER (WHERE current_price_yes >= 0.05 AND current_price_yes <= 0.95)::numeric * 100 / NULLIF(COUNT(*), 0), 1) FROM markets WHERE tracking_status = 'active' AND is_active = true" 2>/dev/null || echo 0),
+  "db_timeout_errors": $(echo "$ERROR_LOGS" | jq '[.[] | select(.line | test("timeout exceeded"))] | length' 2>/dev/null || echo 0),
+  "zombie_count": $(echo "$ZOMBIES" | jq '.count // 0'),
+  "invariant_capital_ok": $(echo "$INVARIANT_CHECKS" | jq '.capital_matches_cashflows // false'),
+  "invariant_fees_ok": $(echo "$INVARIANT_CHECKS" | jq '.fees_match // false')
+}
+HISTEOF
+)
+
+# Append to history (keep last 30 days)
+if [ -f "$HISTORY_FILE" ]; then
+  EXISTING=$(cat "$HISTORY_FILE")
+  # Remove entries older than 30 days and add new one
+  echo "$EXISTING" | jq --argjson new "$HISTORY_ENTRY" \
+    '[.[] | select(.date >= (now | strftime("%Y-%m-%d") | . as $today | ($today | strptime("%Y-%m-%d") | mktime) - 2592000 | strftime("%Y-%m-%d")))] + [$new]' \
+    > "${HISTORY_FILE}.tmp" && mv "${HISTORY_FILE}.tmp" "$HISTORY_FILE"
+else
+  echo "[$HISTORY_ENTRY]" > "$HISTORY_FILE"
+fi
+echo "Saved review history entry" >&2
+```
+
+Also, add a new section to the JSON output that reads the last 7 entries of review history:
+
+```bash
+# In the final JSON assembly, add:
+"review_history": $(cat "$HISTORY_FILE" 2>/dev/null | jq 'sort_by(.date) | .[-7:]' 2>/dev/null || echo "[]"),
+```
+
+**Step 2: Add trending section to prompt**
+
+Add to `scripts/daily-review-prompt.md` after the "Market Intelligence System" section:
+
+```markdown
+### Cross-Review Trending (mandatory if review_history has 2+ entries)
+
+The `review_history` section contains metrics from previous daily reviews. Compare today vs recent days:
+
+- **Capital trajectory**: Growing, flat, or declining?
+- **Tradeable market %**: Is it degrading over time?
+- **DB timeout count**: Persistent (same count multiple days) or transient?
+- **Signal count trend**: Increasing, decreasing, or volatile?
+
+**If a metric has been bad for 2+ consecutive days**, escalate severity by one level and prefix with `[PERSISTENT]`.
+
+**If a metric improved after a PR was merged**, note: "Fix in PR #N appears effective (metric improved from X to Y)."
+```
+
+**Step 3: Commit**
+
+```bash
+git add scripts/daily-review.sh scripts/daily-review-prompt.md
+git commit -m "feat: add cross-review trending to daily auto-review"
+```
+
+---
+
+### Task 3: Fix Verification & Persistent Issue Escalation in Prompt
+
+**Problem:** Auto-review never checks if yesterday's merged PR actually worked, and flags the same P1 issues for days without escalating.
+
+**Files:**
+- Modify: `scripts/daily-review-prompt.md`
+
+**Step 1: Add fix verification section to prompt**
+
+Add after "Step 0: Check Existing Work":
+
+```markdown
+## Step 0b: Verify Recent Fixes
+
+Check if any PRs were merged since the last review:
+
+```bash
+gh pr list --state merged --label daily-review --limit 5 --json number,title,mergedAt
+```
+
+For each PR merged in the last 48h:
+1. Read its description to understand what it fixed
+2. Check if the fix is effective by running the relevant verification (SQL query, log check, etc.)
+3. Report in the issue: "PR #N (merged YYYY-MM-DD): [EFFECTIVE|INEFFECTIVE] — evidence: [query result]"
+
+If a fix is **ineffective**, flag as HIGH and investigate why.
+```
+
+**Step 2: Add persistent issue escalation rule**
+
+Add to the "Alert Guidance" section:
+
+```markdown
+### Persistent Issue Escalation
+
+When `review_history` shows the same problem for 2+ consecutive days:
+- **Escalate severity by one level** (Info→Warning, Warning→High, High→Critical)
+- **Prefix alert with `[PERSISTENT - N days]`**
+- **Require an action**: either create a fix PR or explain why the issue can't be fixed automatically
+
+Never write "recurring known issue" without:
+1. Citing the issue number that tracks it
+2. Stating how many consecutive days it has persisted
+3. Proposing a concrete next step
+```
+
+**Step 3: Commit**
+
+```bash
+git add scripts/daily-review-prompt.md
+git commit -m "feat: add fix verification and persistent issue escalation to auto-review prompt"
+```
+
+---
+
+### Task 4: Reset-Epoch Filter for Invariant Checks
+
+**Problem:** `capital_matches_cashflows=false` and `fees_match=false` appear every review because the SQL sums include pre-reset trades against a post-reset account. This is noise that wastes auto-review time.
+
+**Approach:** Store the last reset timestamp in `paper_account` and use it to filter invariant check queries in `daily-review.sh`.
+
+**Files:**
+- Modify: `scripts/daily-review.sh` (filter invariant queries by last reset date)
+
+**Step 1: Update invariant check SQL to filter by last reset**
+
+The simplest approach: use the most recent circuit_breaker_log entry or a known reset date. Since we know the last reset was 2026-03-26, and the account reset endpoint doesn't log to circuit_breaker_log, we'll detect the reset time from the earliest post-reset trade.
+
+In `daily-review.sh`, update the invariant checks section:
+
+```bash
+# Detect last reset time (earliest trade after last known 0-balance state)
+RESET_EPOCH=$(DB_QUERY "
+  SELECT COALESCE(
+    (SELECT MAX(timestamp) FROM circuit_breaker_log),
+    '2026-03-26T00:00:00Z'
+  )::text
+")
+
+# capital_matches_cashflows — only count post-reset trades
+INVARIANT_CHECKS=$(DB_QUERY "
+  WITH account AS (SELECT * FROM paper_account WHERE id = 1),
+  post_reset_flows AS (
+    SELECT
+      COALESCE(SUM(CASE WHEN side = 'buy' THEN -(size * price + fee) ELSE (size * price - fee) END), 0) as net_cash_flow,
+      COALESCE(SUM(fee), 0) as total_trade_fees
+    FROM paper_trades
+    WHERE created_at >= '$RESET_EPOCH'
+  ),
+  ...
+")
+```
+
+The key change: add `WHERE created_at >= '$RESET_EPOCH'` to the cashflow and fee summation queries.
+
+**Step 2: Test locally**
+
+Run the invariant check SQL manually against the DB to verify it returns `true` for both checks.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/daily-review.sh
+git commit -m "fix: filter invariant checks by last reset epoch to eliminate pre-reset noise"
+```
+
+---
+
+## Execution Order
+
+Tasks are independent and can be parallelized, but the natural order is:
+
+1. **Task 1** (DB keepalive) — quick code change, immediate production impact
+2. **Task 4** (reset-epoch) — reduces noise in tomorrow's review
+3. **Task 2** (review history) — enables trending in future reviews
+4. **Task 3** (prompt improvements) — builds on Task 2's trending data
+
+## Deployment
+
+After all tasks are committed, push and let CI/CD deploy. If CI/CD doesn't trigger, manual deploy:
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- \
+  "cd /home/Usuario/polymarket-trader && git pull && docker compose -f docker-compose.gcp.yml pull && docker compose -f docker-compose.gcp.yml up -d --remove-orphans"
+```

--- a/scripts/check-ohlc-variation.js
+++ b/scripts/check-ohlc-variation.js
@@ -1,0 +1,51 @@
+const { Pool } = require('pg');
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+async function check() {
+  // Check recent price bars for OHLC variation
+  const recent = await pool.query(`
+    SELECT
+      market_id,
+      time,
+      open, high, low, close,
+      (high - low) / NULLIF(close, 0) * 100 as range_pct
+    FROM price_history
+    WHERE time > NOW() - INTERVAL '30 minutes'
+      AND close > 0
+    ORDER BY time DESC
+    LIMIT 20
+  `);
+
+  console.log('=== RECENT PRICE BARS (last 30 min) ===\n');
+  console.log('Time     | Market  | Open   | High   | Low    | Close  | Range%');
+  console.log('-'.repeat(75));
+
+  let hasVariation = 0;
+  recent.rows.forEach(r => {
+    const time = new Date(r.time).toISOString().substring(11, 19);
+    const o = parseFloat(r.open).toFixed(3);
+    const h = parseFloat(r.high).toFixed(3);
+    const l = parseFloat(r.low).toFixed(3);
+    const c = parseFloat(r.close).toFixed(3);
+    const range = parseFloat(r.range_pct).toFixed(2);
+
+    if (parseFloat(range) > 0.1) hasVariation++;
+
+    console.log(time + ' | ' + r.market_id.toString().padEnd(7) + ' | ' + o + ' | ' + h + ' | ' + l + ' | ' + c + ' | ' + range + '%');
+  });
+
+  console.log('\nBars with >0.1% variation: ' + hasVariation + '/' + recent.rows.length);
+
+  if (hasVariation === 0) {
+    console.log('\n❌ NO VARIATION DETECTED - New code NOT running');
+    console.log('Container needs full rebuild from source');
+  } else if (hasVariation > 10) {
+    console.log('\n✅ VARIATION DETECTED - New code IS running');
+  } else {
+    console.log('\n⚠️  PARTIAL VARIATION - Checking further...');
+  }
+
+  await pool.end();
+}
+
+check().catch(console.error);

--- a/scripts/monitor-data-improvement.js
+++ b/scripts/monitor-data-improvement.js
@@ -1,0 +1,117 @@
+const { Pool } = require('pg');
+
+async function monitor() {
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+  try {
+    console.log('=== MONITORING DATA COLLECTION IMPROVEMENTS ===\n');
+
+    // 1. Check data frequency
+    console.log('1. DATA FREQUENCY (last hour):');
+    const frequency = await pool.query(`
+      SELECT
+        COUNT(*) as total_points,
+        COUNT(DISTINCT market_id) as unique_markets,
+        ROUND(COUNT(*)::numeric / COUNT(DISTINCT market_id), 2) as avg_points_per_market
+      FROM price_history
+      WHERE time > NOW() - INTERVAL '1 hour'
+    `);
+
+    console.log('  Total price points:', frequency.rows[0].total_points);
+    console.log('  Unique markets:', frequency.rows[0].unique_markets);
+    console.log('  Avg points per market:', frequency.rows[0].avg_points_per_market);
+    console.log('  Target: >50 points/market/hour\n');
+
+    // 2. Check OHLC variation
+    console.log('2. OHLC VARIATION (sample of recent bars):');
+    const variation = await pool.query(`
+      SELECT
+        market_id,
+        AVG(ABS(high - low) / NULLIF(close, 0)) * 100 as avg_range_pct,
+        COUNT(*) as bars
+      FROM price_history
+      WHERE time > NOW() - INTERVAL '1 hour'
+        AND close > 0
+      GROUP BY market_id
+      HAVING COUNT(*) >= 10
+      ORDER BY avg_range_pct DESC
+      LIMIT 10
+    `);
+
+    if (variation.rows.length > 0) {
+      console.log('  Top 10 markets by price variation:');
+      variation.rows.forEach((r, i) => {
+        console.log(`    ${i+1}. Market ${r.market_id}: ${parseFloat(r.avg_range_pct).toFixed(3)}% range (${r.bars} bars)`);
+      });
+      const avgVariation = variation.rows.reduce((sum, r) => sum + parseFloat(r.avg_range_pct), 0) / variation.rows.length;
+      console.log(`  Average variation: ${avgVariation.toFixed(3)}%`);
+      console.log('  Target: >1% variation\n');
+    } else {
+      console.log('  Not enough data yet for variation analysis\n');
+    }
+
+    // 3. Check signal diversity
+    console.log('3. SIGNAL DIVERSITY (last hour):');
+    const signals = await pool.query(`
+      SELECT
+        COUNT(DISTINCT (confidence, strength)) as unique_combinations,
+        COUNT(*) as total_signals
+      FROM signal_predictions
+      WHERE time > NOW() - INTERVAL '1 hour'
+    `);
+
+    console.log('  Unique signal combinations:', signals.rows[0].unique_combinations);
+    console.log('  Total signals:', signals.rows[0].total_signals);
+    console.log('  Target: >50 unique combinations/hour\n');
+
+    // 4. Check data recency
+    console.log('4. DATA RECENCY:');
+    const recency = await pool.query(`
+      SELECT
+        MAX(time) as latest_price,
+        NOW() - MAX(time) as age
+      FROM price_history
+    `);
+
+    const ageSeconds = Math.floor(recency.rows[0].age.seconds + recency.rows[0].age.minutes * 60);
+    console.log('  Latest price:', recency.rows[0].latest_price);
+    console.log('  Age:', ageSeconds, 'seconds');
+    console.log('  Target: <120 seconds\n');
+
+    // 5. Data collector status (from logs if available)
+    console.log('5. IMPROVEMENT METRICS:');
+    const before = { pointsPerHour: 212, avgVariation: 0, uniqueSignals: 6 };
+    const after = {
+      pointsPerHour: parseInt(frequency.rows[0].total_points),
+      avgVariation: variation.rows.length > 0
+        ? variation.rows.reduce((sum, r) => sum + parseFloat(r.avg_range_pct), 0) / variation.rows.length
+        : 0,
+      uniqueSignals: parseInt(signals.rows[0].unique_combinations)
+    };
+
+    console.log('  Before improvements:');
+    console.log(`    - ${before.pointsPerHour} points/hour`);
+    console.log(`    - ${before.avgVariation.toFixed(3)}% variation`);
+    console.log(`    - ${before.uniqueSignals} unique signals`);
+    console.log('\n  After improvements:');
+    console.log(`    - ${after.pointsPerHour} points/hour (${((after.pointsPerHour / before.pointsPerHour - 1) * 100).toFixed(0)}% change)`);
+    console.log(`    - ${after.avgVariation.toFixed(3)}% variation`);
+    console.log(`    - ${after.uniqueSignals} unique signals (${((after.uniqueSignals / before.uniqueSignals - 1) * 100).toFixed(0)}% change)`);
+
+    console.log('\n=== RECOMMENDATION ===');
+    if (after.pointsPerHour > 1000 && after.avgVariation > 1.0 && after.uniqueSignals > 20) {
+      console.log('✅ Data quality significantly improved! Consider enabling trading.');
+    } else if (after.pointsPerHour > 500) {
+      console.log('⏳ Improvements in progress, wait 30-60 minutes for full effect.');
+    } else {
+      console.log('⚠️  Not enough improvement yet. Check data-collector logs.');
+    }
+
+  } catch (error) {
+    console.error('Error:', error.message);
+  } finally {
+    await pool.end();
+  }
+}
+
+monitor().catch(console.error);


### PR DESCRIPTION
## What

The working tree had accumulated ~150 untracked files. This sorts them: junk gets gitignored + deleted, genuine files that were never committed get tracked.

**Gitignored + deleted (junk):**
- Compiled TypeScript artifacts (`.js` / `.d.ts` / `.js.map` / `.d.ts.map`) emitted in place next to `.ts` source under `packages/*/src`, `tests/`, `scripts/`, and root `vitest.config.*` — ~140 files.
- ~22 `tmp-*.sql` / `.sh` / `.js` scratch files.
- `bash.exe.stackdump`, `vercel-check.png`, Playwright `test-results/`.
- A stray `package-lock.json` — this project uses pnpm (`pnpm-lock.yaml`).

**Now tracked (should have been committed all along):**
- `.coderabbit.yaml` — CI reviewer config.
- 22 `docs/plans/*.md` design documents — `CLAUDE.md` already references `docs/plans/` as repo content; some plan docs were already tracked.
- `scripts/check-ohlc-variation.js`, `scripts/monitor-data-improvement.js` — real ops scripts.

`.gitignore` also dedups a repeated `.worktrees/` entry and ignores `.claude/scheduled_tasks.lock`.

## Scope

No source or runtime behaviour changed — `.gitignore` + deletions of untracked artifacts + tracking of pre-existing files. The compiled artifacts regenerate from `.ts` on the next build; they were never meant to be in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)