### PR TITLE
fix(polymarket-service): drop volume filter from per-type fetch path

### DIFF
--- a/packages/dashboard/src/services/PolymarketService.test.ts
+++ b/packages/dashboard/src/services/PolymarketService.test.ts
@@ -110,6 +110,8 @@ describe('buildFetchSQL', () => {
     expect(sql).toContain('LIMIT $4');
     expect(sql).toContain('m.id = ANY($5::varchar[])');
     expect(sql).not.toContain('UNION ALL');
+    // Legacy path KEEPS the volume filter (preserves prior behaviour).
+    expect(sql).toContain('m.volume_24h >= $3');
   });
 
   it('builds one sub-query per type plus a force-include branch', () => {
@@ -123,6 +125,10 @@ describe('buildFetchSQL', () => {
     expect(sql).toContain('m.id = ANY($4::varchar[])');
     // 3 branches (2 types + 1 force-include) → 2 UNION ALL joins.
     expect(sql.split('UNION ALL').length).toBe(3);
+    // Per-type path DROPS the volume filter — point of per-type allocation
+    // is to surface low-volume types (event_short) the legacy MIN_VOLUME
+    // filter excludes. Per-type LIMIT caps the result set instead.
+    expect(sql).not.toContain('m.volume_24h >= $3');
   });
 
   it('drops types with unsafe characters from the SQL (defence in depth)', () => {

--- a/packages/dashboard/src/services/PolymarketService.ts
+++ b/packages/dashboard/src/services/PolymarketService.ts
@@ -235,14 +235,15 @@ export function selectByTypeBudget<T extends SelectableMarket>(
 export function buildFetchSQL(
   fetchBudgets: Map<string, number>,
 ): { sql: string; perTypeMode: boolean } {
-  const baseFilters = `
+  // Filters always applied (both paths). The volume filter is intentionally
+  // NOT here — see per-type vs legacy split below.
+  const sharedFilters = `
         m.is_active = true
     AND m.is_resolved = false
     AND COALESCE(m.tracking_status, 'active') != 'cold'
     AND m.clob_token_id_yes IS NOT NULL AND m.clob_token_id_yes != ''
     AND m.current_price_yes > $1
     AND m.current_price_yes < $2
-    AND m.volume_24h >= $3
     AND EXISTS (
       SELECT 1 FROM price_history ph
       WHERE ph.token_id = m.clob_token_id_yes
@@ -260,11 +261,13 @@ export function buildFetchSQL(
     m.market_score`;
 
   if (fetchBudgets.size === 0) {
-    // Legacy single-query path.
+    // Legacy single-query path — keeps the volume filter (preserves prior
+    // behaviour for callers that have not opted into per-type allocation).
     const sql = `
       SELECT ${selectCols}
       FROM markets m
-      WHERE ${baseFilters}
+      WHERE (${sharedFilters}
+        AND m.volume_24h >= $3)
         OR m.id = ANY($5::varchar[])
       ORDER BY m.volume_24h DESC NULLS LAST
       LIMIT $4
@@ -272,7 +275,13 @@ export function buildFetchSQL(
     return { sql, perTypeMode: false };
   }
 
-  // Per-type UNION ALL path.
+  // Per-type UNION ALL path. The volume filter is dropped because the whole
+  // point of per-type allocation is to ensure low-volume types (event_short)
+  // get representation; requiring volume_24h >= MIN_VOLUME re-introduces the
+  // exact starvation we are trying to fix (verified 2026-05-26 #271 post-
+  // deploy: event_short had 18 tracked but only 1 met MIN_VOLUME=500). The
+  // per-type LIMIT already caps the candidate pool, so dropping the filter
+  // does not blow up the result-set size.
   const TYPE_SAFE_RE = /^[a-z_]+$/;
   const branches: string[] = [];
   for (const [type, budget] of fetchBudgets) {
@@ -284,7 +293,7 @@ export function buildFetchSQL(
     branches.push(`
       (SELECT ${selectCols}
        FROM markets m
-       WHERE ${baseFilters}
+       WHERE ${sharedFilters}
          AND m.market_type = '${type}'
        ORDER BY m.volume_24h DESC NULLS LAST
        LIMIT ${safeBudget})


### PR DESCRIPTION
Post-deploy hotfix for #271. event_short stayed at 0 predictions because the per-type sub-query inherited `volume_24h >= $3` (default 500), filtering 17 of 18 tracked event_short markets. Split SQL filters so the volume gate only applies in the legacy single-query path. Per-type path relies on its own LIMIT for bounding + price_history EXISTS for quality. Tests updated, 11/11 pass, TS build green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved market data retrieval to properly differentiate between standard and per-type analysis modes. Per-type market analysis now includes lower-volume market segments for more comprehensive market coverage.

* **Tests**
  * Updated test assertions to verify correct filtering behavior across different query modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->