### PR TITLE
fix(daily-review): deterministic supply-collapse alert for ALLOWED types

### DIFF
--- a/scripts/coverage-alerts.js
+++ b/scripts/coverage-alerts.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// coverage-alerts.js — deterministic coverage alerts for the daily watchdog.
+//
+// Background: Watchdog #280 (2026-05-29) silently missed that crypto_intraday
+// had 0 tracked markets despite being in ALLOWED_MARKET_TYPES. The rule
+// "tracked = 0 for an ALLOWED type → supply collapse" lived ONLY in the LLM
+// prompt (daily-review-prompt.md §1d), so it depended on the model noticing it
+// inside a wall of metrics — and in watchdog-mode the coverage table was
+// compressed away entirely. This module makes that check deterministic.
+//
+// Two failure modes it covers:
+//   1. The type appears in coverage_by_type with tracked=0.
+//   2. The type is ENTIRELY ABSENT from coverage_by_type — the gather query
+//      uses `GROUP BY market_type`, which emits no row for a type that has zero
+//      rows in `markets`, making the gap invisible to any row-iterating check.
+'use strict';
+
+// Mirrors the executor's ALLOWED_MARKET_TYPES (live-tradeable types). event_long
+// is intentionally excluded — it is shadow-only by policy, so tracked=0 there is
+// expected, not a collapse. Keep in sync with the executor config; the LLM
+// prompt §1d remains the backstop if this drifts.
+const DEFAULT_ALLOWED_MARKET_TYPES = ['crypto_intraday', 'crypto_daily', 'event_financial', 'event_short'];
+
+/**
+ * Return the ALLOWED market types whose tracked count is zero (or which are
+ * absent from the coverage rows entirely).
+ *
+ * @param {Array<{market_type:string, tracked?:number|string}>} coverageByType
+ * @param {string[]} allowedTypes
+ * @returns {Array<{market_type:string, tracked:number}>}
+ */
+function detectSupplyCollapse(coverageByType, allowedTypes) {
+  const allowed = Array.isArray(allowedTypes) && allowedTypes.length
+    ? allowedTypes
+    : DEFAULT_ALLOWED_MARKET_TYPES;
+  const rows = Array.isArray(coverageByType) ? coverageByType : [];
+  const byType = new Map(rows.map((r) => [r.market_type, r]));
+
+  const out = [];
+  for (const t of allowed) {
+    const row = byType.get(t);
+    const tracked = row ? Number(row.tracked) : 0;
+    // Absent row → treated as tracked=0. NaN (malformed) → treat as 0 so we
+    // err toward surfacing rather than hiding.
+    if (!row || !Number.isFinite(tracked) || tracked === 0) {
+      out.push({ market_type: t, tracked: Number.isFinite(tracked) ? tracked : 0 });
+    }
+  }
+  return out;
+}
+
+module.exports = { detectSupplyCollapse, DEFAULT_ALLOWED_MARKET_TYPES };

