### PR TITLE
feat(weights): per-direction seed for crypto_daily + event_long (closes Gap B)

### DIFF
--- a/data/cost-aware-tstat-2026-05-28.json
+++ b/data/cost-aware-tstat-2026-05-28.json
@@ -1,0 +1,430 @@
+{
+  "_meta": {
+    "generated_at": "2026-05-28",
+    "source": "scripts/export-tstat-from-edge.js — latest measurement per cell from generator_edge",
+    "lookback_hours": 48,
+    "windows_horizons_observed": [
+      "7d/4h"
+    ],
+    "rt_cost_assumption_pct": 1,
+    "rt_cost_source": "generator_edge.rt_cost_pct (per-row); aggregated to per-type means in companion rt-cost JSON. Pass --rt-cost <file> to the seed script for per-type cost.",
+    "types": [
+      "crypto_daily",
+      "event_financial",
+      "event_long",
+      "event_short"
+    ],
+    "cell_count": 51,
+    "note": "For cells where gross_pct == 0 (static-midpoint markets, e.g. event_short at long horizons), the seed script writes no per-direction row (zero information). The combiner falls back to __all__."
+  },
+  "cells": [
+    {
+      "signal_id": "cross_market_corr",
+      "market_type": "crypto_daily",
+      "direction": "long",
+      "n": 380,
+      "gross_pct": 0.002631578947368421,
+      "t_gross": 0.534019498408261
+    },
+    {
+      "signal_id": "cross_market_corr",
+      "market_type": "crypto_daily",
+      "direction": "short",
+      "n": 406,
+      "gross_pct": -0.04310344827586207,
+      "t_gross": -3.3033680062562674
+    },
+    {
+      "signal_id": "cross_market_corr",
+      "market_type": "event_financial",
+      "direction": "long",
+      "n": 701,
+      "gross_pct": -0.42368045649072755,
+      "t_gross": -3.810024088942486
+    },
+    {
+      "signal_id": "cross_market_corr",
+      "market_type": "event_financial",
+      "direction": "short",
+      "n": 795,
+      "gross_pct": 0.2350314465408805,
+      "t_gross": 2.3752000210983657
+    },
+    {
+      "signal_id": "cross_market_corr",
+      "market_type": "event_long",
+      "direction": "long",
+      "n": 209,
+      "gross_pct": -0.03588516746411483,
+      "t_gross": -0.45110102385673523
+    },
+    {
+      "signal_id": "cross_market_corr",
+      "market_type": "event_long",
+      "direction": "short",
+      "n": 213,
+      "gross_pct": 0.2868544600938967,
+      "t_gross": 1.5355801343501256
+    },
+    {
+      "signal_id": "cross_market_corr",
+      "market_type": "event_short",
+      "direction": "long",
+      "n": 76,
+      "gross_pct": -0.006578947368421052,
+      "t_gross": -1.0000000000000002
+    },
+    {
+      "signal_id": "favorite_longshot_bias",
+      "market_type": "crypto_daily",
+      "direction": "short",
+      "n": 1221,
+      "gross_pct": 0.01506961506961507,
+      "t_gross": 3.615221881936927
+    },
+    {
+      "signal_id": "favorite_longshot_bias",
+      "market_type": "event_financial",
+      "direction": "long",
+      "n": 75,
+      "gross_pct": 0,
+      "t_gross": 0
+    },
+    {
+      "signal_id": "favorite_longshot_bias",
+      "market_type": "event_financial",
+      "direction": "short",
+      "n": 386,
+      "gross_pct": 0.09235751295336787,
+      "t_gross": 3.1200207094547676
+    },
+    {
+      "signal_id": "mean_reversion",
+      "market_type": "crypto_daily",
+      "direction": "long",
+      "n": 858,
+      "gross_pct": 0.01520979020979021,
+      "t_gross": 0.5611933890599082
+    },
+    {
+      "signal_id": "mean_reversion",
+      "market_type": "crypto_daily",
+      "direction": "short",
+      "n": 181,
+      "gross_pct": -0.5220994475138122,
+      "t_gross": -3.3809828674112947
+    },
+    {
+      "signal_id": "mean_reversion",
+      "market_type": "event_financial",
+      "direction": "long",
+      "n": 666,
+      "gross_pct": -0.5453453453453454,
+      "t_gross": -6.005856365141477
+    },
+    {
+      "signal_id": "mean_reversion",
+      "market_type": "event_financial",
+      "direction": "short",
+      "n": 397,
+      "gross_pct": -0.18110831234256927,
+      "t_gross": -1.2229793419228967
+    },
+    {
+      "signal_id": "mean_reversion",
+      "market_type": "event_long",
+      "direction": "long",
+      "n": 518,
+      "gross_pct": -0.03986486486486487,
+      "t_gross": -0.4793251469340649
+    },
+    {
+      "signal_id": "mean_reversion",
+      "market_type": "event_long",
+      "direction": "short",
+      "n": 363,
+      "gross_pct": 0.05509641873278237,
+      "t_gross": 0.3746165764263193
+    },
+    {
+      "signal_id": "mean_reversion",
+      "market_type": "event_short",
+      "direction": "long",
+      "n": 931,
+      "gross_pct": -0.05692803437164339,
+      "t_gross": -2.6322322539389713
+    },
+    {
+      "signal_id": "mean_reversion",
+      "market_type": "event_short",
+      "direction": "short",
+      "n": 695,
+      "gross_pct": -0.025179856115107913,
+      "t_gross": -0.6582360702321214
+    },
+    {
+      "signal_id": "mlofi",
+      "market_type": "crypto_daily",
+      "direction": "long",
+      "n": 858,
+      "gross_pct": -0.11538461538461539,
+      "t_gross": -3.27873077506613
+    },
+    {
+      "signal_id": "mlofi",
+      "market_type": "crypto_daily",
+      "direction": "short",
+      "n": 1353,
+      "gross_pct": -0.11056910569105691,
+      "t_gross": -5.272268600294613
+    },
+    {
+      "signal_id": "mlofi",
+      "market_type": "event_financial",
+      "direction": "long",
+      "n": 1115,
+      "gross_pct": -0.4732286995515695,
+      "t_gross": -6.249243618966554
+    },
+    {
+      "signal_id": "mlofi",
+      "market_type": "event_financial",
+      "direction": "short",
+      "n": 1000,
+      "gross_pct": -0.043,
+      "t_gross": -0.5369947892927756
+    },
+    {
+      "signal_id": "mlofi",
+      "market_type": "event_long",
+      "direction": "long",
+      "n": 905,
+      "gross_pct": -0.27497237569060773,
+      "t_gross": -4.213943315431977
+    },
+    {
+      "signal_id": "mlofi",
+      "market_type": "event_long",
+      "direction": "short",
+      "n": 1038,
+      "gross_pct": -0.16965317919075146,
+      "t_gross": -3.0702755473642585
+    },
+    {
+      "signal_id": "mlofi",
+      "market_type": "event_short",
+      "direction": "long",
+      "n": 1327,
+      "gross_pct": -0.03240391861341371,
+      "t_gross": -2.4233760964530124
+    },
+    {
+      "signal_id": "mlofi",
+      "market_type": "event_short",
+      "direction": "short",
+      "n": 396,
+      "gross_pct": -0.09974747474747475,
+      "t_gross": -3.3304565893625417
+    },
+    {
+      "signal_id": "momentum",
+      "market_type": "crypto_daily",
+      "direction": "long",
+      "n": 2277,
+      "gross_pct": 0.031796223100570925,
+      "t_gross": 1.9707114849944198
+    },
+    {
+      "signal_id": "momentum",
+      "market_type": "crypto_daily",
+      "direction": "short",
+      "n": 170,
+      "gross_pct": 0.09676470588235295,
+      "t_gross": 1.0492475936109877
+    },
+    {
+      "signal_id": "momentum",
+      "market_type": "event_financial",
+      "direction": "long",
+      "n": 1607,
+      "gross_pct": -0.23257622899813316,
+      "t_gross": -4.2985471620486155
+    },
+    {
+      "signal_id": "momentum",
+      "market_type": "event_financial",
+      "direction": "short",
+      "n": 579,
+      "gross_pct": 0.6642487046632124,
+      "t_gross": 4.282280968579027
+    },
+    {
+      "signal_id": "momentum",
+      "market_type": "event_long",
+      "direction": "long",
+      "n": 2663,
+      "gross_pct": -0.012279384153210665,
+      "t_gross": -0.40473956009820977
+    },
+    {
+      "signal_id": "momentum",
+      "market_type": "event_long",
+      "direction": "short",
+      "n": 352,
+      "gross_pct": 0.17017045454545454,
+      "t_gross": 1.2948692140962474
+    },
+    {
+      "signal_id": "momentum",
+      "market_type": "event_short",
+      "direction": "long",
+      "n": 1769,
+      "gross_pct": 0.004804974561899378,
+      "t_gross": 0.4600296249631078
+    },
+    {
+      "signal_id": "momentum",
+      "market_type": "event_short",
+      "direction": "short",
+      "n": 159,
+      "gross_pct": 0.059748427672955975,
+      "t_gross": 0.9021889269251927
+    },
+    {
+      "signal_id": "news_sentiment",
+      "market_type": "event_financial",
+      "direction": "long",
+      "n": 88,
+      "gross_pct": 0.004545454545454545,
+      "t_gross": 0.018379482356362296
+    },
+    {
+      "signal_id": "news_sentiment",
+      "market_type": "event_long",
+      "direction": "long",
+      "n": 116,
+      "gross_pct": -0.009482758620689655,
+      "t_gross": -0.5065727509959814
+    },
+    {
+      "signal_id": "news_sentiment",
+      "market_type": "event_long",
+      "direction": "short",
+      "n": 87,
+      "gross_pct": 0.11666666666666667,
+      "t_gross": 0.6760369529023484
+    },
+    {
+      "signal_id": "ofi",
+      "market_type": "crypto_daily",
+      "direction": "long",
+      "n": 1382,
+      "gross_pct": 0.059117221418234445,
+      "t_gross": 2.285191749813542
+    },
+    {
+      "signal_id": "ofi",
+      "market_type": "crypto_daily",
+      "direction": "short",
+      "n": 476,
+      "gross_pct": 0.09170168067226891,
+      "t_gross": 2.8532068019879997
+    },
+    {
+      "signal_id": "ofi",
+      "market_type": "event_financial",
+      "direction": "long",
+      "n": 1724,
+      "gross_pct": -0.20414733178654293,
+      "t_gross": -3.1399829215488757
+    },
+    {
+      "signal_id": "ofi",
+      "market_type": "event_financial",
+      "direction": "short",
+      "n": 397,
+      "gross_pct": 0.24848866498740554,
+      "t_gross": 2.2563006099896588
+    },
+    {
+      "signal_id": "ofi",
+      "market_type": "event_long",
+      "direction": "long",
+      "n": 2439,
+      "gross_pct": -0.017179171791717917,
+      "t_gross": -0.5221630697491859
+    },
+    {
+      "signal_id": "ofi",
+      "market_type": "event_long",
+      "direction": "short",
+      "n": 383,
+      "gross_pct": -0.264621409921671,
+      "t_gross": -2.1516805336029132
+    },
+    {
+      "signal_id": "ofi",
+      "market_type": "event_short",
+      "direction": "long",
+      "n": 1891,
+      "gross_pct": 0.002908514013749339,
+      "t_gross": 0.2600042335023213
+    },
+    {
+      "signal_id": "ofi",
+      "market_type": "event_short",
+      "direction": "short",
+      "n": 114,
+      "gross_pct": -0.039473684210526314,
+      "t_gross": -0.6907180884535792
+    },
+    {
+      "signal_id": "resolution_prior",
+      "market_type": "event_long",
+      "direction": "long",
+      "n": 177,
+      "gross_pct": -0.01694915254237288,
+      "t_gross": -1.7419766814227706
+    },
+    {
+      "signal_id": "resolution_prior",
+      "market_type": "event_long",
+      "direction": "short",
+      "n": 227,
+      "gross_pct": 0.12136563876651982,
+      "t_gross": 1.269892348987391
+    },
+    {
+      "signal_id": "spread_compression",
+      "market_type": "event_financial",
+      "direction": "long",
+      "n": 73,
+      "gross_pct": 0.11506849315068493,
+      "t_gross": 0.18400706994336147
+    },
+    {
+      "signal_id": "spread_compression",
+      "market_type": "event_financial",
+      "direction": "short",
+      "n": 82,
+      "gross_pct": 0.4225609756097561,
+      "t_gross": 0.6350218508856168
+    },
+    {
+      "signal_id": "spread_compression",
+      "market_type": "event_long",
+      "direction": "long",
+      "n": 81,
+      "gross_pct": 0.18024691358024691,
+      "t_gross": 1.5185313707943826
+    },
+    {
+      "signal_id": "spread_compression",
+      "market_type": "event_short",
+      "direction": "long",
+      "n": 73,
+      "gross_pct": 0.2602739726027397,
+      "t_gross": 8.006162854315109
+    }
+  ]
+}

