### PR TITLE
chore(config): reallocate freed crypto_intraday signal slots to live types

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -155,13 +155,15 @@ services:
       # Unset both vars to fall back to legacy volume-sorted single-query
       # behaviour (backward-compatible default).
       # Covers the live ALLOWED_MARKET_TYPES (crypto_daily + event_financial +
-      # event_short) plus an event_long share for FLB shadow measurement. The
-      # crypto_intraday entries below are vestigial: the type was dropped from
-      # ALLOWED_MARKET_TYPES (untradeable 5-min markets), so its 8 slots are
-      # never consumed. TODO: reallocate the freed crypto_intraday slots across
-      # the live types (a tuning decision — left for deliberate optimization).
-      SIGNAL_FETCH_BUDGET_PER_TYPE: "crypto_intraday:30,crypto_daily:30,event_financial:40,event_short:40,event_long:60"
-      SIGNAL_SLOTS_PER_TYPE: "crypto_intraday:8,crypto_daily:8,event_financial:12,event_short:12,event_long:10"
+      # event_short) plus an event_long share for FLB shadow measurement.
+      # crypto_intraday was dropped from ALLOWED_MARKET_TYPES (untradeable 5-min
+      # markets); its share was reallocated (2026-05-29) to event_financial and
+      # event_short — the two with abundant live supply, which benefit most from
+      # signal/measurement coverage now that resolution detection is fixed.
+      # crypto_daily kept flat (thin supply), event_long kept flat (shadow-only).
+      # Slot sum = 50 = MAX_SIGNAL_MARKETS; fetch-budget sum = 200 (both preserved).
+      SIGNAL_FETCH_BUDGET_PER_TYPE: "crypto_daily:30,event_financial:55,event_short:55,event_long:60"
+      SIGNAL_SLOTS_PER_TYPE: "crypto_daily:8,event_financial:16,event_short:16,event_long:10"
       # Force-tracked experiment cohort — same list as the data-collector.
       # MarketSelector pins these to the signal-selection pool so the
       # FLB tail-band markets + the TTR-≤7d RPv2 markets both receive


### PR DESCRIPTION
Follow-up to #282. crypto_intraday was dropped from ALLOWED_MARKET_TYPES, leaving 8/50 SIGNAL_SLOTS_PER_TYPE on a supply-less type. Reallocates +4 slots each to event_financial and event_short (abundant live supply, now measurable post-resolution-fix); crypto_daily and event_long unchanged. Slot sum stays 50 (=MAX_SIGNAL_MARKETS), fetch-budget sum stays 200 — same total work, redistributed off the dead type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)