### PR TITLE
feat(daily-review): bilateral block check + shadow temporal-lumpiness flag + SHORT forensic recipe

### DIFF
--- a/scripts/daily-review-prompt.md
+++ b/scripts/daily-review-prompt.md
@@ -159,6 +159,24 @@ Report one line: `Real PnL $X (Y% of reported $Z), inverted N`. If
 `inverted_count > 0` → **CRITICAL regression** — the price-inversion bug is
 back; investigate the responsible collector code path immediately.
 
+**SHORT-side forensic — when NOT to claim phantom PnL.** The inversion query
+above is LONG-asymmetric: it tests `entry + exit ≈ 1.0`. For SHORT positions
+this test never fires because `avg_entry_price` and `current_price` are stored
+in the held-token (NO) frame — both in the same frame, no `entry + exit ≈ 1.0`
+signature. If a SHORT position shows negative `realized_pnl` after an apparently
+favorable YES-frame price move and you suspect a SHORT-side phantom bug, run
+the 3-step recipe before claiming the bug:
+
+1. `SELECT pp.token_id = m.clob_token_id_yes FROM paper_positions pp JOIN markets m ON m.id = pp.market_id WHERE pp.id = <pos>;`
+   Expect `f` for SHORT — confirms held-token is NO.
+2. `SELECT side, executed_size, executed_price, fee FROM paper_trades WHERE market_id = <mkt> AND token_id = <tok> ORDER BY time;`
+   Confirm BUY + SELL legs, both in NO frame.
+3. Compute `(sell_executed_price − buy_executed_price) × size − exit_fee` and
+   confirm it matches `realized_pnl`. If it does, the loss is real, not phantom.
+
+If steps 1-3 are consistent, the price-inversion bug is NOT involved — the
+SHORT just lost because NO dropped (YES rose). See `project_short_pnl_convention`.
+
 ---
 
 ## 1e. Rolling-window vs today distinction (anti-framing)
@@ -306,6 +324,63 @@ WHERE s.n_shadow >= 100
   `<type>:<direction>` to `EXECUTOR_BLOCKED_TYPE_DIRECTIONS` — human decision"**.
   Do NOT file the PR yourself. Cross-check that the cohort is not already
   blocked before alarming (read the dashboard-api env or the docker-compose).
