### PR TITLE
fix(daily-review): remove buggy unexplained_diff; use cashflow invariant

### DIFF
--- a/scripts/daily-review.sh
+++ b/scripts/daily-review.sh
@@ -226,29 +226,18 @@ orphaned_buys=$(query_one "
   ) t;
 ")
 
-# 11. Account consistency check
-# Formula: current_capital + open_positions_cost = initial_capital + realized_pnl - fees
-# (capital is reduced when positions are opened; we must add position costs back to balance)
-account_consistency=$(query_one "
-  SELECT row_to_json(t) FROM (
-    SELECT
-      a.current_capital::float AS capital,
-      a.initial_capital::float AS initial,
-      a.total_realized_pnl::float AS realized_pnl,
-      a.total_fees_paid::float AS total_fees,
-      COALESCE(pos.open_cost, 0)::float AS open_positions_cost,
-      (a.current_capital + COALESCE(pos.open_cost, 0) - (a.initial_capital + a.total_realized_pnl - a.total_fees_paid))::float AS unexplained_diff
-    FROM paper_account a
-    LEFT JOIN (
-      SELECT SUM(size * avg_entry_price) AS open_cost
-      FROM paper_positions
-      WHERE closed_at IS NULL
-    ) pos ON true
-    LIMIT 1
-  ) t;
-")
-
-# 11b. Generalized invariant checks (PASS/FAIL)
+# 11. Generalized invariant checks (PASS/FAIL)
+#
+# NOTE: a prior `account_consistency` check (an `unexplained_diff` formula:
+# current_capital + open_cost - (initial + realized_pnl - total_fees_paid)) was
+# removed here. It used an inconsistent fee convention: `realized_pnl` is stored
+# net of the EXIT fee only (PositionClosingService computes netPnl = grossPnl -
+# exit_fee), while `total_fees_paid` accumulates BOTH entry and exit fees. The
+# formula therefore double-subtracted the exit fee and reported a spurious
+# positive `unexplained_diff == +SUM(exit_fee)` (~half of total_fees_paid) that
+# grew with trade volume but represented no real capital loss. The
+# `capital_matches_cashflows` check below reconstructs net cash leg-by-leg from
+# paper_trades and is convention-independent — it fully supersedes that check.
 # Uses last_reset_at from paper_account as the epoch so that pre-reset trades
 # (e.g. from the 2026-03-30 No-token corruption incident) are excluded from the
 # cashflow and fee cross-checks, preventing false-positive CRITICAL alerts.
@@ -728,7 +717,6 @@ jq -n \
   --argjson recently_closed "$recently_closed" \
   --argjson zombie_positions "$zombie_positions" \
   --argjson orphaned_buys "$orphaned_buys" \
-  --argjson account_consistency "$account_consistency" \
   --argjson invariant_checks "$invariant_checks" \
   --argjson price_freshness "$price_freshness" \
   --argjson signal_freshness "$signal_freshness" \
@@ -764,7 +752,6 @@ jq -n \
     recently_closed: $recently_closed,
     zombie_positions: $zombie_positions,
     orphaned_buys: $orphaned_buys,
-    account_consistency: $account_consistency,
     invariant_checks: $invariant_checks,
     price_freshness: $price_freshness,
     signal_freshness: $signal_freshness,

--- a/scripts/format-review.js
+++ b/scripts/format-review.js
@@ -163,7 +163,7 @@ const worstPositions = Array.isArray(data.worst_positions) ? data.worst_position
 const recentlyClosed = Array.isArray(data.recently_closed) ? data.recently_closed : [];
 const zombiePositions = data.zombie_positions || null;
 const orphanedBuys = data.orphaned_buys || null;
-const accountConsistency = data.account_consistency || null;
+const invariantChecks = data.invariant_checks || null;
 const priceFreshness = data.price_freshness || null;
 const signalFreshness = data.signal_freshness || null;
 const optimizationRuns = Array.isArray(data.optimization_runs) ? data.optimization_runs : [];
@@ -551,10 +551,11 @@ function buildMarkdown() {
   ln(`|-------|-------|`);
   ln(`| Zombie Positions | ${zombieCount} |`);
   ln(`| Orphaned Buys | ${orphanedBuys ? fmt(orphanedBuys.count, 0) : 'N/A'} (${orphanedBuys ? fmtUsd(orphanedBuys.total_value) : 'N/A'}) |`);
-  ln(`| Unexplained Capital Diff | ${accountConsistency ? fmtUsd(accountConsistency.unexplained_diff) : 'N/A'} |`);
+  ln(`| Capital Reconciliation (cashflow) | ${invariantChecks ? (invariantChecks.capital_matches_cashflows ? 'OK' : 'MISMATCH') + ` (gap ${fmtUsd(invariantChecks.cashflow_gap)})` : 'N/A'} |`);
+  ln(`| Fees Match | ${invariantChecks ? (invariantChecks.fees_match ? 'OK' : 'MISMATCH') : 'N/A'} |`);
   ln();
-  if (accountConsistency) {
-    ln(`> Capital: ${fmtUsd(accountConsistency.capital)} = Initial ${fmtUsd(accountConsistency.initial)} + PnL ${fmtUsd(accountConsistency.realized_pnl)} - Fees ${fmtUsd(accountConsistency.total_fees)} + unexplained ${fmtUsd(accountConsistency.unexplained_diff)}`);
+  if (invariantChecks) {
+    ln(`> Capital change ${fmtUsd(invariantChecks.capital_change)} vs net cash flow ${fmtUsd(invariantChecks.net_cash_flow)} (leg-by-leg from paper_trades; convention-independent).`);
     ln();
   }
 

--- a/scripts/select-rpv2-cohort.js
+++ b/scripts/select-rpv2-cohort.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * select-rpv2-cohort.js
+ *
+ * Selects ~6 candidate markets to refresh the RPv2 sub-cohort in
+ * FORCE_INCLUDE_MARKET_IDS. The RPv2 generator (ResolutionPriorV2Generator)
+ * only fires within `cutoffDays=7`, so without a steady supply of TTR-≤7d
+ * markets pinned to `active` the generator has no measurement signal.
+ *
+ * This script is idempotent and read-only. Output is paste-ready: copy the
+ * "FORCE_INCLUDE_MARKET_IDS:" line into docker-compose.gcp.yml (both
+ * occurrences: data-collector and dashboard-api).
+ *
+ * Cadence: run weekly (or whenever the current RPv2 sub-cohort markets resolve).
+ * Recorded 2026-05-20 in docker-compose.gcp.yml.
+ *
+ * Usage (locally):
+ *   NODE_TLS_REJECT_UNAUTHORIZED=0 DATABASE_URL="postgres://..." \
+ *     node scripts/select-rpv2-cohort.js
+ *
+ * Usage (in dashboard container):
+ *   docker exec polymarket-dashboard-api node /app/select-rpv2-cohort.js
+ *
+ * Flags:
+ *   --keep "id1,id2,..."   FLB sub-cohort to preserve (defaults to the
+ *                          12-market list documented in compose). The script
+ *                          adds 6 RPv2 markets, prints the combined list.
+ *   --count N              How many RPv2 markets to select (default 6).
+ *   --min-volume V         Min volume_24h for candidates (default 2000).
+ *   --min-ttr-hours H      Min TTR in hours (default 36 — leave one full day
+ *                          of measurement before resolution).
+ *   --max-ttr-hours H      Max TTR in hours (default 168 — the RPv2 cutoff).
+ */
+
+const { Pool } = require('pg');
+
+// Defaults — the FLB sub-cohort documented in docker-compose.gcp.yml (the
+// tail-band markets pinned for `favorite_longshot_bias` measurement). Update
+// only if those markets resolve and the cohort comment changes.
+const DEFAULT_FLB_COHORT = [
+  '616905', '616906', '948956', '948957', '1144471', '1654959',
+  '1294363', '1032269', '951180', '1652691', '1818152', '1032270',
+];
+
+function arg(name, def) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : def;
+}
+
+async function main() {
+  const keep = (arg('keep', DEFAULT_FLB_COHORT.join(',')) || '')
+    .split(',').map(s => s.trim()).filter(Boolean);
+  const count = parseInt(arg('count', '6'), 10);
+  const minVolume = parseFloat(arg('min-volume', '2000'));
+  const minTtrHours = parseFloat(arg('min-ttr-hours', '36'));
+  const maxTtrHours = parseFloat(arg('max-ttr-hours', '168'));
+
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  console.log(`=== RPv2 cohort selection — ${new Date().toISOString().slice(0, 10)} ===`);
+  console.log(`keep (FLB sub-cohort): ${keep.length} markets`);
+  console.log(`target count: ${count}, min volume: $${minVolume}, TTR window: ${minTtrHours}-${maxTtrHours}h`);
+
+  // Step 1 — fetch current candidates ordered by volume_24h. Exclude markets
+  // already in `keep` and anything already resolved. Restrict to types that
+  // actually flow predictions; event_long is included (shadow-only live but
+  // the prediction stream is what feeds the t-stat job).
+  const res = await pool.query(`
+    SELECT
+      m.id,
+      m.market_type,
+      ROUND((EXTRACT(EPOCH FROM (m.end_date - NOW()))/3600)::numeric, 1) AS ttr_hours,
+      m.volume_24h,
+      (SELECT close FROM price_history WHERE market_id = m.id ORDER BY time DESC LIMIT 1) AS recent_yes,
+      LEFT(m.question, 80) AS question
+    FROM markets m
+    WHERE m.is_active = true
+      AND COALESCE(m.is_resolved, false) = false
+      AND m.end_date > NOW() + ($1 || ' hours')::interval
+      AND m.end_date < NOW() + ($2 || ' hours')::interval
+      AND m.market_type IN ('event_financial','crypto_daily','event_short','event_long')
+      AND m.volume_24h >= $3
+      AND NOT (m.id::text = ANY($4))
+    ORDER BY m.volume_24h DESC NULLS LAST
+    LIMIT 50
+  `, [minTtrHours, maxTtrHours, minVolume, keep]);
+
+  if (res.rows.length === 0) {
+    console.error('No candidate markets matched the filters. Try lowering --min-volume or widening --max-ttr-hours.');
+    process.exit(1);
+  }
+
+  // Step 2 — diversity selection: pick `count` markets aiming for at least
+  // one of each type that has candidates, then fill the rest by descending
+  // volume. Bias toward `event_financial`/`crypto_daily` since those are
+  // the live-allowed types (event_long stays shadow).
+  const byType = new Map();
+  for (const row of res.rows) {
+    if (!byType.has(row.market_type)) byType.set(row.market_type, []);
+    byType.get(row.market_type).push(row);
+  }
+
+  const picked = [];
+  // First pass: one per type with candidates, preferring event_financial / crypto_daily.
+  const typeOrder = ['event_financial', 'crypto_daily', 'event_short', 'event_long'];
+  for (const t of typeOrder) {
+    if (picked.length >= count) break;
+    const candidates = byType.get(t) || [];
+    if (candidates.length > 0) picked.push(candidates[0]);
+  }
+  // Second pass: fill remaining slots by descending volume across all types,
+  // skipping anything already picked.
+  for (const row of res.rows) {
+    if (picked.length >= count) break;
+    if (picked.find(p => p.id === row.id)) continue;
+    picked.push(row);
+  }
+
+  console.log('\nProposed RPv2 sub-cohort:');
+  console.log('  id        | type             | ttr (h) | vol_24h    | recent_yes | question');
+  console.log('  ----------|------------------|---------|------------|------------|---------');
+  for (const r of picked) {
+    const vol = r.volume_24h == null ? '       ?' : Number(r.volume_24h).toFixed(0).padStart(8);
+    const yes = r.recent_yes == null ? '   none   ' : Number(r.recent_yes).toFixed(4).padStart(9);
+    console.log(`  ${String(r.id).padEnd(9)} | ${(r.market_type || '?').padEnd(16)} | ${String(r.ttr_hours).padStart(7)} | ${vol} | ${yes}  | ${r.question}`);
+  }
+
+  const combined = [...keep, ...picked.map(p => String(p.id))];
+  console.log('\nPaste-ready compose env (both data-collector and dashboard-api):');
+  console.log(`      FORCE_INCLUDE_MARKET_IDS: "${combined.join(',')}"`);
+
+  console.log('\nNext steps:');
+  console.log('  1. Update docker-compose.gcp.yml (two occurrences: data-collector + dashboard-api).');
+  console.log('  2. Update the "Selection YYYY-MM-DD" line in the comment block above the var.');
+  console.log('  3. PR + CI deploy + verify env on VM after deploy.');
+
+  await pool.end();
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Problem

Daily reviews #260/#261 kept flagging a small positive `unexplained_diff` (+$10.10 → +$10.20) in the account-consistency check, growing ~$0.10/day, with the suggestion to "monitor for growth."

Root-cause investigation (against live DB) shows this is **not a real capital discrepancy** — it is a bug in the watchdog's reconciliation formula.

## Root cause

The removed `account_consistency` check computed:

```
unexplained_diff = current_capital + open_cost
                   - (initial_capital + realized_pnl - total_fees_paid)
```

This assumes `realized_pnl` is **gross** of fees. It isn't:

- **Open** (`repositories.ts:587-589`): `current_capital -= (cost + entry_fee)`, `total_fees_paid += entry_fee`.
- **Close** (`PositionClosingService.ts:123-164`): `netPnl = grossPnl - exit_fee`; `realized_pnl += netPnl`, `total_fees_paid += exit_fee`.

So `realized_pnl` is **net of the exit fee only**, while `total_fees_paid` accumulates **both** legs. The formula therefore subtracts the exit fee twice → `unexplained_diff == +SUM(exit_fee)`, which is ~half of `total_fees_paid` and grows with trade volume.

## Evidence (live data, post 2026-05-11 reset)

| Side | n | Σ fee |
|------|---|-------|
| buy (entry) | 84 | $10.4236 |
| sell (exit) | 84 | $10.1956 |
| total | | $20.6192 = `total_fees_paid` |

Observed `unexplained_diff` = **+$10.20** == `SUM(sell-side fees)` $10.196. Corrected formula (subtracting entry fees only) reconciles to **+$0.001**.

The engine's capital is correct: the authoritative `capital_matches_cashflows` invariant (which reconstructs net cash leg-by-leg from `paper_trades`, convention-independent) and `fees_match` both PASS.

## Change

- Remove the redundant `account_consistency` SQL block and its JSON wiring from `daily-review.sh`. A comment documents why.
- `format-review.js` Data Integrity table now surfaces the convention-independent `capital_matches_cashflows` (+ `fees_match`) check instead of the buggy `unexplained_diff`.

## Verification

- `bash -n daily-review.sh` ✓, `node --check format-review.js` ✓
- Ran `format-review.js` against a fixture: exit 0, renders `Capital Reconciliation (cashflow) | OK (gap $0.00)` and `Fees Match | OK`.
- No remaining live references to `account_consistency` / `unexplained_diff` (only the explanatory comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RPv2 market cohort selection tool to identify active markets based on configurable volume and time criteria.

* **Improvements**
  * Refined consistency metrics in daily health checks to focus on cashflow, fee, and locking validation.
  * Updated report generation to display capital reconciliation and fee matching data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->