--- a/scripts/coverage-alerts.test.js
+++ b/scripts/coverage-alerts.test.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for detectSupplyCollapse — the deterministic "an ALLOWED market
+ * type has zero tracked markets" alert. Added 2026-05-29 after Watchdog #280
+ * silently missed crypto_intraday=0 (the supply-collapse rule lived only in the
+ * LLM prompt §1d, not in format-review.js's deterministic alert layer).
+ */
+const assert = require('node:assert/strict');
+const { detectSupplyCollapse, DEFAULT_ALLOWED_MARKET_TYPES } = require('./coverage-alerts.js');
+
+const ALLOWED = ['crypto_intraday', 'crypto_daily', 'event_financial', 'event_short'];
+
+const cases = [
+  {
+    name: 'allowed type present with tracked=0 → flagged',
+    fn: () => {
+      const coverage = [
+        { market_type: 'crypto_intraday', tracked: 0, priced_24h: 0, with_preds_24h: 0 },
+        { market_type: 'crypto_daily', tracked: 7, priced_24h: 7, with_preds_24h: 5 },
+        { market_type: 'event_financial', tracked: 14, priced_24h: 14, with_preds_24h: 5 },
+        { market_type: 'event_short', tracked: 22, priced_24h: 22, with_preds_24h: 64 },
+      ];
+      const got = detectSupplyCollapse(coverage, ALLOWED);
+      assert.equal(got.length, 1);
+      assert.equal(got[0].market_type, 'crypto_intraday');
+      assert.equal(got[0].tracked, 0);
+    },
+  },
+  {
+    name: 'allowed type entirely absent from coverage (GROUP BY dropped it) → flagged',
+    fn: () => {
+      // event_short has zero rows in the markets table → the GROUP BY query
+      // emits no row for it. It must still be flagged, not silently invisible.
+      const coverage = [
+        { market_type: 'crypto_daily', tracked: 7, priced_24h: 7, with_preds_24h: 5 },
+      ];
+      const got = detectSupplyCollapse(coverage, ALLOWED);
+      const types = got.map((r) => r.market_type).sort();
+      assert.deepEqual(types, ['crypto_intraday', 'event_financial', 'event_short']);
+      // absent types report tracked=0
+      assert.ok(got.every((r) => r.tracked === 0));
+    },
+  },
+  {
+    name: 'all allowed types tracked > 0 → no alert',
+    fn: () => {
+      const coverage = ALLOWED.map((market_type) => ({ market_type, tracked: 5, priced_24h: 5, with_preds_24h: 5 }));
+      const got = detectSupplyCollapse(coverage, ALLOWED);
+      assert.equal(got.length, 0);
+    },
+  },
+  {
+    name: 'shadow-only type (event_long) with tracked=0 is NOT flagged (not in ALLOWED)',
+    fn: () => {
+      const coverage = [
+        { market_type: 'event_long', tracked: 0, priced_24h: 0, with_preds_24h: 0 },
+        ...ALLOWED.map((market_type) => ({ market_type, tracked: 5, priced_24h: 5, with_preds_24h: 5 })),
+      ];
+      const got = detectSupplyCollapse(coverage, ALLOWED);
+      assert.equal(got.length, 0);
+    },
+  },
+  {
+    name: 'string-typed tracked (json numerics arrive as strings) handled',
+    fn: () => {
+      const coverage = [
+        { market_type: 'crypto_intraday', tracked: '0', priced_24h: '0', with_preds_24h: '0' },
+        { market_type: 'crypto_daily', tracked: '7' },
+        { market_type: 'event_financial', tracked: '14' },
+        { market_type: 'event_short', tracked: '22' },
+      ];
+      const got = detectSupplyCollapse(coverage, ALLOWED);
+      assert.equal(got.length, 1);
+      assert.equal(got[0].market_type, 'crypto_intraday');
+    },
+  },
+  {
+    name: 'defaults: empty/undefined coverage flags every allowed type',
+    fn: () => {
+      const got = detectSupplyCollapse([], DEFAULT_ALLOWED_MARKET_TYPES);
+      assert.equal(got.length, DEFAULT_ALLOWED_MARKET_TYPES.length);
+    },
+  },
+  {
+    name: 'undefined coverage arg does not throw',
+    fn: () => {
+      const got = detectSupplyCollapse(undefined, ALLOWED);
+      assert.equal(got.length, ALLOWED.length);
+    },
+  },
+];
+
+let failed = 0;
+for (const c of cases) {
+  try {
+    c.fn();
+    console.log(`  ✓ ${c.name}`);
+  } catch (err) {
+    failed += 1;
+    console.error(`  ✗ ${c.name}\n    ${err.message}`);
+  }
+}
+if (failed > 0) {
+  console.error(`\n${failed}/${cases.length} tests failed`);
+  process.exit(1);
+}
+console.log(`\n${cases.length}/${cases.length} tests passed`);

--- a/scripts/daily-review.sh
+++ b/scripts/daily-review.sh
@@ -527,6 +527,19 @@ if command -v docker &>/dev/null; then
   fi
 fi
 
+# 17b. ALLOWED_MARKET_TYPES from the running dashboard container — single source
+# of truth for the supply-collapse coverage check (#280/#281), so format-review.js
+# does not hardcode a list that can drift from the executor config. Falls back to
+# the known live-tradeable set if the container or env var is unavailable.
+allowed_market_types='["crypto_intraday","crypto_daily","event_financial","event_short"]'
+if command -v docker &>/dev/null; then
+  raw_allowed=$(docker exec polymarket-dashboard-api printenv ALLOWED_MARKET_TYPES 2>/dev/null | tr -d '\r' || echo "")
+  if [ -n "$raw_allowed" ]; then
+    parsed_allowed=$(echo "$raw_allowed" | jq -R 'split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length > 0))' 2>/dev/null || echo "")
+    [ -n "$parsed_allowed" ] && allowed_market_types="$parsed_allowed"
+  fi
+fi
+
 # 18. Resource usage (CPU%, MEM usage/limit per container)
 resource_usage="[]"
 if command -v docker &>/dev/null; then
@@ -813,6 +826,7 @@ jq -n \
   --argjson edge_cohorts_traded "$edge_cohorts_traded" \
   --argjson opens_today "$opens_today" \
   --argjson coverage_by_type "$coverage_by_type" \
+  --argjson allowed_market_types "$allowed_market_types" \
   --argjson edge_gap "$edge_gap" \
   --argjson edge_measurement_freshness "$edge_measurement_freshness" \
   --argjson review_history "$(cat "$HISTORY_FILE" 2>/dev/null | jq 'sort_by(.date) | .[-7:]' 2>/dev/null || echo "[]")" \
@@ -850,6 +864,7 @@ jq -n \
     edge_cohorts_traded: $edge_cohorts_traded,
     opens_today: $opens_today,
     coverage_by_type: $coverage_by_type,
+    allowed_market_types: $allowed_market_types,
     edge_gap: $edge_gap,
     edge_measurement_freshness: $edge_measurement_freshness,
     review_history: $review_history

--- a/scripts/format-review.js
+++ b/scripts/format-review.js
@@ -9,6 +9,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { detectSupplyCollapse } = require('./coverage-alerts.js');
 
 // ── Read input ──────────────────────────────────────────────────────────────
 
@@ -253,6 +254,22 @@ if (feedStarvedTypes.length > 0) {
   });
 }
 