+
+### 3c-bis. Bilateral block check (counter-WR is not a costs defence)
+
+When the alarm in 3c fires on **one** direction of a (market_type, X) cell, run
+the live-side query for the **other** direction of the same cell too, even if
+its shadow arm has `n_resolved < 100`. The auto-review on 2026-05-27 surfaced
+`event_short:long` 0/23, recommended blocking only the LONG side under the
+framing "the SHORT direction is correct (mean +7.44% favorable 4h move), losing
+to costs". 24h later live `event_short:short` was 0/19 — the SHORT side also had
+the direction wrong, the "costs only" framing was a misread. The PR-decision
+cost was an extra day of bleed.
+
+Surface both sides in the issue when:
+- Side A meets the 3c bar (shadow `n≥100` `wins≤5%` `avg_pnl<0` + live `n≥5`
+  `WR<20%` `total<0`), AND
+- Side B has live `n≥10` with `WR<20%` and `total_pnl<0` (regardless of shadow
+  availability for B).
+
+Cost-domination produces a wide PnL distribution; **uniform-sign losses across
+a cohort** (every trade in the same sign) are a directional signature, not a
+cost signature. When a human PR proposes to keep side B enabled with the
+"direction correct, losing to costs" framing, require either (a) `n ≥ 30` on
+side B with the PnL distribution histogram, or (b) flag this section back to
+the human as the basis for the dispute. See `feedback_counterwr_costs_misread`.
+
+### 3c-ter. Shadow temporal-lumpiness sanity check (run before action)
+
+Shadow `win_rate` over 30 days is **temporally lumpy** — event markets share
+resolution dates, so a single tournament/election/expiry calendar can put
+hundreds of correlated outcomes in one day. On 2026-05-27 the auto-review
+quoted `event_long LONG shadow WR = 96.1% (n=791 resolved)`; on 2026-05-28 the
+same SQL gave `WR = 22% (n=5494)` — 3605 LONG resolutions landed on a single
+day. The data was correct in both runs; the 96.1% was a real-but-transient
+peak that one resolution wave wiped out.
+
+Before treating any shadow WR above ~70% or below ~20% as a candidate for
+promotion/demotion (3b alarms are cost-aware and immune to this), check the
+temporal distribution:
+
+```sql
+SELECT m.market_type, s.direction,
+       DATE(s.resolved_at) AS d,
+       COUNT(*) n_resolved,
+       ROUND(AVG(s.theoretical_pnl)::numeric, 4) avg_pnl
+FROM shadow_trades s JOIN markets m ON m.id = s.market_id
+WHERE s.resolved_at IS NOT NULL AND s.time >= NOW() - INTERVAL '30 days'
+  AND m.market_type = '<type>' AND s.direction = '<direction>'
+GROUP BY 1, 2, 3
+ORDER BY 4 DESC
+LIMIT 5;
+```
+
+If any single date contributes >20% of the 30d resolved sample for that cohort,
+flag it in the issue under the shadow line:
+`Shadow <type>:<dir> WR=X% (lumpy: <dominant date> = Y% of n_resolved)`.
+Do **not** recommend action on lumpy shadow alone. The `shadow_summary_by_direction`
+JSON also surfaces `dominant_date_pct` directly — use it as the trigger.
 
 **Misattribution caveat**: shadow_trades' `s.market_type` is frozen at the
 trade time. Markets get reclassified (WTI Oil moved from `event_short` →

--- a/scripts/daily-review.sh
+++ b/scripts/daily-review.sh
@@ -694,30 +694,58 @@ shadow_summary=$(query_json "
 # (shadow SHORT win rates run very high in prediction markets because most
 # markets resolve NO; not a strategy edge). Promotion logic uses this to
 # decide whether a high overall win_rate is genuine or SHORT-bias-inflated.
+#
+# dominant_date_pct exposes the temporal-lumpiness artifact: event markets share
+# resolution dates and resolve in batches. A single-day wave can flip the
+# 30d win_rate by 70+ percentage points (2026-05-27 → 2026-05-28: event_long
+# LONG WR 96.1% → 22% after 3605 resolutions landed on one day). Acts as a
+# "do not promote on this sample yet" flag — see feedback_shadow_lumpy_resolutions.
 shadow_summary_by_direction=$(query_json "
+  WITH resolved_rows AS (
+    SELECT market_type, direction, theoretical_pnl, DATE(resolved_at) AS resolved_day
+    FROM shadow_trades
+    WHERE time >= NOW() - INTERVAL '30 days' AND resolved_at IS NOT NULL
+  ),
+  per_day AS (
+    SELECT market_type, direction, resolved_day, COUNT(*) AS n
+    FROM resolved_rows GROUP BY market_type, direction, resolved_day
+  ),
+  dominant AS (
+    SELECT market_type, direction,
+           MAX(n) AS top_n,
+           SUM(n) AS total_n,
+           (ARRAY_AGG(resolved_day ORDER BY n DESC))[1] AS top_day
+    FROM per_day GROUP BY market_type, direction
+  )
   SELECT COALESCE(json_agg(row_to_json(t)), '[]') FROM (
-    SELECT market_type,
-           direction,
+    SELECT s.market_type,
+           s.direction,
            COUNT(*) AS total,
-           COUNT(*) FILTER (WHERE resolved_at IS NOT NULL) AS resolved,
-           ROUND(AVG(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)::numeric, 4) AS avg_pnl,
+           COUNT(*) FILTER (WHERE s.resolved_at IS NOT NULL) AS resolved,
+           ROUND(AVG(s.theoretical_pnl) FILTER (WHERE s.resolved_at IS NOT NULL)::numeric, 4) AS avg_pnl,
            ROUND(
-             (COUNT(*) FILTER (WHERE resolved_at IS NOT NULL AND theoretical_pnl > 0)::numeric
-               / NULLIF(COUNT(*) FILTER (WHERE resolved_at IS NOT NULL), 0))::numeric,
+             (COUNT(*) FILTER (WHERE s.resolved_at IS NOT NULL AND s.theoretical_pnl > 0)::numeric
+               / NULLIF(COUNT(*) FILTER (WHERE s.resolved_at IS NOT NULL), 0))::numeric,
              3
            ) AS win_rate,
-           ROUND(STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)::numeric, 4) AS pnl_stddev,
+           ROUND(STDDEV(s.theoretical_pnl) FILTER (WHERE s.resolved_at IS NOT NULL)::numeric, 4) AS pnl_stddev,
            ROUND(
-             CASE WHEN STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL) > 0
-               THEN AVG(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)
-                    / STDDEV(theoretical_pnl) FILTER (WHERE resolved_at IS NOT NULL)
+             CASE WHEN STDDEV(s.theoretical_pnl) FILTER (WHERE s.resolved_at IS NOT NULL) > 0
+               THEN AVG(s.theoretical_pnl) FILTER (WHERE s.resolved_at IS NOT NULL)
+                    / STDDEV(s.theoretical_pnl) FILTER (WHERE s.resolved_at IS NOT NULL)
                ELSE 0 END::numeric,
              3
-           ) AS sharpe
-    FROM shadow_trades
-    WHERE time >= NOW() - INTERVAL '30 days'
-    GROUP BY market_type, direction
-    ORDER BY market_type, direction
+           ) AS sharpe,
+           d.top_day AS dominant_resolved_date,
+           ROUND(
+             CASE WHEN d.total_n > 0 THEN d.top_n::numeric / d.total_n ELSE 0 END,
+             3
+           ) AS dominant_date_pct
+    FROM shadow_trades s
+    LEFT JOIN dominant d ON d.market_type = s.market_type AND d.direction = s.direction
+    WHERE s.time >= NOW() - INTERVAL '30 days'
+    GROUP BY s.market_type, s.direction, d.top_day, d.top_n, d.total_n
+    ORDER BY s.market_type, s.direction
   ) t;
 ")
 


