### PR TITLE
feat(signal-engine): per-market_type allocation for fair feed coverage

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -139,11 +139,24 @@ services:
       DB_IDLE_TIMEOUT_MS: "10000"
       ENABLE_SIGNAL_ENGINE: "true"
       SIGNAL_INTERVAL_MS: "300000"
-      # Raised 35→45 (2026-05-18), kept at 45 with the 18-market force-include
-      # cohort (12 tail-band + 6 TTR-≤7d added 2026-05-20). Leaves ~27 slots for
-      # merit-selected markets per signal cycle. Bump if the FLB or RPv2 cohorts
-      # grow further.
-      MAX_SIGNAL_MARKETS: "45"
+      # Raised 35→45 (2026-05-18), then 45→50 (2026-05-26) to match the sum
+      # of SIGNAL_SLOTS_PER_TYPE below. Leaves ~32 slots for merit-selected
+      # markets per signal cycle after the 18-market force-include cohort.
+      MAX_SIGNAL_MARKETS: "50"
+      # Per-`market_type` allocation for the SignalEngine feed pipeline.
+      # Spec: docs/superpowers/specs/2026-05-26-signalengine-per-type-allocation-design.md
+      # SIGNAL_FETCH_BUDGET_PER_TYPE: per-type LIMIT in the candidate fetch
+      #   UNION ALL — guarantees event_short candidates enter the pool even
+      #   though their volume_24h is lower than event_long.
+      # SIGNAL_SLOTS_PER_TYPE: per-type slot allocation in selectDiversifiedMarkets
+      #   — guarantees each market_type gets its share of MAX_SIGNAL_MARKETS.
+      # Unset both vars to fall back to legacy volume-sorted single-query
+      # behaviour (backward-compatible default).
+      # Defaults sized for ALLOWED_MARKET_TYPES (crypto_intraday + crypto_daily +
+      # event_financial + event_short) + a smaller event_long share for FLB
+      # shadow measurement. Sum of slots = 50, matches MAX_SIGNAL_MARKETS.
+      SIGNAL_FETCH_BUDGET_PER_TYPE: "crypto_intraday:30,crypto_daily:30,event_financial:40,event_short:40,event_long:60"
+      SIGNAL_SLOTS_PER_TYPE: "crypto_intraday:8,crypto_daily:8,event_financial:12,event_short:12,event_long:10"
       # Force-tracked experiment cohort — same list as the data-collector.
       # MarketSelector pins these to the signal-selection pool so the
       # FLB tail-band markets + the TTR-≤7d RPv2 markets both receive

--- a/packages/dashboard/src/services/MarketSelector.test.ts
+++ b/packages/dashboard/src/services/MarketSelector.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   parseForceIncludeIds,
+  parsePerTypeBudget,
   parseVolumeWeight,
   rankMarketsByVolumeScoreBlend,
   DEFAULT_VOLUME_WEIGHT,
@@ -135,5 +136,58 @@ describe('rankMarketsByVolumeScoreBlend', () => {
     expect(ranked[0].market.id).toBe('b');
     expect(ranked[1].market.id).toBe('a');
     expect(ranked[2].market.id).toBe('c');
+  });
+});
+
+describe('parsePerTypeBudget', () => {
+  it('returns empty Map for undefined input', () => {
+    expect(parsePerTypeBudget(undefined)).toEqual(new Map());
+  });
+
+  it('returns empty Map for empty string', () => {
+    expect(parsePerTypeBudget('')).toEqual(new Map());
+  });
+
+  it('parses a single type:budget pair', () => {
+    expect(parsePerTypeBudget('event_short:15')).toEqual(new Map([['event_short', 15]]));
+  });
+
+  it('parses multiple pairs separated by commas', () => {
+    const result = parsePerTypeBudget('crypto_daily:8,event_financial:12,event_short:12');
+    expect(result).toEqual(new Map([
+      ['crypto_daily', 8],
+      ['event_financial', 12],
+      ['event_short', 12],
+    ]));
+  });
+
+  it('tolerates whitespace around tokens', () => {
+    const result = parsePerTypeBudget(' crypto_daily : 8 , event_short : 12 ');
+    expect(result).toEqual(new Map([['crypto_daily', 8], ['event_short', 12]]));
+  });
+
+  it('drops entries with non-numeric budgets', () => {
+    const result = parsePerTypeBudget('event_short:abc,crypto_daily:5');
+    expect(result).toEqual(new Map([['crypto_daily', 5]]));
+  });
+
+  it('drops entries with missing colon', () => {
+    const result = parsePerTypeBudget('event_short15,crypto_daily:5');
+    expect(result).toEqual(new Map([['crypto_daily', 5]]));
+  });
+
+  it('drops entries with empty type name', () => {
+    const result = parsePerTypeBudget(':15,crypto_daily:5');
+    expect(result).toEqual(new Map([['crypto_daily', 5]]));
+  });
+
+  it('drops entries with negative or zero budget', () => {
+    const result = parsePerTypeBudget('event_short:-5,crypto_daily:0,event_long:10');
+    expect(result).toEqual(new Map([['event_long', 10]]));
+  });
+
+  it('floors fractional budgets to integers', () => {
+    const result = parsePerTypeBudget('event_short:12.7,crypto_daily:5');
+    expect(result).toEqual(new Map([['event_short', 12], ['crypto_daily', 5]]));
   });
 });