+// 2026-05-29 #280: supply collapse. An ALLOWED (live-tradeable) market type
+// with 0 tracked markets — or entirely absent from coverage_by_type because the
+// gather query's GROUP BY drops empty groups — means the rotator/collector has
+// no supply for that type. The rule used to live only in the LLM prompt §1d;
+// Watchdog #280 silently skipped it for crypto_intraday. Deterministic now.
+// Warning (not critical): a type can be legitimately empty (e.g. crypto_intraday
+// = 5-min markets we can't trade) without being an outage — surfacing it daily
+// is the point; paging on it is not.
+const supplyCollapseTypes = detectSupplyCollapse(coverageByType);
+if (supplyCollapseTypes.length > 0) {
+  alerts.push({
+    level: 'warning',
+    message: `Supply collapse: ${supplyCollapseTypes.length} ALLOWED market_type(s) have 0 tracked markets: ${supplyCollapseTypes.map((r) => r.market_type).join(', ')}. Either the collector/rotator stopped feeding the type, or its catalog is genuinely empty — verify against the live Polymarket catalog before assuming an outage.`,
+  });
+}
+
 // 5+ consecutive losses. The metric is a cumulative DB counter, so when the
 // executor has been idle (tradingInactive) the "5 in a row" is historical and
 // not actionable — surface that context instead of paging on stale data.
