### PR TITLE
feat(executor): Gate 0g — block crypto_daily LONG at OTM longshot prices

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -187,6 +187,18 @@ services:
       # materialize. Re-tighten only if post-flip live SHORT WR underperforms.
       EXECUTOR_SHORT_MAX_YES_PRICE: "1.0"
       EXECUTOR_SHORT_SIZE_MULT: "1.0"
+      # Gate 0g — OTMLongshotGate. Block crypto-class LONG opens below
+      # the price threshold. Empirical 2026-05-26: crypto_daily:long
+      # n=8 lifetime, 1 win, total -$61.15, avg entry 0.206 — daily-
+      # review #266 identified this as the active bleed. RT cost (~1%)
+      # dominates typical 4h price moves at these prices. Surgical
+      # price-band block (NOT a full type-direction block in
+      # EXECUTOR_BLOCKED_TYPE_DIRECTIONS) preserves balanced-price
+      # crypto_daily:long entries that remain viable. Re-evaluate
+      # threshold if shadow_trades with `signal_type='otm_longshot_blocked'`
+      # show different cost-aware edge in a future P2 t-stat run.
+      EXECUTOR_OTM_LONGSHOT_TYPES: "crypto_daily"
+      EXECUTOR_OTM_LONGSHOT_PRICE_LO: "0.30"
       # EXECUTOR_LOSS_GATE_EPOCH removed 2026-05-20. The 7-day rolling window of
       # the per-market consecutive-loss block + persistent-loser ban cleared
       # past the 2026-05-04 dm-flip on 2026-05-11; the epoch filter no longer

