### PR TITLE
fix(executor): block event_financial:long — anti-edge confirmed

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -232,8 +232,16 @@ services:
       #   crypto_intraday markets are multi-month binary price targets (end date
       #   Jul 2026 – Jan 2027); 4h MAX_HOLD_TIME_HOURS causes 7/7 time exits
       #   with 0% WR. Structural mismatch, not a signal quality issue.
+      # Configured 2026-05-20: event_financial LONG blocked — anti-edge
+      #   confirmed by both live and shadow. Live since 2026-05-11 reset:
+      #   n=69, WR 18.8%, -$203.46 (~91% of total -$222 drawdown). Shadow
+      #   30d: n=390, 0 wins, avg -$92.62, sharpe -3.64. With SHORT already
+      #   blocked (SHORT-resolves-NO shadow bias), event_financial is now
+      #   shadow-only live. Continues to be measured in shadow_trades and
+      #   generator_edge — re-enable only when a cohort shows positive
+      #   t_net in P2 cost-aware analysis.
       # Closes of existing positions are never blocked (unwind path).
-      EXECUTOR_BLOCKED_TYPE_DIRECTIONS: "event_financial:short,crypto_intraday:long"
+      EXECUTOR_BLOCKED_TYPE_DIRECTIONS: "event_financial:short,event_financial:long,crypto_intraday:long"
       # Per-market consecutive-loss block threshold (default 3).
       # Lowered to 2 on 2026-05-15: CL futures markets accumulated 10 and 8 losses
       # respectively (1652677, 1652685) in 4 days — each 24h ban cycle absorbed 3


### PR DESCRIPTION
## Summary

- Adds `event_financial:long` to `EXECUTOR_BLOCKED_TYPE_DIRECTIONS`.
- Live since 2026-05-11 reset: **n=69, WR 18.8%, total -$203.46** (~91% of the -$222 drawdown post-reset).
- Shadow last 30d corroborates: **n=390, 0 wins, avg -$92.62, sharpe -3.64**.
- Triggered by analysis of daily-review #254. The auto-review itself wrote "*avoid long direction confirmed*" in the FLB section but did not file the PR (root-cause not confirmed per its own bar). Cohort evidence is sufficient: shadow has 390 resolved trades and the live cohort recreates the same loss profile.

With SHORT already blocked (SHORT-resolves-NO shadow bias) and LONG now blocked, **event_financial is effectively shadow-only live** — coherent with the Phase 4 "trading near zero" posture (`project_phase4_completed_2026-05-13.md`).

## Patch vs root-cause classification

`containment` — same Gate 0f mechanism used for `event_financial:short` and `crypto_intraday:long`. The signal_weights schema can't separately downweight SHORT vs LONG inside a (signal, type), so the executor filter is the granular tool. Shadow_trades and generator_edge continue measuring this cell; re-enable when P2 cost-aware analysis (t_net) shows positive edge.

## Test plan

- [ ] CI build green
- [ ] After deploy, verify on VM: `docker compose -f docker-compose.gcp.yml exec dashboard-api env | grep EXECUTOR_BLOCKED_TYPE_DIRECTIONS` → contains `event_financial:long`
- [ ] Confirm new event_financial:long opens are rejected at Gate 0f (look for `gate_0f_blocked` log lines)
- [ ] Existing event_financial open positions can still close (unwind path bypasses Gate 0f)
- [ ] Shadow_trades continues recording event_financial entries (no shadow gate change)

Closes part of #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dashboard service configuration to restrict an additional trading direction type from execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->