### PR TITLE
fix(gamma): resolveOurMarkets SELECT pinned e2-micro DB — drop correlated EXISTS ordering

### DIFF
--- a/packages/data-collector/src/collectors/GammaCollector.ts
+++ b/packages/data-collector/src/collectors/GammaCollector.ts
@@ -525,11 +525,12 @@ export class GammaCollector {
         AND NOT COALESCE(m.is_resolved, false)
         AND (m.last_resolution_check IS NULL
              OR m.last_resolution_check < NOW() - ($1 || ' hours')::interval)
-      ORDER BY
-        (EXISTS (SELECT 1 FROM shadow_trades s WHERE s.market_id = m.id AND s.resolved_at IS NULL)) DESC,
-        (EXISTS (SELECT 1 FROM market_panel mp WHERE mp.market_id = m.id AND mp.resolved_at IS NULL)) DESC,
-        (m.market_type IN ('crypto_daily','event_financial','event_short')) DESC,
-        m.end_date DESC
+      -- Recency order only. The earlier consumer/tradeable-priority ORDER BY used
+      -- correlated EXISTS subqueries that ran per-row over the ~71k-row backlog and
+      -- pinned the e2-micro DB for 30+ min (verified in prod). Plain end_date DESC
+      -- is served by idx_markets_resolution_backlog (partial index) as a backward
+      -- index scan — instant. The backlog drains over cron cycles regardless of order.
+      ORDER BY m.end_date DESC
       LIMIT $2
       `,
       [String(RESOLUTION_RECHECK_HOURS), RESOLUTION_BUDGET_PER_RUN]


### PR DESCRIPTION
Hotfix to #282. The priority ORDER BY in resolveOurMarkets used two correlated EXISTS subqueries (shadow_trades, market_panel) evaluated per-row over the ~71k unresolved-ended backlog. On the 1GB e2-micro the first post-deploy run pinned the DB for 30+ min (confirmed via pg_stat_activity) and left the scheduler job stuck (isRunning=true, lastRun=null). Runaway query cancelled in prod.

Fix: plain `ORDER BY m.end_date DESC`, served by idx_markets_resolution_backlog as a backward index scan. Backlog drains over cron cycles regardless of order. 11/11 GammaCollector tests pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated market ordering logic to prioritize unresolved-ended markets by end date, replacing complex multi-criteria ordering for improved query efficiency and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->