### PR TITLE
feat(daily-review): SignalEngine feed coverage + opens-today checks

### DIFF
--- a/scripts/daily-review-prompt.md
+++ b/scripts/daily-review-prompt.md
@@ -95,6 +95,18 @@ persisted 2+ days, prefix it `[PERSISTENT - N days]` and escalate severity.
   ```
   If everything is `cold` → the rotator is not running.
 
+## 1d. SignalEngine feed coverage — catches downstream feed bugs
+
+Use `coverage_by_type` from `review-data.json`. It has, per `market_type`:
+`tracked` (rotator active), `priced_24h` (data-collector pricing), `with_preds_24h` (SignalEngine produced predictions), `active_in_db` (raw supply).
+
+Flag and investigate:
+- `with_preds_24h = 0` while `tracked > 0` and `priced_24h > 0` → **HIGH, INFRA** — SignalEngine feed bug; the market data exists but the engine is not generating predictions on this type. This was the 2026-05-26 root cause of the chronic "event_short edge stale" alarm — the feed pipeline excluded event_short. Do NOT classify the resulting downstream `edge_measurement_freshness` alarm as the problem; it's a symptom.
+- `priced_24h < 0.5 × tracked` → MEDIUM, INFRA — data-collector is failing to price half of what it tracks; investigate ClobCollector or rate limits.
+- `tracked = 0` for a type listed in `ALLOWED_MARKET_TYPES` → HIGH — supply collapse or rotator misconfiguration.
+
+A "stale edge measurement" alarm WITHOUT a coverage-side anomaly = the cron broke. A "stale edge measurement" alarm WITH `with_preds_24h = 0` = feed bug. Distinguish before classifying.
+
 ## 1b. System invariants — a violation here is a real bug
 
 - **Position lifecycle**: all closes go through `PositionClosingService`. Rows
@@ -148,6 +160,17 @@ Report one line: `Real PnL $X (Y% of reported $Z), inverted N`. If
 back; investigate the responsible collector code path immediately.
 
 ---
+
+## 1e. Rolling-window vs today distinction (anti-framing)
+
+`edge_cohorts_traded` is a rolling 7-day window — it persists historical activity even after a cohort has been blocked. Treating it as "current activity" misclassifies an already-mitigated bleed as an open problem (2026-05-26 #266: framed event_financial:long as "still being traded" when last open predated the block deploy by 4 days).
+
+Use `opens_today` from `review-data.json` for current-day activity, and separately reference `edge_cohorts_traded` only as a 7-day cumulative. When reporting any cohort as a concern:
+- Phrase as "X opens today" if drawn from `opens_today`.
+- Phrase as "X in rolling 7d" if drawn from `edge_cohorts_traded`.
+- Cross-check `MAX(opened_at)` for the cohort against any block deploy date (see PR history) before classifying as "actively trading".
+
+A cohort in `edge_cohorts_traded` with zero `opens_today` and a block deploy in the last 7d = block is working; report "block effective, rolling window will decay".
 
 # Role 2 — FLB shadow-recorder guardian
 

--- a/scripts/daily-review.sh
+++ b/scripts/daily-review.sh
@@ -421,6 +421,52 @@ edge_gap=$(query_json "
   ) t
 ")
 
+# 15c2. Today's open distribution by (type, side) — distinct from rolling 7d
+# in 15b. Surfaces the bleed cohort BEFORE it accumulates into the 7d window.
+# Use this to distinguish "X opens today" from "X in rolling 7d", a framing
+# trap surfaced 2026-05-26 (#266 misread event_financial:long).
+opens_today=$(query_json "
+  SELECT COALESCE(json_agg(t), '[]'::json) FROM (
+    SELECT
+      m.market_type,
+      p.side AS direction,
+      COUNT(*)::float AS n_opens_today,
+      ROUND(AVG(p.avg_entry_price)::numeric, 3)::float AS avg_entry,
+      ROUND(COALESCE(SUM(p.realized_pnl), 0)::numeric, 2)::float AS pnl_so_far,
+      COUNT(*) FILTER (WHERE p.realized_pnl > 0)::float AS wins,
+      COUNT(*) FILTER (WHERE p.closed_at IS NOT NULL)::float AS closed
+    FROM paper_positions p
+    JOIN markets m ON m.id = p.market_id
+    WHERE p.opened_at >= DATE_TRUNC('day', NOW())
+    GROUP BY 1, 2
+    ORDER BY n_opens_today DESC
+  ) t
+")
+
+# 15c3. Market coverage by type — tracked vs priced vs producing predictions.
+# Surfaces SignalEngine feed bugs (a type can be tracked + priced but produce
+# zero predictions if the feed slice excludes it — the bug that caused
+# event_short edge stale 201h alarm on 2026-05-26 #266).
+coverage_by_type=$(query_json "
+  SELECT COALESCE(json_agg(t), '[]'::json) FROM (
+    SELECT
+      m.market_type,
+      COUNT(DISTINCT m.id) FILTER (WHERE m.tracking_status='active')::float AS tracked,
+      COUNT(DISTINCT m.id) FILTER (WHERE m.tracking_status='active' AND EXISTS (
+        SELECT 1 FROM price_history ph
+        WHERE ph.token_id = m.clob_token_id_yes
+          AND ph.time > NOW() - INTERVAL '24 hours'
+      ))::float AS priced_24h,
+      COUNT(DISTINCT g.market_id) FILTER (WHERE g.time > NOW() - INTERVAL '24 hours')::float AS with_preds_24h,
+      COUNT(DISTINCT m.id) FILTER (WHERE m.is_active = true)::float AS active_in_db
+    FROM markets m
+    LEFT JOIN generator_predictions g ON g.market_id::text = m.id::text
+    WHERE m.market_type IS NOT NULL
+    GROUP BY 1
+    ORDER BY 1
+  ) t
+")
+
 # 15d. Measurement freshness — when was each market_type last measured?
 # Stale (> 48h) means the nightly cron isn't running or is timing out for
 # that type. The daily-review should alert when hours_since > 48.
@@ -737,6 +783,8 @@ jq -n \
   --argjson shadow_summary_by_direction "$shadow_summary_by_direction" \
   --argjson edge_cohorts_positive "$edge_cohorts_positive" \
   --argjson edge_cohorts_traded "$edge_cohorts_traded" \
+  --argjson opens_today "$opens_today" \
+  --argjson coverage_by_type "$coverage_by_type" \
   --argjson edge_gap "$edge_gap" \
   --argjson edge_measurement_freshness "$edge_measurement_freshness" \
   --argjson review_history "$(cat "$HISTORY_FILE" 2>/dev/null | jq 'sort_by(.date) | .[-7:]' 2>/dev/null || echo "[]")" \
@@ -772,6 +820,8 @@ jq -n \
     shadow_summary_by_direction: $shadow_summary_by_direction,
     edge_cohorts_positive: $edge_cohorts_positive,
     edge_cohorts_traded: $edge_cohorts_traded,
+    opens_today: $opens_today,
+    coverage_by_type: $coverage_by_type,
     edge_gap: $edge_gap,
     edge_measurement_freshness: $edge_measurement_freshness,
     review_history: $review_history

--- a/scripts/format-review.js
+++ b/scripts/format-review.js
@@ -180,6 +180,10 @@ const edgeCohortsPositive = Array.isArray(data.edge_cohorts_positive) ? data.edg
 const edgeCohortsTraded = Array.isArray(data.edge_cohorts_traded) ? data.edge_cohorts_traded : [];
 const edgeGap = Array.isArray(data.edge_gap) ? data.edge_gap : [];
 const edgeMeasurementFreshness = Array.isArray(data.edge_measurement_freshness) ? data.edge_measurement_freshness : [];
+// 2026-05-26 #266: added to surface SignalEngine feed coverage gaps and
+// current-day open distribution (distinct from rolling 7d edge_cohorts_traded).
+const opensToday = Array.isArray(data.opens_today) ? data.opens_today : [];
+const coverageByType = Array.isArray(data.coverage_by_type) ? data.coverage_by_type : [];
 const generatedAt = data.generated_at || new Date().toISOString();
 
 // ── Trading-state derived signals ───────────────────────────────────────────
@@ -217,10 +221,35 @@ if (edgeGap.length > 0) {
 // Phase 5 Pilar 4-A: measurement infra. Stale edge measurement (>48h) means
 // the nightly EdgeCapacityRefresher cron is failing for some types.
 const staleMeasurements = edgeMeasurementFreshness.filter((r) => Number(r.hours_since) > 48);
-if (staleMeasurements.length > 0) {
+// 2026-05-26 #266: classify stale-measurement alarms — a type that is also
+// starved at the feed (with_preds_24h = 0) is a downstream symptom, not a
+// cron failure. Suppress the cron-failure alert for those types so it doesn't
+// drown out the actual feed bug.
+const coverageByMarketType = new Map(coverageByType.map((r) => [r.market_type, r]));
+const trueCronStales = staleMeasurements.filter((r) => {
+  const cov = coverageByMarketType.get(r.market_type);
+  return !cov || Number(cov.with_preds_24h) > 0;
+});
+if (trueCronStales.length > 0) {
   alerts.push({
     level: 'warning',
-    message: `Edge measurement stale (>48h) for ${staleMeasurements.length} market_type(s): ${staleMeasurements.map((r) => r.market_type).join(', ')}`,
+    message: `Edge measurement stale (>48h) for ${trueCronStales.length} market_type(s): ${trueCronStales.map((r) => r.market_type).join(', ')}`,
+  });
+}
+
+// 2026-05-26 #266: SignalEngine feed coverage. A type tracked + priced but
+// with 0 predictions in 24h is starved by the signal feed slice (the
+// SignalEngine per-type allocation bug). This is the root cause behind
+// many "edge stale Xh" downstream alarms.
+const feedStarvedTypes = coverageByType.filter((r) => {
+  return Number(r.tracked) > 0
+    && Number(r.priced_24h) > 0
+    && Number(r.with_preds_24h) === 0;
+});
+if (feedStarvedTypes.length > 0) {
+  alerts.push({
+    level: 'critical',
+    message: `SignalEngine feed starved for ${feedStarvedTypes.length} type(s) (tracked + priced but 0 predictions/24h): ${feedStarvedTypes.map((r) => `${r.market_type} (${r.tracked} tracked)`).join(', ')}`,
   });
 }
 


### PR DESCRIPTION
## Summary

Daily-review #266 session 2026-05-26 surfaced two recurring failure modes the existing daily-review prompt + data gathering missed:

1. **SignalEngine feed bug presented as 'edge measurement stale' downstream alarm.** event_short had 549 active markets, 18 tracked + priced, but 0 predictions/24h — the feed slice excluded the type. The prompt classified the resulting 'edge stale 201h' alarm as 'category depleted' rather than investigating the upstream feed bug. (Separate spec for the structural fix: docs/superpowers/specs/2026-05-26-signalengine-per-type-allocation-design.md.)
2. **Rolling 7-day edge_cohorts_traded read as 'currently being traded'.** event_financial:long was flagged as 17 active trades when last actual open predated the block deploy by 4 days.

## Changes

**scripts/daily-review.sh**:
- 15c2 \`opens_today\`: today-only (DATE_TRUNC day) opens per (type, side) with avg entry price, pnl-so-far, wins, closed-count.
- 15c3 \`coverage_by_type\`: tracked / priced_24h / with_preds_24h / active_in_db per market_type.

**scripts/daily-review-prompt.md**:
- Role 1d 'SignalEngine feed coverage' — coverage triage with classification rules. Distinguishes feed bug from cron failure before classifying any 'edge stale' alarm.
- Role 1e 'Rolling-window vs today distinction' — explicit phrasing rules + cross-check against block deploy dates before classifying any cohort as 'actively traded'.

**scripts/format-review.js**:
- New CRITICAL alert: 'SignalEngine feed starved' (tracked + priced but 0 predictions/24h).
- Refined existing 'edge measurement stale' alert: suppresses for types that are already starved at the feed (downstream symptom, not cron failure).

## Patch vs root-cause classification

Meta-process improvement. Doesn't fix the SignalEngine feed bug (separate spec); makes the daily review correctly classify that bug when it surfaces so the misframing doesn't recur. Sister PR for the human-side skill is #269.

## Test plan

- [x] Bash syntax check passes (\`bash -n scripts/daily-review.sh\`)
- [x] Node syntax check passes (\`node -c scripts/format-review.js\`)
- [ ] Next workflow run on the VM produces review-data.json with the new \`opens_today\` and \`coverage_by_type\` fields populated
- [ ] Format-review email contains the new feed-starved alert if any type currently has tracked + priced + 0 preds

🤖 Generated with [Claude Code](https://claude.com/claude-code)