--- a/packages/dashboard/src/services/MarketSelector.ts
+++ b/packages/dashboard/src/services/MarketSelector.ts
@@ -62,6 +62,44 @@ export function parseVolumeWeight(raw: string | undefined): number {
   return Math.max(0, Math.min(1, parsed));
 }
 
+/**
+ * Parse a per-`market_type` budget map from an env var string.
+ *
+ * Format: `type:budget,type:budget,...` — e.g. `"crypto_daily:8,event_short:12"`.
+ *
+ * Used by SignalEngine feed allocation: each `market_type` gets a fixed share of
+ * the total processing slots, so low-volume types (event_short) are not starved
+ * by the volume-sorted candidate pool. See spec
+ * `docs/superpowers/specs/2026-05-26-signalengine-per-type-allocation-design.md`.
+ *
+ * Tolerant of malformed entries: invalid entries are silently dropped (logged is
+ * not necessary — env vars are operator-controlled). Empty / undefined input
+ * returns an empty Map, signalling "no per-type allocation; fall back to legacy
+ * behaviour".
+ *
+ * Rules:
+ * - Both type and budget must be present (entry must contain `:`).
+ * - Type name must be non-empty after trim.
+ * - Budget must parse to a finite positive integer (fractional values are floored).
+ *
+ * @returns Map<market_type, budget>. Empty when input is unset/malformed.
+ */
+export function parsePerTypeBudget(raw: string | undefined): Map<string, number> {
+  const out = new Map<string, number>();
+  if (!raw) return out;
+  for (const entry of raw.split(',')) {
+    const colonIdx = entry.indexOf(':');
+    if (colonIdx < 0) continue;
+    const type = entry.slice(0, colonIdx).trim();
+    const budgetRaw = entry.slice(colonIdx + 1).trim();
+    if (type.length === 0) continue;
+    const budget = Number(budgetRaw);
+    if (!Number.isFinite(budget) || budget <= 0) continue;
+    out.set(type, Math.floor(budget));
+  }
+  return out;
+}
+
 export interface RankedMarket<T extends RankableMarket> {
   market: T;
   /** Normalised rank in `[1/N, 1]`; lower is better. */

--- a/packages/dashboard/src/services/PolymarketService.test.ts
+++ b/packages/dashboard/src/services/PolymarketService.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { selectByTypeBudget, type SelectableMarket } from './PolymarketService.js';
+
+const m = (id: string, marketType: string, volume = 100, marketScore = 0.5): SelectableMarket => ({
+  id, marketType, volume, marketScore,
+  // Other fields irrelevant for the budget selector.
+} as SelectableMarket);
+
+describe('selectByTypeBudget', () => {
+  beforeEach(() => {
+    delete process.env.ALLOWED_MARKET_TYPES;
+  });
+
+  it('returns empty when budgets is empty', () => {
+    const ms = [m('a', 'event_long')];
+    expect(selectByTypeBudget(ms, new Map(), 10, new Set())).toEqual([]);
+  });
+
+  it('honours per-type budgets when supply is sufficient', () => {
+    const ms = [
+      m('l1', 'event_long', 100), m('l2', 'event_long', 90), m('l3', 'event_long', 80),
+      m('s1', 'event_short', 50), m('s2', 'event_short', 40),
+    ];
+    const budgets = new Map([['event_long', 2], ['event_short', 2]]);
+    const picked = selectByTypeBudget(ms, budgets, 10, new Set()).map((x) => x.id).sort();
+    expect(picked).toEqual(['l1', 'l2', 's1', 's2']);
+  });
+
+  it('redistributes underfill to ALLOWED types first', () => {
+    process.env.ALLOWED_MARKET_TYPES = 'event_short,crypto_daily';
+    const ms = [
+      m('s1', 'event_short'), m('s2', 'event_short'), m('s3', 'event_short'),
+      m('c1', 'crypto_daily'), m('c2', 'crypto_daily'),
+      m('l1', 'event_long'), m('l2', 'event_long'), m('l3', 'event_long'),
+    ];
+    // Budgets: event_long=4 (only 3 supply → 1 leftover), event_short=2, crypto_daily=2.
+    const budgets = new Map([['event_long', 4], ['event_short', 2], ['crypto_daily', 2]]);
+    const picked = selectByTypeBudget(ms, budgets, 8, new Set()).map((x) => x.id).sort();
+    // event_long picks all 3 (limited supply). 1 leftover slot → event_short or
+    // crypto_daily (both allowed). Either is acceptable; assert count + supply
+    // sources rather than exact ID.
+    expect(picked.length).toBe(8);
+    const counts = countByPrefix(picked);
+    expect(counts.l).toBe(3);
+    // 3 + 2 + 2 = 7; the 8th came from an allowed type.
+    expect(counts.s + counts.c).toBe(5);
+  });
+
+  it('redistributes leftover to non-allowed types if no allowed surplus exists', () => {
+    process.env.ALLOWED_MARKET_TYPES = 'event_short';
+    const ms = [
+      m('s1', 'event_short'),                                 // 1 supply
+      m('l1', 'event_long'), m('l2', 'event_long'),
+      m('l3', 'event_long'), m('l4', 'event_long'),           // 4 supply
+    ];
+    const budgets = new Map([['event_short', 3], ['event_long', 1]]);
+    const picked = selectByTypeBudget(ms, budgets, 5, new Set()).map((x) => x.id).sort();
+    // event_short can only fill 1 (supply limit); 2 budget unused. No allowed
+    // surplus. Leftover goes to event_long.
+    expect(picked).toContain('s1');
+    expect(picked.filter((id) => id.startsWith('l')).length).toBeGreaterThanOrEqual(2);
+    expect(picked.length).toBeLessThanOrEqual(5);
+  });
+
+  it('never exceeds maxTotal even if budgets sum higher', () => {
+    const ms = [
+      m('l1', 'event_long'), m('l2', 'event_long'), m('l3', 'event_long'),
+      m('s1', 'event_short'), m('s2', 'event_short'),
+    ];
+    const budgets = new Map([['event_long', 5], ['event_short', 5]]);
+    const picked = selectByTypeBudget(ms, budgets, 3, new Set());
+    expect(picked.length).toBe(3);
+  });
+
+  it('excludes force-included markets from the per-type budget', () => {
+    const ms = [
+      m('forced1', 'event_long'), m('l1', 'event_long'), m('l2', 'event_long'),
+    ];
+    const budgets = new Map([['event_long', 2]]);
+    const picked = selectByTypeBudget(ms, budgets, 10, new Set(['forced1']));
+    // 'forced1' is excluded from per-type picks (caller adds it back separately).
+    // event_long budget=2 → l1, l2.
+    expect(picked.map((x) => x.id).sort()).toEqual(['l1', 'l2']);
+  });
+
+  it('uses within-bucket volume order (highest first)', () => {
+    const ms = [
+      m('low', 'event_short', 10), m('high', 'event_short', 100), m('mid', 'event_short', 50),
+    ];
+    const budgets = new Map([['event_short', 2]]);
+    const picked = selectByTypeBudget(ms, budgets, 10, new Set());
+    expect(picked.map((x) => x.id)).toEqual(['high', 'mid']);
+  });
+});
+
+function countByPrefix(ids: string[]): Record<string, number> {
+  const counts: Record<string, number> = { l: 0, s: 0, c: 0 };
+  for (const id of ids) {
+    const prefix = id[0];
+    counts[prefix] = (counts[prefix] || 0) + 1;
+  }
+  return counts;
+}

--- a/packages/dashboard/src/services/PolymarketService.test.ts
+++ b/packages/dashboard/src/services/PolymarketService.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { selectByTypeBudget, type SelectableMarket } from './PolymarketService.js';
+import { buildFetchSQL, selectByTypeBudget, type SelectableMarket } from './PolymarketService.js';
 
 const m = (id: string, marketType: string, volume = 100, marketScore = 0.5): SelectableMarket => ({
   id, marketType, volume, marketScore,
@@ -101,3 +101,44 @@ function countByPrefix(ids: string[]): Record<string, number> {
   }
   return counts;
 }
+
+describe('buildFetchSQL', () => {
+  it('returns the legacy single-query SQL when budgets is empty', () => {
+    const { sql, perTypeMode } = buildFetchSQL(new Map());
+    expect(perTypeMode).toBe(false);
+    expect(sql).toContain('ORDER BY m.volume_24h DESC NULLS LAST');
+    expect(sql).toContain('LIMIT $4');
+    expect(sql).toContain('m.id = ANY($5::varchar[])');
+    expect(sql).not.toContain('UNION ALL');
+  });
+
+  it('builds one sub-query per type plus a force-include branch', () => {
+    const budgets = new Map([['crypto_daily', 8], ['event_short', 12]]);
+    const { sql, perTypeMode } = buildFetchSQL(budgets);
+    expect(perTypeMode).toBe(true);
+    expect(sql).toContain("m.market_type = 'crypto_daily'");
+    expect(sql).toContain("m.market_type = 'event_short'");
+    expect(sql).toContain('LIMIT 8');
+    expect(sql).toContain('LIMIT 12');
+    expect(sql).toContain('m.id = ANY($4::varchar[])');
+    // 3 branches (2 types + 1 force-include) → 2 UNION ALL joins.
+    expect(sql.split('UNION ALL').length).toBe(3);
+  });
+
+  it('drops types with unsafe characters from the SQL (defence in depth)', () => {
+    const budgets = new Map([
+      ['crypto_daily', 5],
+      ["bobby'; DROP TABLE--", 5],  // SQL injection attempt
+    ]);
+    const { sql } = buildFetchSQL(budgets);
+    expect(sql).toContain("m.market_type = 'crypto_daily'");
+    expect(sql).not.toContain('DROP TABLE');
+    expect(sql).not.toContain('bobby');
+  });
+
+  it('floors fractional budgets and clamps to a minimum of 1', () => {
+    const budgets = new Map([['event_short', 0.5]]);
+    const { sql } = buildFetchSQL(budgets);
+    expect(sql).toContain('LIMIT 1');
+  });
+});

--- a/packages/dashboard/src/services/PolymarketService.ts
+++ b/packages/dashboard/src/services/PolymarketService.ts
@@ -209,6 +209,101 @@ export function selectByTypeBudget<T extends SelectableMarket>(
   return selected.slice(0, maxTotal);
 }
 
+/**
+ * Build the candidate-fetch SQL for the markets table.
+ *
+ * Two modes:
+ * - When `fetchBudgets` is empty → single ORDER BY volume_24h DESC LIMIT $4
+ *   (legacy behaviour, backward-compatible default).
+ * - When `fetchBudgets` is non-empty → one sub-query per type each with its
+ *   own LIMIT, joined by UNION ALL. The total candidate pool size is
+ *   sum(budgets) + |forceIds|. Force-included IDs are always appended as a
+ *   final sub-query with minimal filters so they never get excluded.
+ *
+ * Returns { sql, params } — caller spreads `params` into pg's query().
+ *
+ * Parameter layout (legacy path):
+ *   $1 = MIN_PRICE, $2 = MAX_PRICE, $3 = MIN_VOLUME, $4 = LIMIT, $5 = forceIds
+ *
+ * Parameter layout (per-type path):
+ *   $1 = MIN_PRICE, $2 = MAX_PRICE, $3 = MIN_VOLUME, $4 = forceIds.
+ *   The per-type LIMITs and type names are interpolated into the SQL string
+ *   directly because pg does not bind LIMIT or table names. Both are
+ *   operator-controlled (env var) so SQL injection is not a concern — but
+ *   defensively, type names are sanitised to ^[a-z_]+$ before interpolation.
+ */
+export function buildFetchSQL(
+  fetchBudgets: Map<string, number>,
+): { sql: string; perTypeMode: boolean } {
+  const baseFilters = `
+        m.is_active = true
+    AND m.is_resolved = false
+    AND COALESCE(m.tracking_status, 'active') != 'cold'
+    AND m.clob_token_id_yes IS NOT NULL AND m.clob_token_id_yes != ''
+    AND m.current_price_yes > $1
+    AND m.current_price_yes < $2
+    AND m.volume_24h >= $3
+    AND EXISTS (
+      SELECT 1 FROM price_history ph
+      WHERE ph.token_id = m.clob_token_id_yes
+        AND ph.time > NOW() - INTERVAL '24 hours'
+      LIMIT 1
+    )`;
+
+  const selectCols = `
+    m.id, m.condition_id, m.question, m.category,
+    m.clob_token_id_yes, m.clob_token_id_no,
+    m.current_price_yes, m.current_price_no,
+    m.volume_24h, m.liquidity, m.end_date, m.is_active,
+    m.market_type,
+    m.tracking_status,
+    m.market_score`;
+
+  if (fetchBudgets.size === 0) {
+    // Legacy single-query path.
+    const sql = `
+      SELECT ${selectCols}
+      FROM markets m
+      WHERE ${baseFilters}
+        OR m.id = ANY($5::varchar[])
+      ORDER BY m.volume_24h DESC NULLS LAST
+      LIMIT $4
+    `;
+    return { sql, perTypeMode: false };
+  }
+
+  // Per-type UNION ALL path.
+  const TYPE_SAFE_RE = /^[a-z_]+$/;
+  const branches: string[] = [];
+  for (const [type, budget] of fetchBudgets) {
+    if (!TYPE_SAFE_RE.test(type)) {
+      console.warn(`[PolymarketService] Skipping unsafe market_type in budget: '${type}'`);
+      continue;
+    }
+    const safeBudget = Math.max(1, Math.floor(budget));
+    branches.push(`
+      (SELECT ${selectCols}
+       FROM markets m
+       WHERE ${baseFilters}
+         AND m.market_type = '${type}'
+       ORDER BY m.volume_24h DESC NULLS LAST
+       LIMIT ${safeBudget})
+    `);
+  }
+  // Always append a force-include branch (skips volume + price-history filters).
+  branches.push(`
+    (SELECT ${selectCols}
+     FROM markets m
+     WHERE m.id = ANY($4::varchar[])
+       AND m.is_active = true
+       AND m.is_resolved = false
+       AND m.clob_token_id_yes IS NOT NULL)
+  `);
+
+  const sql = branches.join('\n      UNION ALL\n');
+  return { sql, perTypeMode: true };
+}
+
 export class PolymarketService extends EventEmitter {
   private config: PolymarketConfig;
   private isRunning = false;
@@ -560,6 +655,13 @@ export class PolymarketService extends EventEmitter {
       // and a sane price range — those are correctness preconditions for the
       // downstream engine, not selection filters.
       const forceIds = Array.from(parseForceIncludeIds(process.env.FORCE_INCLUDE_MARKET_IDS));
+      const fetchBudgets = parsePerTypeBudget(process.env.SIGNAL_FETCH_BUDGET_PER_TYPE);
+      const { sql: fetchSQL, perTypeMode } = buildFetchSQL(fetchBudgets);
+
+      const fetchParams = perTypeMode
+        ? [MIN_PRICE, MAX_PRICE, this.config.minVolume24h, forceIds]
+        : [MIN_PRICE, MAX_PRICE, this.config.minVolume24h, this.config.marketsToFetch, forceIds];
+
       const marketsResult = await query<{
         id: string;
         condition_id: string;
@@ -576,41 +678,9 @@ export class PolymarketService extends EventEmitter {
         market_type: string | null;
         tracking_status: string | null;
         market_score: string | null;
-      }>(`
-        SELECT
-          m.id, m.condition_id, m.question, m.category,
-          m.clob_token_id_yes, m.clob_token_id_no,
-          m.current_price_yes, m.current_price_no,
-          m.volume_24h, m.liquidity, m.end_date, m.is_active,
-          m.market_type,
-          m.tracking_status,
-          m.market_score
-        FROM markets m
-        WHERE m.is_active = true
-          AND m.is_resolved = false
-          AND COALESCE(m.tracking_status, 'active') != 'cold'
-          AND m.clob_token_id_yes IS NOT NULL AND m.clob_token_id_yes != ''
-          AND m.current_price_yes > $1
-          AND m.current_price_yes < $2
-          AND (
-            -- Normal path: above volume threshold AND has recent price history
-            (m.volume_24h >= $3
-              AND EXISTS (
-                SELECT 1 FROM price_history ph
-                WHERE ph.token_id = m.clob_token_id_yes
-                  AND ph.time > NOW() - INTERVAL '24 hours'
-                LIMIT 1
-              ))
-            OR
-            -- Force-include bypass: explicitly allow-listed markets skip the
-            -- volume + price-history filters above.
-            m.id = ANY($5::varchar[])
-          )
-        ORDER BY m.volume_24h DESC NULLS LAST
-        LIMIT $4
-      `, [MIN_PRICE, MAX_PRICE, this.config.minVolume24h, this.config.marketsToFetch, forceIds]);
+      }>(fetchSQL, fetchParams);
 
-      console.log(`[PolymarketService] Found ${marketsResult.rows.length} markets with recent price data (filtered by price_history)`);
+      console.log(`[PolymarketService] Found ${marketsResult.rows.length} markets with recent price data (filtered by price_history, perTypeMode=${perTypeMode})`);
 
       const candidateMarkets: PolymarketMarket[] = [];
 

--- a/packages/dashboard/src/services/PolymarketService.ts
+++ b/packages/dashboard/src/services/PolymarketService.ts
@@ -12,6 +12,7 @@ import { getDataCollectorService, type PriceData } from './DataCollectorService.
 import { applyLiquidityFilter } from './MarketLiquidityFilterBridge.js';
 import {
   parseForceIncludeIds,
+  parsePerTypeBudget,
   parseVolumeWeight,
   rankMarketsByVolumeScoreBlend,
 } from './MarketSelector.js';
@@ -81,6 +82,18 @@ export interface PolymarketMarket {
   marketScore?: number;
 }
 
+/**
+ * Structural alias for `selectByTypeBudget`. The selector only reads the fields
+ * listed here; full `PolymarketMarket` extends this. Exported so tests can pass
+ * minimal synthetic objects without constructing the full shape.
+ */
+export interface SelectableMarket {
+  id: string;
+  marketType?: string;
+  volume: number;
+  marketScore?: number;
+}
+
 export interface PolymarketPrice {
   marketId: string;
   tokenId: string;
@@ -111,6 +124,89 @@ interface ClobMarketResponse {
 interface ClobMarketsResponse {
   data?: ClobMarketResponse[];
   next_cursor?: string;
+}
+
+/**
+ * Select markets up to a per-`market_type` budget, with underfill
+ * redistribution to ALLOWED_MARKET_TYPES (live-traded) first.
+ *
+ * Why standalone (not a method): pure function with no DB / state access, so
+ * it can be unit-tested with synthetic inputs covering all edge cases.
+ *
+ * Algorithm:
+ *   1. Filter out force-included IDs — the caller pins those separately.
+ *   2. Bucket remaining markets by `marketType`. Within each bucket, sort by
+ *      volume DESC (within-bucket priority is volume-blend; the caller can
+ *      pre-sort by score-blend if a different priority is desired).
+ *   3. First pass: take min(budget[type], bucket.length) from each type.
+ *   4. Compute leftover = maxTotal - selected_so_far - sum(unused budget).
+ *      Wait — simpler: while selected < maxTotal AND any type with surplus
+ *      candidates still exists, pull one more from the type with the highest
+ *      original budget that has surplus. Prefer ALLOWED_MARKET_TYPES.
+ *   5. Final cap at maxTotal.
+ */
+export function selectByTypeBudget<T extends SelectableMarket>(
+  markets: T[],
+  budgets: Map<string, number>,
+  maxTotal: number,
+  forceIds: Set<string>,
+): T[] {
+  if (budgets.size === 0 || maxTotal <= 0) return [];
+
+  // 1. Drop force-included; caller pins those.
+  const candidates = markets.filter((m) => !forceIds.has(m.id));
+
+  // 2. Bucket by marketType + sort within bucket by volume DESC.
+  const buckets = new Map<string, T[]>();
+  for (const m of candidates) {
+    const key = m.marketType ?? '__unknown__';
+    if (!buckets.has(key)) buckets.set(key, []);
+    buckets.get(key)!.push(m);
+  }
+  for (const bucket of buckets.values()) {
+    bucket.sort((a, b) => b.volume - a.volume);
+  }
+
+  // 3. First pass: take min(budget, supply) from each type. Track any
+  //    leftover (unused budget) — those slots can be redistributed below.
+  const selected: T[] = [];
+  const remainingByType = new Map<string, T[]>();
+  let leftover = 0;
+  for (const [type, budget] of budgets) {
+    const bucket = buckets.get(type) ?? [];
+    const take = Math.min(budget, bucket.length);
+    selected.push(...bucket.slice(0, take));
+    remainingByType.set(type, bucket.slice(take));
+    leftover += Math.max(0, budget - take);
+  }
+
+  // 4. Underfill: redistribute unused budget to types with surplus supply.
+  //    Priority: ALLOWED_MARKET_TYPES first, then non-allowed; within each
+  //    priority, the type with the largest original budget wins ties.
+  //    Cap at `leftover` slots — we never expand a type beyond its own budget
+  //    unless other types under-supplied.
+  const allowed = new Set(
+    (process.env.ALLOWED_MARKET_TYPES ?? '')
+      .split(',').map((s) => s.trim()).filter(Boolean)
+  );
+  while (leftover > 0 && selected.length < maxTotal) {
+    // Build the prioritised list of types that still have surplus.
+    const surplus = [...remainingByType.entries()]
+      .filter(([, rem]) => rem.length > 0)
+      .map(([type, rem]) => ({
+        type,
+        budget: budgets.get(type) ?? 0,
+        rem,
+        priority: allowed.size === 0 || allowed.has(type) ? 0 : 1, // 0 = allowed/no-allowlist, 1 = non-allowed
+      }))
+      .sort((a, b) => a.priority - b.priority || b.budget - a.budget);
+    if (surplus.length === 0) break;
+    selected.push(surplus[0].rem.shift()!);
+    leftover--;
+  }
+
+  // 5. Hard cap.
+  return selected.slice(0, maxTotal);
 }
 
 export class PolymarketService extends EventEmitter {
@@ -366,6 +462,7 @@ export class PolymarketService extends EventEmitter {
 
     const forceIds = parseForceIncludeIds(process.env.FORCE_INCLUDE_MARKET_IDS);
     const volumeWeight = parseVolumeWeight(process.env.MARKET_SELECTION_VOLUME_WEIGHT);
+    const perTypeBudget = parsePerTypeBudget(process.env.SIGNAL_SLOTS_PER_TYPE);
 
     // Step 1: pin force-included markets at the top, regardless of volume/score.
     const forced = allMarkets.filter(m => forceIds.has(m.id));
@@ -377,12 +474,24 @@ export class PolymarketService extends EventEmitter {
       console.log(`[PolymarketService] Force-include IDs not in candidate set (skipped): ${missingForced.join(',')}`);
     }
 
-    // Step 2: rank the non-forced pool by blended volume + market_score.
+    // Step 2: NEW — if SIGNAL_SLOTS_PER_TYPE is configured, use per-type budgets
+    // as the primary diversification axis. This guarantees low-volume types
+    // (event_short) get representation. Otherwise fall back to the legacy
+    // byCategory path for full backward compatibility.
+    if (perTypeBudget.size > 0) {
+      const remainingSlots = Math.max(0, maxTotal - forced.length);
+      const byType = selectByTypeBudget(allMarkets, perTypeBudget, remainingSlots, forceIds);
+      const selected = [...forced, ...byType];
+      console.log(`[PolymarketService] Per-type selection: forced=${forced.length}, byType=${byType.length}, total=${selected.length}`);
+      return selected;
+    }
+
+    // Step 3 (legacy path): rank the non-forced pool by blended volume + market_score.
     const candidates = allMarkets.filter(m => !forceIds.has(m.id));
     const ranked = rankMarketsByVolumeScoreBlend(candidates, volumeWeight);
     const rankMap = new Map(ranked.map(r => [r.market.id, r.blendedRank]));
 
-    // Step 3: diversify by category, taking the highest-ranked first.
+    // Step 4: diversify by category, taking the highest-ranked first.
     const byCategory = new Map<string, PolymarketMarket[]>();
     for (const { market } of ranked) {
       const cat = market.category;
@@ -399,7 +508,7 @@ export class PolymarketService extends EventEmitter {
       console.log(`[PolymarketService] Category '${category}': ${toTake}/${markets.length} markets selected`);
     }
 
-    // Step 4: fill remaining slots with the next best by blended rank.
+    // Step 5: fill remaining slots with the next best by blended rank.
     if (selected.length < maxTotal) {
       const selectedIds = new Set(selected.map(m => m.id));
       const remaining = ranked
@@ -414,7 +523,7 @@ export class PolymarketService extends EventEmitter {
       }
     }
 
-    // Step 5: trim if we overshoot. Force-included markets are preserved;
+    // Step 6: trim if we overshoot. Force-included markets are preserved;
     // non-forced trimming preserves blended-rank order.
     if (selected.length > maxTotal) {
       const forcedKeep = selected.filter(m => forceIds.has(m.id));

--- a/packages/dashboard/src/services/SignalEngine.perTypeSlice.test.ts
+++ b/packages/dashboard/src/services/SignalEngine.perTypeSlice.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { pickMarketsForCycle, type ActiveMarketLike } from './SignalEngine.js';
+
+// Helper: synthetic markets with just the fields the picker reads.
+const m = (id: string, marketType: string): ActiveMarketLike => ({
+  id, marketType,
+  // Other fields irrelevant for the round-robin pick — keep minimal.
+} as ActiveMarketLike);
+
+describe('pickMarketsForCycle', () => {
+  it('returns all markets when count <= maxMarketsPerCycle', () => {
+    const ms = [m('a', 'event_long'), m('b', 'crypto_daily')];
+    expect(pickMarketsForCycle(ms, 10).map((x) => x.id)).toEqual(['a', 'b']);
+  });
+
+  it('returns empty array when input is empty', () => {
+    expect(pickMarketsForCycle([], 10)).toEqual([]);
+  });
+
+  it('returns empty array when maxMarketsPerCycle is 0', () => {
+    expect(pickMarketsForCycle([m('a', 'event_long')], 0)).toEqual([]);
+  });
+
+  it('round-robins across types when input is biased', () => {
+    // Biased input: 6 event_long, 2 crypto_daily, 1 event_short
+    const ms = [
+      m('l1', 'event_long'), m('l2', 'event_long'), m('l3', 'event_long'),
+      m('l4', 'event_long'), m('l5', 'event_long'), m('l6', 'event_long'),
+      m('c1', 'crypto_daily'), m('c2', 'crypto_daily'),
+      m('s1', 'event_short'),
+    ];
+    const picked = pickMarketsForCycle(ms, 6).map((x) => x.id);
+    // Expect round-robin: l1, c1, s1, l2, c2, l3 (one from each type per cycle
+    // until that type is exhausted).
+    expect(picked).toEqual(['l1', 'c1', 's1', 'l2', 'c2', 'l3']);
+  });
+
+  it('skips exhausted types and continues with the rest', () => {
+    // event_short has 1 market, others have 3 — after 1 round, event_short is
+    // exhausted and the remaining slots are filled from the survivors.
+    const ms = [
+      m('l1', 'event_long'), m('l2', 'event_long'), m('l3', 'event_long'),
+      m('c1', 'crypto_daily'), m('c2', 'crypto_daily'), m('c3', 'crypto_daily'),
+      m('s1', 'event_short'),
+    ];
+    const picked = pickMarketsForCycle(ms, 7).map((x) => x.id);
+    // Round 1: l1, c1, s1. Round 2: l2, c2 (s exhausted). Round 3: l3, c3.
+    expect(picked).toEqual(['l1', 'c1', 's1', 'l2', 'c2', 'l3', 'c3']);
+  });
+
+  it('treats markets with missing marketType as a single "unknown" bucket', () => {
+    const ms = [
+      m('a', 'event_long'),
+      { id: 'b' } as ActiveMarketLike,           // no marketType
+      { id: 'c', marketType: undefined } as ActiveMarketLike,
+      m('d', 'event_long'),
+    ];
+    const picked = pickMarketsForCycle(ms, 3).map((x) => x.id);
+    // Round 1: a (event_long), b (unknown). Round 2: d.
+    // The 'unknown' bucket gets one slot per round just like any other type.
+    expect(picked).toEqual(['a', 'b', 'd']);
+  });
+
+  it('preserves bucket-internal order (does not sort)', () => {
+    const ms = [
+      m('z', 'event_long'), m('a', 'event_long'),
+      m('y', 'crypto_daily'), m('b', 'crypto_daily'),
+    ];
+    expect(pickMarketsForCycle(ms, 4).map((x) => x.id)).toEqual(['z', 'y', 'a', 'b']);
+  });
+});

--- a/packages/dashboard/src/services/SignalEngine.ts
+++ b/packages/dashboard/src/services/SignalEngine.ts
@@ -157,6 +157,61 @@ interface ActiveMarket {
   trackingStatus?: string; // active, hot, cold — cold markets have stale prices
 }
 
+/**
+ * Structural alias for `pickMarketsForCycle`. The picker only reads `id` and
+ * `marketType`, so tests can pass minimal synthetic objects. Production callers
+ * pass the full `ActiveMarket` (which extends this).
+ */
+export interface ActiveMarketLike {
+  id: string;
+  marketType?: string;
+}
+
+/**
+ * Round-robin pick across `market_type` buckets up to `maxMarketsPerCycle`.
+ *
+ * Why: the legacy `activeMarkets.slice(0, N)` preserves whatever order the
+ * pipeline upstream produced — typically volume-sorted, which biases the pick
+ * toward `event_long` (high volume) and starves low-volume types like
+ * `event_short` (which currently produce 0 predictions despite being tracked).
+ *
+ * Per-type round-robin guarantees fair coverage per cycle regardless of upstream
+ * order. Markets without `marketType` are bucketed together under the `__unknown__`
+ * key and round-robined like any other type.
+ *
+ * Bucket-internal order is preserved (no sort) so callers retain control over
+ * within-type prioritisation (e.g. by score, recent activity).
+ */
+export function pickMarketsForCycle<T extends ActiveMarketLike>(
+  activeMarkets: T[],
+  maxMarketsPerCycle: number,
+): T[] {
+  if (maxMarketsPerCycle <= 0 || activeMarkets.length === 0) return [];
+
+  // Group preserving insertion order — Map iteration order = insertion order.
+  const buckets = new Map<string, T[]>();
+  for (const market of activeMarkets) {
+    const key = market.marketType ?? '__unknown__';
+    if (!buckets.has(key)) buckets.set(key, []);
+    buckets.get(key)!.push(market);
+  }
+
+  const result: T[] = [];
+  // Round-robin: keep iterating until result is full or every bucket is empty.
+  // No sort — bucket iteration order is the order types first appeared.
+  while (result.length < maxMarketsPerCycle) {
+    let pickedThisRound = false;
+    for (const bucket of buckets.values()) {
+      if (bucket.length === 0) continue;
+      result.push(bucket.shift()!);
+      pickedThisRound = true;
+      if (result.length >= maxMarketsPerCycle) break;
+    }
+    if (!pickedThisRound) break; // all buckets exhausted
+  }
+  return result;
+}
+
 export class SignalEngine extends EventEmitter {
   private config: SignalEngineConfig;
   private signals: Map<string, ISignal> = new Map();
@@ -504,7 +559,7 @@ export class SignalEngine extends EventEmitter {
 
     const startTime = Date.now();
     const results: SignalResult[] = [];
-    const marketsToProcess = this.activeMarkets.slice(0, this.config.maxMarketsPerCycle);
+    const marketsToProcess = pickMarketsForCycle(this.activeMarkets, this.config.maxMarketsPerCycle);
 
     // console.log(`[SignalEngine] Computing signals for ${marketsToProcess.length} markets`);
 


### PR DESCRIPTION
## Summary

Closes the SignalEngine feed bug surfaced in daily-review #266: `event_short` markets were tracked + priced (18 markets, 229 bars/24h avg) but produced **0 generator predictions in any 24h window**. Three layers in the feed pipeline ignored `market_type`, each biasing toward high-volume types and collectively starving event_short.

Implementation per spec [`docs/superpowers/specs/2026-05-26-signalengine-per-type-allocation-design.md`](../blob/main/docs/superpowers/specs/2026-05-26-signalengine-per-type-allocation-design.md):

- **L1 (`fetchMarketsFromDb`)**: per-type sub-query UNION ALL with per-type LIMIT, replaces the single `ORDER BY volume_24h DESC LIMIT N` that excluded low-volume types from the candidate pool. Defence-in-depth: type names sanitised to `^[a-z_]+$` before SQL interpolation.
- **L2 (`selectDiversifiedMarkets`)**: `byMarketType` primary axis with ALLOWED_MARKET_TYPES-first underfill redistribution. Falls back to legacy `byCategory` path when env var unset.
- **L3 (`computeSignals`)**: round-robin per-type slice replaces `activeMarkets.slice(0, N)` so per-cycle distribution is guaranteed even if upstream is biased.

New helpers (all pure, unit-tested):
- `parsePerTypeBudget` (MarketSelector.ts)
- `selectByTypeBudget` (PolymarketService.ts)
- `buildFetchSQL` (PolymarketService.ts)
- `pickMarketsForCycle` (SignalEngine.ts)

Env vars (defaults proportional to ALLOWED_MARKET_TYPES, event_long minor share for FLB measurement):
- `SIGNAL_FETCH_BUDGET_PER_TYPE`: candidate-pool budget per type (sum ≈ 200).
- `SIGNAL_SLOTS_PER_TYPE`: per-cycle slot allocation per type (sum = 50 = MAX_SIGNAL_MARKETS).

`MAX_SIGNAL_MARKETS` raised 45 → 50 to match the sum of slot budgets.

## Patch vs root-cause classification

`root-cause` — fixes the structural bias in all 3 layers. Backward-compatible default (both env vars unset → legacy behaviour preserved) means rollback is a compose-only change, not a code revert.

## Test plan

- [x] **Unit tests for all 4 pure functions** — 10 + 11 + 7 + 18 cases pass.
- [x] **Full dashboard suite**: 416 passed / 0 failed / 14 skipped (37 files passed).
- [x] **TypeScript build**: green.
- [x] **YAML validation**: `docker compose config` succeeds.
- [ ] **Post-deploy (1h)**: `generator_predictions` for event_short > 0 rows in the first hour. Coverage query in [plan Task 7](../blob/main/docs/superpowers/plans/2026-05-26-signalengine-per-type-allocation.md#task-7-post-deploy-verification-on-the-vm).
- [ ] **Post-deploy (1h)**: event_long predictions reduced from ~27/hour to ~10/hour but still > 0 (expected — slot reallocation).
- [ ] **Post-deploy (48h)**: `EdgeCapacityRefresher` writes a fresh `generator_edge` row for event_short (the 201h-stale alarm clears).

## Notes on subagent execution

Implementation done by a fresh subagent following the TDD plan. Two thoughtful deviations from the literal plan code (both reported and verified):
1. `pickMarketsForCycle`: removed an early-return that short-circuited round-robin reordering when `input.length <= max`. Tests required the round-robin order even at exactly the cap.
2. `selectByTypeBudget`: bounded underfill at `sum(budgets)` rather than `maxTotal` to match the test expectations (and the spec's prose).

Both fixes match the spec's intent; the literal plan code was slightly off and the failing tests caught it.

## Spec + plan

- Spec: `docs/superpowers/specs/2026-05-26-signalengine-per-type-allocation-design.md`
- Plan: `docs/superpowers/plans/2026-05-26-signalengine-per-type-allocation.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)