--- a/packages/dashboard/src/services/AutoSignalExecutor.otmLongshotGate.test.ts
+++ b/packages/dashboard/src/services/AutoSignalExecutor.otmLongshotGate.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../database/index.js', () => ({
+  query: vi.fn(),
+  isDatabaseConfigured: vi.fn(() => true),
+}));
+
+vi.mock('../database/repositories.js', () => ({
+  paperTradesRepo: { create: vi.fn() },
+  paperPositionsRepo: {
+    getAll: vi.fn(),
+    insert: vi.fn(),
+    upsert: vi.fn(),
+    openPositionAtomically: vi.fn().mockResolvedValue({ opened: true }),
+  },
+  signalPredictionsRepo: { create: vi.fn() },
+  signalWeightsRepo: { get: vi.fn() },
+}));
+
+vi.mock('./PositionClosingService.js', () => {
+  const { EventEmitter } = require('events');
+  const mockService = new EventEmitter();
+  mockService.close = vi.fn().mockResolvedValue({ executed: true, pnl: 0 });
+  return { getPositionClosingService: vi.fn(() => mockService) };
+});
+
+vi.mock('./CircuitBreakerService.js', () => ({
+  getCircuitBreakerService: vi.fn(() => ({ isTradingHalted: vi.fn(() => false) })),
+}));
+
+vi.mock('./ExecutionRouter.js', () => ({ getExecutionRouter: vi.fn(() => null) }));
+
+vi.mock('./OrderBookExecutionSimulator.js', () => ({
+  OrderBookExecutionSimulator: class {
+    simulateBuy = vi.fn().mockResolvedValue({
+      executed: true, executedPrice: 0.50, executedSize: 10,
+      slippagePct: 0.1, fee: 0.005, fillSource: 'estimated',
+      snapshotAgeMs: null, availableDepth: 0,
+      bestBid: null, bestAsk: null,
+    });
+    simulateSell = vi.fn().mockResolvedValue({
+      executed: true, executedPrice: 0.50, executedSize: 10,
+      slippagePct: 0.1, fee: 0.005, fillSource: 'estimated',
+      snapshotAgeMs: null, availableDepth: 0,
+      bestBid: null, bestAsk: null,
+    });
+  },
+}));
+
+import { query } from '../database/index.js';
+import { paperPositionsRepo } from '../database/repositories.js';
+import { AutoSignalExecutor, type SignalResult } from './AutoSignalExecutor.js';
+
+const makeSignal = (overrides?: Partial<SignalResult>): SignalResult => ({
+  signalId: 'mean_reversion',
+  marketId: 'market-crypto-daily-1',
+  tokenId: 'token-yes',
+  direction: 'long',
+  strength: 0.8,
+  confidence: 0.7,
+  price: 0.20,
+  marketType: 'crypto_daily',
+  ...overrides,
+});
+
+function mockMarketActive() {
+  (query as any).mockResolvedValue({
+    rows: [{
+      is_active: true, is_resolved: false,
+      end_date: new Date(Date.now() + 30 * 24 * 3600_000).toISOString(),
+    }],
+  });
+}
+
+describe('OTMLongshotGate (gate 0g)', () => {
+  let executor: AutoSignalExecutor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executor = new AutoSignalExecutor({ enabled: true, cooldownMs: 0 });
+    (paperPositionsRepo.getAll as any).mockResolvedValue([]);
+    mockMarketActive();
+  });
+
+  it('blocks crypto_daily LONG at price 0.20 (below default 0.30 threshold)', async () => {
+    const result = await executor.processSignal(
+      makeSignal({ marketType: 'crypto_daily', direction: 'long', price: 0.20 })
+    );
+    expect(result.executed).toBe(false);
+    expect(result.reason).toMatch(/otm_longshot_blocked/);
+    expect(result.reason).toContain('crypto_daily');
+  });
+
+  it('blocks crypto_daily LONG at boundary-low price 0.299', async () => {
+    const result = await executor.processSignal(
+      makeSignal({ marketType: 'crypto_daily', direction: 'long', price: 0.299 })
+    );
+    expect(result.executed).toBe(false);
+    expect(result.reason).toMatch(/otm_longshot_blocked/);
+  });
+
+  it('does NOT block crypto_daily LONG at threshold 0.30 (strict less-than)', async () => {
+    const result = await executor.processSignal(
+      makeSignal({ marketType: 'crypto_daily', direction: 'long', price: 0.30 })
+    );
+    expect(result.reason || '').not.toMatch(/otm_longshot_blocked/);
+  });
+
+  it('does NOT block crypto_daily LONG at high price 0.85', async () => {
+    const result = await executor.processSignal(
+      makeSignal({ marketType: 'crypto_daily', direction: 'long', price: 0.85 })
+    );
+    expect(result.reason || '').not.toMatch(/otm_longshot_blocked/);
+  });
+
+  it('does NOT block crypto_daily SHORT at low price (gate is LONG-only)', async () => {
+    const result = await executor.processSignal(
+      makeSignal({ marketType: 'crypto_daily', direction: 'short', price: 0.15 })
+    );
+    expect(result.reason || '').not.toMatch(/otm_longshot_blocked/);
+  });
+
+  it('does NOT block event_long LONG at low price (gate scoped to crypto types)', async () => {
+    const result = await executor.processSignal(
+      makeSignal({ marketType: 'event_long', direction: 'long', price: 0.05 })
+    );
+    expect(result.reason || '').not.toMatch(/otm_longshot_blocked/);
+  });
+
+  it('does NOT block event_financial LONG at low price (gate scoped to crypto types)', async () => {
+    const result = await executor.processSignal(
+      makeSignal({ marketType: 'event_financial', direction: 'long', price: 0.08 })
+    );
+    expect(result.reason || '').not.toMatch(/otm_longshot_blocked/);
+  });
+
+  it('does NOT block when an open position exists (allows close/unwind path)', async () => {
+    (paperPositionsRepo.getAll as any).mockResolvedValue([
+      { market_id: 'market-crypto-daily-1', side: 'long', size: 10, closed_at: null },
+    ]);
+    const result = await executor.processSignal(
+      makeSignal({ marketType: 'crypto_daily', direction: 'long', price: 0.20 })
+    );
+    expect(result.reason || '').not.toMatch(/otm_longshot_blocked/);
+  });
+
+  it('records a shadow trade tagged otm_longshot_blocked when gate blocks', async () => {
+    await executor.processSignal(
+      makeSignal({ marketType: 'crypto_daily', direction: 'long', price: 0.20 })
+    );
+    const shadowCalls = (query as any).mock.calls.filter(
+      (c: any[]) => typeof c[0] === 'string' && c[0].includes('INSERT INTO shadow_trades')
+    );
+    expect(shadowCalls.length).toBe(1);
+    // signal_type is the last positional param
+    const params = shadowCalls[0][1] as any[];
+    expect(params[params.length - 1]).toBe('otm_longshot_blocked');
+  });
+
+  it.skip('respects EXECUTOR_OTM_LONGSHOT_PRICE_LO env override (constants read at module-import time)', async () => {
+    // Same module-import-time caveat as EventOTMGate tests. Rollback is verified
+    // at deploy time via docker-compose env overrides.
+  });
+
+  it.skip('respects EXECUTOR_OTM_LONGSHOT_TYPES env override (constants read at module-import time)', async () => {
+    // Same module-import-time caveat. Verified at deploy time.
+  });
+});

--- a/packages/dashboard/src/services/AutoSignalExecutor.ts
+++ b/packages/dashboard/src/services/AutoSignalExecutor.ts
@@ -233,6 +233,29 @@ const ALLOWED_MARKET_TYPES: Set<string> | null = process.env.ALLOWED_MARKET_TYPE
   ? new Set(process.env.ALLOWED_MARKET_TYPES.split(',').map(t => t.trim()))
   : null;
 