@@ -447,7 +464,10 @@ function buildMarkdown() {
     // in exactly that case.
     edgeCohortsPositive.length > 0 ||
     edgeGap.length > 0 ||
-    edgeMeasurementFreshness.length > 0
+    edgeMeasurementFreshness.length > 0 ||
+    // 2026-05-29 #280: render the section when we have coverage data even with
+    // no trades — "type X has 0 supply" is exactly a no-trades-day finding.
+    coverageByType.length > 0
   ) {
     ln(`## Performance Breakdown`);
     ln();
@@ -474,6 +494,27 @@ function buildMarkdown() {
       ln(`|------|--------|----------|---------|--------|-------|`);
       for (const c of categoryPerformance) {
         ln(`| ${c.market_type || 'N/A'} | ${fmt(c.n_trades, 0)} | ${fmtPct(c.win_rate)} | ${fmtUsd(c.avg_pnl)} | ${fmt(c.sharpe_ratio, 3)} | ${fmt(c.prior, 3)} |`);
+      }
+      ln();
+    }
+
+    // 2026-05-29 #280: SignalEngine feed coverage, always rendered so the
+    // per-type tracked/priced/predicted breakdown is visible (not just surfaced
+    // as an alert when something is wrong). Watchdog #280 reported only an
+    // aggregate "MarketRotator: 72 active" line, which hid crypto_intraday=0.
+    if (coverageByType.length > 0) {
+      ln(`### Feed Coverage (by market_type)`);
+      ln();
+      ln(`| Type | Tracked | Priced 24h | Preds 24h | Active in DB |`);
+      ln(`|------|---------|------------|-----------|--------------|`);
+      for (const c of coverageByType) {
+        const collapsed = supplyCollapseTypes.some((s) => s.market_type === c.market_type);
+        const label = collapsed ? `${c.market_type} ⚠️` : c.market_type;
+        ln(`| ${label} | ${fmt(c.tracked, 0)} | ${fmt(c.priced_24h, 0)} | ${fmt(c.with_preds_24h, 0)} | ${fmt(c.active_in_db, 0)} |`);
+      }
+      if (supplyCollapseTypes.length > 0) {
+        ln();
+        ln(`> ⚠️ = ALLOWED type with 0 tracked markets (supply collapse — see Alerts).`);
       }
       ln();
     }

--- a/scripts/format-review.js
+++ b/scripts/format-review.js
@@ -185,6 +185,23 @@ const edgeMeasurementFreshness = Array.isArray(data.edge_measurement_freshness) 
 // current-day open distribution (distinct from rolling 7d edge_cohorts_traded).
 const opensToday = Array.isArray(data.opens_today) ? data.opens_today : [];
 const coverageByType = Array.isArray(data.coverage_by_type) ? data.coverage_by_type : [];
+// ALLOWED_MARKET_TYPES, sourced (in priority order) from the gather payload
+// (read from the running dashboard container by daily-review.sh — single source
+// of truth), then the CI env, then undefined (detectSupplyCollapse falls back to
+// its DEFAULT_ALLOWED_MARKET_TYPES). Avoids a hardcoded list drifting from the
+// executor config. #280/#281.
+const allowedMarketTypes = (() => {
+  if (Array.isArray(data.allowed_market_types) && data.allowed_market_types.length) {
+    return data.allowed_market_types;
+  }
+  const csv = typeof data.allowed_market_types === 'string'
+    ? data.allowed_market_types
+    : process.env.ALLOWED_MARKET_TYPES;
+  if (typeof csv === 'string' && csv.trim()) {
+    return csv.split(',').map((s) => s.trim()).filter(Boolean);
+  }
+  return undefined; // detectSupplyCollapse uses DEFAULT_ALLOWED_MARKET_TYPES
+})();
 const generatedAt = data.generated_at || new Date().toISOString();
 
 // ── Trading-state derived signals ───────────────────────────────────────────
@@ -262,7 +279,7 @@ if (feedStarvedTypes.length > 0) {
 // Warning (not critical): a type can be legitimately empty (e.g. crypto_intraday
 // = 5-min markets we can't trade) without being an outage — surfacing it daily
 // is the point; paging on it is not.
-const supplyCollapseTypes = detectSupplyCollapse(coverageByType);
+const supplyCollapseTypes = detectSupplyCollapse(coverageByType, allowedMarketTypes);
 if (supplyCollapseTypes.length > 0) {
   alerts.push({
     level: 'warning',
@@ -507,7 +524,18 @@ function buildMarkdown() {
       ln();
       ln(`| Type | Tracked | Priced 24h | Preds 24h | Active in DB |`);
       ln(`|------|---------|------------|-----------|--------------|`);
-      for (const c of coverageByType) {
+      // A collapsed type can be ENTIRELY ABSENT from coverageByType (the gather
+      // query's GROUP BY drops empty groups — the crypto_intraday case). Append
+      // synthetic zero-rows for those so the table shows what the alert reports,
+      // instead of re-hiding the very gap this table was added to expose. #281.
+      const presentTypes = new Set(coverageByType.map((c) => c.market_type));
+      const coverageRows = [...coverageByType];
+      for (const s of supplyCollapseTypes) {
+        if (!presentTypes.has(s.market_type)) {
+          coverageRows.push({ market_type: s.market_type, tracked: 0, priced_24h: 0, with_preds_24h: 0, active_in_db: 0 });
+        }
+      }
+      for (const c of coverageRows) {
         const collapsed = supplyCollapseTypes.some((s) => s.market_type === c.market_type);
         const label = collapsed ? `${c.market_type} ⚠️` : c.market_type;
         ln(`| ${label} | ${fmt(c.tracked, 0)} | ${fmt(c.priced_24h, 0)} | ${fmt(c.with_preds_24h, 0)} | ${fmt(c.active_in_db, 0)} |`);


### PR DESCRIPTION
## Why

Watchdog [#280](https://github.com/JaviMaligno/polymarket-trader/issues/280) (2026-05-29) silently missed that **`crypto_intraday` had 0 tracked markets** despite being in `ALLOWED_MARKET_TYPES`. The "tracked=0 for an ALLOWED type → supply collapse" rule lived **only** in the LLM prompt (`daily-review-prompt.md` §1d), so it depended on the model noticing it — and in watchdog-mode the coverage table was compressed away entirely (the issue reported only an aggregate `MarketRotator: 72 active` line that hid the gap).

## What

- **`scripts/coverage-alerts.js`** — pure, unit-tested `detectSupplyCollapse(coverageByType, allowedTypes)`. Flags ALLOWED types with `tracked=0`, **including types entirely absent** from `coverage_by_type` (the gather query's `GROUP BY market_type` drops empty groups, so a fully-absent type is invisible to any row-iterating check).
- **`format-review.js`** — deterministic `WARNING` alert (not `critical`: a type can be legitimately empty — e.g. `crypto_intraday` 5-minute markets we cannot trade — without being an outage). Plus an always-rendered **Feed Coverage (by market_type)** table marking collapsed types with ⚠️.
- **`scripts/coverage-alerts.test.js`** — 7 `node:assert` unit tests (same convention as the sibling script tests; `vitest run` only globs `packages/**/*.test.ts`, so these run manually like their siblings).

## Verification

```
$ node scripts/coverage-alerts.test.js
7/7 tests passed
```

End-to-end against a fixture with `crypto_intraday: tracked=0` produces:
> 🟡 **WARNING**: Supply collapse: 1 ALLOWED market_type(s) have 0 tracked markets: crypto_intraday. …

and renders `| crypto_intraday ⚠️ | 0 | 0 | 0 | 0 |` in the coverage table.

## Scope note

This makes the **detection** deterministic. It does **not** fix the underlying `crypto_intraday` ingestion gap (the collector stopped feeding intraday crypto ~2026-05-01; Polymarket still lists those 5-min markets). That gap is benign for now (the markets are structurally untradeable for our 60s-signal / 4h-hold / ~1% RT-cost pipeline and `crypto_intraday:long` is already blocked) and is tracked separately. The alert will fire daily for `crypto_intraday` until the ingestion gap is resolved — intended, per operator sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Supply-collapse warning alerts trigger when market types have zero tracked markets; detection identifies missing and empty coverage.
  * Feed Coverage table now displays in reports with warning indicators for detected zero-coverage market types.
  * Performance Breakdown section renders even when no trades are present.

* **Tests**
  * Comprehensive test coverage for supply-collapse detection including edge cases and malformed data handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->