### PR TITLE
fix(polymarket-service): renumber per-type SQL params after volume-filter removal

### DIFF
--- a/packages/dashboard/src/services/PolymarketService.test.ts
+++ b/packages/dashboard/src/services/PolymarketService.test.ts
@@ -122,7 +122,7 @@ describe('buildFetchSQL', () => {
     expect(sql).toContain("m.market_type = 'event_short'");
     expect(sql).toContain('LIMIT 8');
     expect(sql).toContain('LIMIT 12');
-    expect(sql).toContain('m.id = ANY($4::varchar[])');
+    expect(sql).toContain('m.id = ANY($3::varchar[])');
     // 3 branches (2 types + 1 force-include) → 2 UNION ALL joins.
     expect(sql.split('UNION ALL').length).toBe(3);
     // Per-type path DROPS the volume filter — point of per-type allocation

--- a/packages/dashboard/src/services/PolymarketService.ts
+++ b/packages/dashboard/src/services/PolymarketService.ts
@@ -300,10 +300,12 @@ export function buildFetchSQL(
     `);
   }
   // Always append a force-include branch (skips volume + price-history filters).
+  // $3 is the force-include array — minVolume ($3 in legacy) is omitted from the
+  // per-type path entirely (per-type LIMIT bounds the result set instead).
   branches.push(`
     (SELECT ${selectCols}
      FROM markets m
-     WHERE m.id = ANY($4::varchar[])
+     WHERE m.id = ANY($3::varchar[])
        AND m.is_active = true
        AND m.is_resolved = false
        AND m.clob_token_id_yes IS NOT NULL)
@@ -668,7 +670,7 @@ export class PolymarketService extends EventEmitter {
       const { sql: fetchSQL, perTypeMode } = buildFetchSQL(fetchBudgets);
 
       const fetchParams = perTypeMode
-        ? [MIN_PRICE, MAX_PRICE, this.config.minVolume24h, forceIds]
+        ? [MIN_PRICE, MAX_PRICE, forceIds]
         : [MIN_PRICE, MAX_PRICE, this.config.minVolume24h, this.config.marketsToFetch, forceIds];
 
       const marketsResult = await query<{


### PR DESCRIPTION
Post-deploy of #272 SignalEngine threw `could not determine data type of parameter $3` on every cycle — ZERO market discovery since 10:14 UTC. #272 removed `m.volume_24h >= $3` from the per-type SQL but the caller still passed $3 (minVolume24h) in fetchParams; pg cannot infer the type of an unreferenced param. Fix: drop minVolume24h from per-type fetchParams (now [$1, $2, $3] with $3 = forceIds), renumber force-include branch from $4 → $3, update test. Legacy path unchanged.