### PR DESCRIPTION
## Summary

Three prompt additions + one JSON enhancement extracted from session 2026-05-28 (the PR #275 → PR #277 sequence). All defensive — they don't change trading behavior, they make the auto-review more likely to catch the next variant of patterns we already paid for.

## Changes

### `scripts/daily-review-prompt.md`

**Role 1c-bis — SHORT realized_pnl forensic recipe.** The standard inversion query (`entry + exit ≈ 1.0`) is LONG-asymmetric. For SHORT positions the test never fires because `avg_entry_price` / `current_price` are stored in the held-token (NO) frame. Adds the 3-step recipe (`token_id = clob_token_id_yes` check → `paper_trades` fills → formula recompute) so future reviews don't spin up phantom-PnL investigations on real SHORT losses. Today's Belgium/Mexico/Colombia World Cup forensic walked this path and confirmed no bug.

**Role 3c-bis — Bilateral block check.** PR #275 (2026-05-27) blocked `event_short:long` for directional inversion but explicitly left `event_short:short` enabled under the framing *"direction correct (mean +7.44% favorable 4h move), losing to costs"*. 24h later PR #277 had to block the SHORT side after live n=19, 0/19 wins. Adds the rule: when the 3c alarm fires on one direction of a (type, X) cell, also evaluate the other direction. If both sides have live n≥5/10 with WR<20% and total_pnl<0, surface BOTH for blocking. Cost-domination produces wide PnL distributions; **uniform-sign losses across a cohort are a directional signature, not a cost signature**. Defending a side under "costs only" requires n≥30 + PnL distribution histogram.

**Role 3c-ter — Shadow temporal-lumpiness sanity check.** Event markets share resolution dates (World Cup brackets, monthly expiries…). On 2026-05-27 the auto-review reported `event_long LONG shadow WR = 96.1% (n=791)`; on 2026-05-28 the same SQL returned `22% (n=5494)` after a 3605-trade single-day resolution wave. The 96.1% was real-but-transient on n=791 — one batch flipped it. Adds the per-cohort `GROUP BY DATE(resolved_at)` query and instructs the reviewer to flag shadow WR in the issue with `(lumpy: <dominant date> = Y% of n_resolved)` when dominant_date_pct > 20%.

### `scripts/daily-review.sh`

Extends `shadow_summary_by_direction` with two new fields:
- `dominant_resolved_date` (DATE) — the single resolution date contributing the most rows.
- `dominant_date_pct` (numeric, 0-1) — that date's share of `resolved`.

This surfaces the temporal-lumpiness signal directly in the JSON the auto-review consumes, so it doesn't depend on the prompt remembering to run a probe query.

## Validation

SQL tested on the production VM (run on `shadow_trades` with the same 30d window the script uses):

```
market_type      direction  resolved  win_rate  dominant_date  dominant_pct
event_long       long       3813      0.188     2026-05-28     0.808  ← lumpy
event_long       short      1376      0.193     2026-05-13     0.580  ← lumpy
crypto_daily/event_short/...  0       —         —              0.000
```

The flagged `event_long LONG dominant_date_pct = 0.808` is exactly the artifact that made #274's `96.1% WR (n=791)` claim collapse to 22% in 24h. With this field in the JSON the next reviewer treats `WR=22%` as a single-snapshot observation, not stable signal.

## Test plan

- [ ] CI passes (compose / SQL syntax only; no code paths touched).
- [ ] Daily review #278 (2026-05-29) renders `dominant_date_pct` in the shadow section.
- [ ] Next time the 3c alarm fires, verify the issue narrative addresses BOTH sides per Role 3c-bis.

## Cross-references

- `feedback_counterwr_costs_misread.md` — the rule extracted from PR #275 → PR #277.
- `feedback_shadow_lumpy_resolutions.md` — the temporal-lumpiness rule.
- `project_short_pnl_convention.md` — the SHORT realized_pnl forensic recipe in detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