--- a/data/rt-cost-2026-05-28.json
+++ b/data/rt-cost-2026-05-28.json
@@ -1,0 +1,6 @@
+{
+  "crypto_daily": 0.01,
+  "event_financial": 0.01,
+  "event_long": 0.01,
+  "event_short": 0.01
+}

--- a/scripts/export-tstat-from-edge.js
+++ b/scripts/export-tstat-from-edge.js
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * Export the latest per-(signal, market_type, direction) cost-aware t-stat
+ * measurement from `generator_edge` into the JSON shape that
+ * `scripts/seed-per-direction-weights.js` consumes.
+ *
+ * Use case: close `project_per_direction_weights_gap` Gap B
+ * (crypto_daily + event_long were never seeded because the original input
+ * file `data/cost-aware-tstat-2026-05-13.json` only covered crypto_intraday,
+ * event_financial, event_short). `EdgeCapacityRefresher` measures all types
+ * nightly into `generator_edge`, so the data already exists — this script
+ * just lifts it into the seed's input format. After 2026-05-13, this is the
+ * preferred way to refresh the seed (the original measurement queries via
+ * `tmp-tstat-focused.sql` were ad-hoc; this is the cron's measurement).
+ *
+ * Output mirrors `data/cost-aware-tstat-2026-05-13.json`:
+ *
+ *   { _meta: { ... }, cells: [ { signal_id, market_type, direction, n, gross_pct, t_gross } ] }
+ *
+ * Also writes a sibling `rt-cost-YYYY-MM-DD.json` so the seed can map per-type
+ * round-trip cost (the cron measures per-type RT cost into
+ * `generator_edge.rt_cost_pct`).
+ *
+ * Usage:
+ *   DATABASE_URL=postgres://... node scripts/export-tstat-from-edge.js \
+ *     --out data/cost-aware-tstat-2026-05-28.json \
+ *     [--rt-out data/rt-cost-2026-05-28.json] \
+ *     [--types crypto_daily,event_long] \
+ *     [--lookback-hours 48]
+ *
+ * Flags:
+ *   --out PATH            Output JSON path (required).
+ *   --rt-out PATH         Companion RT-cost JSON path. Default: alongside --out.
+ *   --types LIST          Comma-separated market_types. Default: all in table.
+ *   --lookback-hours N    Window for "latest measurement". Default 48.
+ *   --min-n N             Drop cells with n < N. Default 30.
+ *
+ * Exit:
+ *   0 — wrote both files.
+ *   1 — error.
+ */
+const { Pool } = require('pg');
+const fs = require('fs');
+const path = require('path');
+
+function parseArgs(argv) {
+  const args = {
+    out: null,
+    rtOut: null,
+    types: null,
+    lookbackHours: 48,
+    minN: 30,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === '--out') args.out = argv[++i];
+    else if (k === '--rt-out') args.rtOut = argv[++i];
+    else if (k === '--types') args.types = argv[++i].split(',').map((s) => s.trim()).filter(Boolean);
+    else if (k === '--lookback-hours') args.lookbackHours = parseInt(argv[++i], 10);
+    else if (k === '--min-n') args.minN = parseInt(argv[++i], 10);
+  }
+  if (!args.out) {
+    console.error('Error: --out <path> is required.');
+    process.exit(1);
+  }
+  if (!args.rtOut) {
+    const dir = path.dirname(args.out);
+    const base = path.basename(args.out).replace(/^cost-aware-tstat-/, 'rt-cost-');
+    args.rtOut = path.join(dir, base);
+  }
+  return args;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  try {
+    const params = [args.lookbackHours, args.minN];
+    let typeFilter = '';
+    if (args.types && args.types.length > 0) {
+      params.push(args.types);
+      typeFilter = ` AND market_type = ANY($${params.length}::text[])`;
+    }
+
+    // Take the LATEST measurement per cell within the lookback window —
+    // the cron writes a new row per cell each night, so duplicates are
+    // expected. DISTINCT ON + ORDER BY measured_at DESC keeps the freshest.
+    const cellsRes = await pool.query(
+      `SELECT DISTINCT ON (signal_id, market_type, direction)
+         signal_id, market_type, direction, n, gross_pct, t_gross, t_net,
+         rt_cost_pct, window_days, horizon_hours, measured_at, source
+       FROM generator_edge
+       WHERE measured_at > NOW() - ($1 || ' hours')::interval
+         AND n >= $2
+         ${typeFilter}
+       ORDER BY signal_id, market_type, direction, measured_at DESC`,
+      params
+    );
+
+    const cells = cellsRes.rows.map((r) => ({
+      signal_id: r.signal_id,
+      market_type: r.market_type,
+      direction: r.direction,
+      n: Number(r.n),
+      gross_pct: Number(r.gross_pct),
+      t_gross: Number(r.t_gross),
+    }));
+
+    // Per-type RT cost: each row carries its own rt_cost_pct (the cron measures
+    // it from paper_trades). Take the mean over the cells of each type so the
+    // file has one value per type — they're nearly identical within a type
+    // because the cron uses one rt cost per type per run.
+    const rtPerType = new Map();
+    for (const r of cellsRes.rows) {
+      const t = r.market_type;
+      const rt = Number(r.rt_cost_pct);
+      if (!rtPerType.has(t)) rtPerType.set(t, []);
+      rtPerType.get(t).push(rt);
+    }
+    const rtCostMap = {};
+    for (const [t, arr] of rtPerType) {
+      const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
+      // generator_edge.rt_cost_pct is a percentage point (e.g. 1.08 = 1.08%).
+      // The seed expects a fraction (e.g. 0.0108). Convert here.
+      rtCostMap[t] = Number((mean / 100).toFixed(6));
+    }
+
+    if (cells.length === 0) {
+      console.error(
+        `No cells matched. Lookback ${args.lookbackHours}h, min-n ${args.minN}` +
+          (args.types ? `, types ${args.types.join(',')}` : '') +
+          '. Check EdgeCapacityRefresher freshness.'
+      );
+      process.exit(1);
+    }
+
+    // Distinct windows/horizons used → for the _meta. Picking the most
+    // common values to record; if the cron uses heterogeneous params for
+    // different types this will alert (different rows in cells).
+    const winSet = new Set(cellsRes.rows.map((r) => `${r.window_days}d/${r.horizon_hours}h`));
+    const fallbackRtPct = rtPerType.size > 0
+      ? (Array.from(rtPerType.values()).flat().reduce((a, b) => a + b, 0)
+         / Array.from(rtPerType.values()).flat().length)
+      : null;
+
+    const output = {
+      _meta: {
+        generated_at: new Date().toISOString().slice(0, 10),
+        source: 'scripts/export-tstat-from-edge.js — latest measurement per cell from generator_edge',
+        lookback_hours: args.lookbackHours,
+        windows_horizons_observed: Array.from(winSet),
+        rt_cost_assumption_pct: fallbackRtPct != null ? Number(fallbackRtPct.toFixed(4)) : null,
+        rt_cost_source:
+          'generator_edge.rt_cost_pct (per-row); aggregated to per-type means in companion rt-cost JSON. ' +
+          'Pass --rt-cost <file> to the seed script for per-type cost.',
+        types: Array.from(new Set(cellsRes.rows.map((r) => r.market_type))),
+        cell_count: cells.length,
+        note:
+          'For cells where gross_pct == 0 (static-midpoint markets, e.g. event_short at long horizons), ' +
+          'the seed script writes no per-direction row (zero information). The combiner falls back to __all__.',
+      },
+      cells,
+    };
+
+    fs.writeFileSync(args.out, JSON.stringify(output, null, 2) + '\n');
+    fs.writeFileSync(args.rtOut, JSON.stringify(rtCostMap, null, 2) + '\n');
+
+    console.log(`Wrote ${cells.length} cells across ${output._meta.types.length} types to ${args.out}`);
+    console.log(`Wrote ${Object.keys(rtCostMap).length} per-type RT costs to ${args.rtOut}`);
+    console.log(
+      'Run: node scripts/seed-per-direction-weights.js ' +
+        `--tstat ${args.out} --rt-cost ${args.rtOut} --dry-run`
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('Error:', err.message);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

Closes Gap B of [`project_per_direction_weights_gap.md`](https://github.com/JaviMaligno/polymarket-trader/blob/main/.claude/projects/.../memory/project_per_direction_weights_gap.md): the per-direction `signal_weights` table had **zero rows** for `crypto_daily` and `event_long` because the original 2026-05-13 seed input file only covered crypto_intraday, event_financial, event_short. Without per-direction rows the combiner fell back to `__all__` for both types, so anti-edge cohorts (e.g. momentum/event_long/long `t_net = -33`, resolution_prior/event_long/long `t_net = -104`) sat at `__all__ × 1.0` with no degradation pathway.

The data has existed all along: `EdgeCapacityRefresher` writes nightly cost-aware measurements into `generator_edge` for every type. This PR lifts those into the seed's input format and runs the seed.

## What ships

| Path | Purpose |
|---|---|
| `scripts/export-tstat-from-edge.js` | Exporter — `DISTINCT ON (signal, type, dir)` over `generator_edge`, configurable lookback, writes the seed's two JSON inputs |
| `data/cost-aware-tstat-2026-05-28.json` | Snapshot of today's export — 51 cells across 4 types (crypto_intraday absent — 0 active markets, documented supply collapse) |
| `data/rt-cost-2026-05-28.json` | Per-type RT cost companion (uniform 1% today; refining is future work) |

## Applied — 19 per-direction rows

Seed run on the production VM (after dry-run review):

```
Seed plan (19 writes, 32 skipped):
signal                 | type            | dir   |    n | gross% | t_gross |   t_net | base  | scale | new_w
favorite_longshot_bias | crypto_daily    | short | 1221 |  0.015 |   +3.62 | -236.29 | 1.313 | 0.050 | 0.066
mean_reversion         | crypto_daily    | long  |  858 |  0.015 |   +0.56 |  -36.34 | 1.975 | 0.050 | 0.099
mean_reversion         | crypto_daily    | short |  181 | -0.522 |   -3.38 |   -9.86 | 1.975 | 0.507 | 1.002
mean_reversion         | event_financial | long  |  666 | -0.545 |   -6.01 |  -17.02 | 1.325 | 0.149 | 0.197
mean_reversion         | event_financial | short |  397 | -0.181 |   -1.22 |   -7.98 | 1.325 | 0.601 | 0.797
mean_reversion         | event_long      | long  |  518 | -0.040 |   -0.48 |  -12.50 | 0.722 | 0.375 | 0.271
mean_reversion         | event_long      | short |  363 |  0.055 |   +0.37 |   -6.42 | 0.722 | 0.679 | 0.490
mean_reversion         | event_short     | long  |  931 | -0.057 |   -2.63 |  -48.87 | 0.897 | 0.050 | 0.045
mean_reversion         | event_short     | short |  695 | -0.025 |   -0.66 |  -26.80 | 0.897 | 0.050 | 0.045
momentum               | crypto_daily    | long  | 2277 |  0.032 |   +1.97 |  -60.01 | 1.034 | 0.050 | 0.052
momentum               | crypto_daily    | short |  170 |  0.097 |   +1.05 |   -9.79 | 1.034 | 0.510 | 0.528
momentum               | event_financial | long  | 1607 | -0.233 |   -4.30 |  -22.78 | 0.247 | 0.050 | 0.012
momentum               | event_financial | short |  579 |  0.664 |   +4.28 |   -2.17 | 0.247 | 0.892 | 0.220
momentum               | event_long      | long  | 2663 | -0.012 |   -0.40 |  -33.37 | 0.640 | 0.050 | 0.032
momentum               | event_long      | short |  352 |  0.170 |   +1.29 |   -6.31 | 0.640 | 0.684 | 0.438
momentum               | event_short     | long  | 1769 |  0.005 |   +0.46 |  -95.28 | 1.274 | 0.050 | 0.064
momentum               | event_short     | short |  159 |  0.060 |   +0.90 |  -14.20 | 1.274 | 0.290 | 0.370
resolution_prior       | event_long      | long  |  177 | -0.017 |   -1.74 | -104.52 | 0.693 | 0.050 | 0.035
resolution_prior       | event_long      | short |  227 |  0.121 |   +1.27 |   -9.19 | 0.693 | 0.540 | 0.375

Applied: 19 per-direction rows.
```

32 cells skipped — almost all are SIGNAL_TYPES_DISABLED (`cross_market_corr`, `mlofi`, `spread_compression`, etc.), or `__all__ is_enabled=false` for that (signal, type), where the seed correctly defers to the upstream gate.

## Why this is safe to ship now

- **Floor 0.05** in the scale (clip `[0.05, 2.0]`) — even `t_net = -200` only scales to 5 % of base, never 0. Preserves Optuna's ability to re-explore the cell.
- **No conflict with Optuna**: PR-C will eventually write per-direction rows from the optimizer, but today Optuna writes only `direction = '__all__'`. The `signal_weights` PK is `(signal_type, market_type, direction)`, so our per-direction rows and Optuna's `__all__` rows coexist.
- **Containment overlap is intentional**: `event_short:*` and `event_financial:*` are already in `EXECUTOR_BLOCKED_TYPE_DIRECTIONS`, so per-direction weights for those cells don't reach live trading — but writing them refreshes the seed for the day a block is lifted.
- **`crypto_daily:long`** balanced-price (above 0.30) is the only currently-live affected cohort; the new weight for `momentum/crypto_daily/long` (0.052, was 1.034) takes that cohort closer to the "trading near zero" target that matches its empirical cost-aware edge.
- **`event_long`** live volume is minimal (n = 7 since reset, last open 2026-05-12) — downweighting doesn't disrupt active trading.

## What this PR does NOT do (and why)

- **No PR-C (Optuna per-direction)**: still ~1-2 weeks of optimizer-side work; gap A (continuous refresh) stays open until that lands.
- **No continuous refresh of the seed**: this is a one-shot. Re-runs are now a 2-command operation (`export-tstat-from-edge.js` → `seed-per-direction-weights.js`), so refresh on demand is easy. Automating it on a cron is the next step but deliberately out of scope here.
- **No per-type RT-cost refinement**: `generator_edge.rt_cost_pct` is uniform 1 % across types. Real costs vary (event_long has higher spread + lower fees than crypto_daily). Separate measurement work.

## Test plan

- [x] Dry-run reviewed against VM data before apply.
- [x] Applied — DB now shows 11 `(crypto_daily, event_long) × direction != '__all__'` rows (+8 refreshed rows on event_financial / event_short).
- [ ] CI passes (no code paths touched in dashboard, scripts/data only).
- [ ] Daily review #278 — expect anti-edge cohorts (e.g. momentum/event_long/long, mean_reversion/crypto_daily/long) to fire fewer accepted signals.
- [ ] If a future cell's t_net flips positive, re-running `export-tstat-from-edge.js` + `seed-per-direction-weights.js` will rescale weights upward (scale > 1 for `t_net > 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