+// Gate 0g: OTM-longshot block. Crypto-class markets at low prices are
+// structurally cost-dominated for LONG opens — a market entered at 0.20
+// needs the YES price to move from 0.20 → 0.21 just to break even on a
+// 1% round-trip fee, but most 4h moves are smaller than that. Empirical
+// 2026-05-26 cohort: crypto_daily:long n=8, 1 win, total -$61.15, avg
+// entry 0.206 (daily-review #266 forensic). Block LONG opens below the
+// price threshold for the listed market types. SHORT opens are NOT
+// blocked here (different risk geometry) — use Gate 0f if a SHORT cohort
+// turns anti-edge. Closes are always allowed (legacy unwind path).
+//
+// Why not Gate 0f for the whole crypto_daily:long cohort: empirically the
+// long-tail is the cost-dominated subset; balanced-price entries (0.30-0.70)
+// are still strategically viable. Gate 0f is type-wide; this is band-wide.
+const OTM_LONGSHOT_TYPES: Set<string> = new Set(
+  (process.env.EXECUTOR_OTM_LONGSHOT_TYPES || 'crypto_daily')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+);
+// Tunable: block LONG below this YES price (strict <, so 0.30 means
+// 0.299 blocked but 0.300 allowed). Default 0.30.
+const OTM_LONGSHOT_PRICE_LO = parseFiniteEnvNumber('EXECUTOR_OTM_LONGSHOT_PRICE_LO', 0.30);
+
 /**
  * Per-(market_type, direction) blocklist. Surgically blocks (type, side)
  * combinations that empirical generator_predictions analysis identifies as
@@ -576,6 +599,41 @@ export class AutoSignalExecutor extends EventEmitter {
           );
           return { executed: false, reason: 'event_otm_near_expiry: position check failed' };
         }
+      }
+    }
+
+    // 0g. OTMLongshotGate: block LONG opens at low YES price in crypto-class
+    // markets where round-trip cost dominates the typical 4h price move.
+    // Empirical 2026-05-26: crypto_daily:long n=8 lifetime, 1 win, total
+    // -$61.15, avg entry 0.206 — daily-review #266 forensic identified this
+    // as the active bleed. Surgical price-band block (not full type-direction
+    // block) preserves balanced-price entries that remain viable.
+    if (
+      signal.direction === 'long' &&
+      signal.marketType &&
+      OTM_LONGSHOT_TYPES.has(signal.marketType) &&
+      signal.price < OTM_LONGSHOT_PRICE_LO
+    ) {
+      try {
+        const openPositions = await paperPositionsRepo.getAll();
+        const hasOpenPosition = openPositions.some((p) => p.market_id === signal.marketId);
+        if (!hasOpenPosition) {
+          console.log(
+            `[AutoExecutor] REJECTED ${signal.marketId.substring(0, 12)}... : ` +
+              `otm_longshot_blocked (${signal.marketType}, price=${signal.price.toFixed(4)} < ${OTM_LONGSHOT_PRICE_LO})`
+          );
+          this.insertShadowTrade(signal, 'otm_longshot_blocked').catch(() => {});
+          return {
+            executed: false,
+            reason: `otm_longshot_blocked: ${signal.marketType} long@${signal.price.toFixed(4)}`,
+          };
+        }
+      } catch {
+        console.log(
+          `[AutoExecutor] REJECTED ${signal.marketId.substring(0, 12)}... : ` +
+            `otm_longshot_blocked (position check failed)`
+        );
+        return { executed: false, reason: 'otm_longshot_blocked: position check failed' };
       }
     }
 


### PR DESCRIPTION
## Summary

Daily-review #266 forensic identified `crypto_daily:long` as the active bleed: **n=8 lifetime, 1 win, total -$61.15, avg entry 0.206** (all opened 2026-05-25/26). Pattern: longshots at YES 0.15-0.33, exit 4h later near entry — 1% RT cost dominates the typical 4h price move, producing deterministic loss.

Same cost-dominated geometry that motivated blocking `crypto_intraday:long` entirely (PR #209). For `crypto_daily` we use a **surgical price-band block** instead of a full type-direction block: balanced-price subset (0.30-0.70) remains viable, only the longshot tail is structurally broken.

## Patch vs root-cause classification

`containment` — like 0f, executor-level granular tool because `signal_weights` schema can't downweight LONG within a price band. Structural fix would be price-band-aware weights in the combiner; deferred to separate design.

## Test plan

- [x] 9/9 unit tests pass (2 skipped for env-override which require module reload)
- [x] TypeScript build green
- [ ] After deploy, verify on VM: `docker compose exec dashboard-api env | grep EXECUTOR_OTM_LONGSHOT` shows the two vars
- [ ] Confirm new crypto_daily LONG opens at price <0.30 are rejected with `otm_longshot_blocked` in logs
- [ ] `shadow_trades.signal_type = 'otm_longshot_blocked'` accumulating new rows
- [ ] Existing crypto_daily open positions can still close (unwind path bypasses Gate 0g)
- [ ] 7-day check: live crypto_daily:long WR improves (sample to compare against the pre-block baseline of 12.5%)

## Why LONG-only

SHORT geometry differs — shorting a low YES price = buying NO at high price = paying premium, which is a different risk profile (favourite bet). The empirical evidence at #266 is LONG only; SHORT mirror block would need its own evidence.

## Why not event_long

event_long longshots are the **FLB target** and are empirically profitable hold-to-resolution (`event_long:long` t=+36.26 in #266). They get a different exit path (hold to resolution) where the 1% RT cost is irrelevant. Crypto markets don't have that structural escape — they use 4h time-exit which is exactly where the cost kills the geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)