### PR TITLE
fix(daily-review): distinguish signal generation from execution — kill #286 false CRITICAL

### DIFF
--- a/scripts/coverage-alerts.js
+++ b/scripts/coverage-alerts.js
@@ -49,4 +49,62 @@ function detectSupplyCollapse(coverageByType, allowedTypes) {
   return out;
 }
 
-module.exports = { detectSupplyCollapse, DEFAULT_ALLOWED_MARKET_TYPES };
+/**
+ * Distinguish a real signal-generation outage from a benign execution drought.
+ *
+ * The watchdog's "Signals (1h)" metric is sourced from `signal_predictions`,
+ * which is written ONLY inside open/close of a position (AutoSignalExecutor.ts)
+ * — i.e. AFTER every block gate and the combiner threshold. So when all cohorts
+ * are blocked, or no combined signal clears `minCombinedConfidence`, that count
+ * is 0 even though the generators are producing predictions normally. Watchdog
+ * #286 (2026-05-30) read "Signals (1h)=0" as "signal generation blocked" and
+ * escalated to CRITICAL — a false positive (generator_predictions was healthy
+ * at 76983/24h; every signal was simply below threshold or blocked).
+ *
+ * Generation liveness lives in `generator_predictions`, surfaced per-type as
+ * `with_preds_24h` in coverage_by_type. This classifier separates:
+ *   - generation dead + price feed alive → CRITICAL (real SignalEngine outage)
+ *   - generation alive + 0 executions/1h → INFO (execution drought; expected
+ *     when everything is blocked/below-threshold; NOT a generation failure)
+ *   - generation dead + price feed also dead → null (the "no prices" alert owns
+ *     it; avoid double-paging on a single upstream cause)
+ *   - generation alive + executions > 0 → null (normal operation)
+ *
+ * @param {{coverageByType?:Array<{with_preds_24h?:number|string}>, executions1h?:number|string, prices1h?:number|string}} [input]
+ * @returns {{level:'critical'|'info', kind:'generation_halted'|'execution_drought', message:string}|null}
+ */
+function classifySignalActivity(input) {
+  const { coverageByType, executions1h, prices1h } = input || {};
+  const rows = Array.isArray(coverageByType) ? coverageByType : [];
+  const generation24h = rows.reduce((sum, r) => {
+    const n = Number(r && r.with_preds_24h);
+    return sum + (Number.isFinite(n) ? n : 0);
+  }, 0);
+  const execNum = Number(executions1h);
+  const executions = Number.isFinite(execNum) ? execNum : 0;
+  const priceNum = Number(prices1h);
+  const pricesLive = Number.isFinite(priceNum) && priceNum > 0;
+
+  if (generation24h === 0) {
+    // No generation. Only a real outage if prices are still flowing; otherwise
+    // the price-feed alert is the root cause — stay silent to avoid double-alarm.
+    if (!pricesLive) return null;
+    return {
+      level: 'critical',
+      kind: 'generation_halted',
+      message:
+        'Signal generation halted: 0 generator predictions in 24h while the price feed is live. The SignalEngine is not producing predictions — a real outage, not a trading drought.',
+    };
+  }
+  if (executions === 0) {
+    return {
+      level: 'info',
+      kind: 'execution_drought',
+      message:
+        `Execution drought: ${generation24h} generator predictions in 24h but 0 signals executed in the last hour. Signals ARE being generated; they are all below the combiner threshold or blocked by gates. Expected steady state when cohorts are blocked — NOT a generation failure. Do not escalate on "Signals (1h)=0" alone.`,
+    };
+  }
+  return null;
+}
+
+module.exports = { detectSupplyCollapse, classifySignalActivity, DEFAULT_ALLOWED_MARKET_TYPES };

--- a/scripts/coverage-alerts.test.js
+++ b/scripts/coverage-alerts.test.js
@@ -6,7 +6,11 @@
  * LLM prompt §1d, not in format-review.js's deterministic alert layer).
  */
 const assert = require('node:assert/strict');
-const { detectSupplyCollapse, DEFAULT_ALLOWED_MARKET_TYPES } = require('./coverage-alerts.js');
+const {
+  detectSupplyCollapse,
+  classifySignalActivity,
+  DEFAULT_ALLOWED_MARKET_TYPES,
+} = require('./coverage-alerts.js');
 
 const ALLOWED = ['crypto_intraday', 'crypto_daily', 'event_financial', 'event_short'];
 
@@ -93,6 +97,87 @@ const cases = [
     fn: () => {
       assert.ok(!DEFAULT_ALLOWED_MARKET_TYPES.includes('crypto_intraday'));
       assert.deepEqual(DEFAULT_ALLOWED_MARKET_TYPES, ['crypto_daily', 'event_financial', 'event_short']);
+    },
+  },
+
+  // ── classifySignalActivity — generation outage vs execution drought ───────
+  // Watchdog #286 (2026-05-30) read "Signals (1h)=0" (sourced from
+  // signal_predictions, which is written only AFTER block gates, on actual
+  // open/close) as "signal generation blocked → CRITICAL". It was a false
+  // positive: generator_predictions was healthy (76983/24h); every signal was
+  // simply below the combiner threshold or blocked. This classifier makes the
+  // distinction deterministic so the watchdog cannot conflate the two again.
+  {
+    name: 'generation alive + 0 executions/1h → INFO execution_drought (the #286 case)',
+    fn: () => {
+      const got = classifySignalActivity({
+        coverageByType: [
+          { market_type: 'crypto_daily', with_preds_24h: 5 },
+          { market_type: 'event_short', with_preds_24h: 29 },
+        ],
+        executions1h: 0,
+        prices1h: 888,
+      });
+      assert.ok(got);
+      assert.equal(got.level, 'info');
+      assert.equal(got.kind, 'execution_drought');
+    },
+  },
+  {
+    name: 'generation dead + price feed alive → CRITICAL generation_halted',
+    fn: () => {
+      const got = classifySignalActivity({
+        coverageByType: [
+          { market_type: 'crypto_daily', with_preds_24h: 0 },
+          { market_type: 'event_short', with_preds_24h: 0 },
+        ],
+        executions1h: 0,
+        prices1h: 814,
+      });
+      assert.ok(got);
+      assert.equal(got.level, 'critical');
+      assert.equal(got.kind, 'generation_halted');
+    },
+  },
+  {
+    name: 'generation dead + price feed also dead → null (price alert owns it, no double-alarm)',
+    fn: () => {
+      const got = classifySignalActivity({
+        coverageByType: [{ market_type: 'crypto_daily', with_preds_24h: 0 }],
+        executions1h: 0,
+        prices1h: 0,
+      });
+      assert.equal(got, null);
+    },
+  },
+  {
+    name: 'generation alive + executions > 0 → null (normal operation)',
+    fn: () => {
+      const got = classifySignalActivity({
+        coverageByType: [{ market_type: 'crypto_daily', with_preds_24h: 5 }],
+        executions1h: 3,
+        prices1h: 888,
+      });
+      assert.equal(got, null);
+    },
+  },
+  {
+    name: 'string-typed json numerics handled',
+    fn: () => {
+      const got = classifySignalActivity({
+        coverageByType: [{ market_type: 'event_short', with_preds_24h: '29' }],
+        executions1h: '0',
+        prices1h: '888',
+      });
+      assert.ok(got);
+      assert.equal(got.kind, 'execution_drought');
+    },
+  },
+  {
+    name: 'undefined/empty input does not throw',
+    fn: () => {
+      assert.equal(classifySignalActivity(), null);
+      assert.equal(classifySignalActivity({}), null);
     },
   },
 ];

--- a/scripts/daily-review-prompt.md
+++ b/scripts/daily-review-prompt.md
@@ -88,6 +88,17 @@ persisted 2+ days, prefix it `[PERSISTENT - N days]` and escalate severity.
   generated? If 0 signals, run the tracked-market price-distribution query
   before classifying — connection-timeout log lines are symptoms, not a root
   cause.
+- **Generation vs execution (do NOT conflate — #286)**: `Signals executed (1h)`
+  comes from `signal_predictions`, which is written ONLY on an actual open/close,
+  *after* every block gate and the combiner threshold. So it reads **0 during a
+  block-induced drought even when the SignalEngine is perfectly healthy**.
+  Generation liveness is `Signals generated (24h)` (from `generator_predictions`,
+  also visible per-type as `with_preds_24h` in coverage). Rule:
+  `generated>0 & executed=0` → **execution drought, INFO, expected** (all cohorts
+  blocked / below threshold). `generated=0 & price feed live` → **CRITICAL real
+  outage**. Never escalate to CRITICAL on `Signals (1h)=0` alone — Watchdog #286
+  did exactly that and was a false positive. The deterministic
+  `classifySignalActivity` alert already encodes this; trust it over the raw count.
 - **MarketRotator alive**: 
   ```sql
   SELECT tracking_status, COUNT(*) FROM markets

--- a/scripts/format-review.js
+++ b/scripts/format-review.js
@@ -9,7 +9,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { detectSupplyCollapse } = require('./coverage-alerts.js');
+const { detectSupplyCollapse, classifySignalActivity } = require('./coverage-alerts.js');
 
 // ── Read input ──────────────────────────────────────────────────────────────
 
@@ -285,6 +285,22 @@ if (supplyCollapseTypes.length > 0) {
     level: 'warning',
     message: `Supply collapse: ${supplyCollapseTypes.length} ALLOWED market_type(s) have 0 tracked markets: ${supplyCollapseTypes.map((r) => r.market_type).join(', ')}. Either the collector/rotator stopped feeding the type, or its catalog is genuinely empty — verify against the live Polymarket catalog before assuming an outage.`,
   });
+}
+
+// 2026-05-30 #286: signal generation vs execution. "Signals (1h)" is sourced
+// from signal_predictions, written only AFTER block gates on actual open/close,
+// so it reads 0 during a block-induced drought even while generators are
+// healthy. Watchdog #286 mislabelled that as "signal generation blocked →
+// CRITICAL". Classify deterministically: a real generation outage (0 preds/24h
+// with a live price feed) is CRITICAL; an execution drought (preds flowing but
+// 0 executed) is INFO, not an outage.
+const signalActivity = classifySignalActivity({
+  coverageByType,
+  executions1h: signalFreshness ? signalFreshness.count_last_hour : null,
+  prices1h: priceFreshness ? priceFreshness.record_count_1h : null,
+});
+if (signalActivity) {
+  alerts.push({ level: signalActivity.level, message: signalActivity.message });
 }
 
 // 5+ consecutive losses. The metric is a cumulative DB counter, so when the
@@ -681,8 +697,16 @@ function buildMarkdown() {
   if (signalFreshness) {
     ln(`| Metric | Value |`);
     ln(`|--------|-------|`);
+    // "Signals executed (1h)" — from signal_predictions, written only on actual
+    // open/close (post-gate). 0 here during a block drought is expected, NOT a
+    // generation failure. Generation liveness is the next row (#286).
+    const generation24h = coverageByType.reduce((sum, r) => {
+      const n = Number(r && r.with_preds_24h);
+      return sum + (Number.isFinite(n) ? n : 0);
+    }, 0);
     ln(`| Latest Signal | ${fmtDate(signalFreshness.latest_signal)} |`);
-    ln(`| Signals (1h) | ${fmt(signalFreshness.count_last_hour, 0)} |`);
+    ln(`| Signals executed (1h) | ${fmt(signalFreshness.count_last_hour, 0)} |`);
+    ln(`| Signals generated (24h) | ${fmt(generation24h, 0)} |`);
   } else {
     ln(`*Signal freshness data unavailable.*`);
   }


### PR DESCRIPTION
Watchdog #286 (2026-05-30) escalated to CRITICAL on `Signals (1h)=0` claiming generation was blocked. False positive: generator_predictions healthy (76983/24h), dashboard-api healthy at 0.25% CPU. Root cause: `Signals (1h)` reads signal_predictions, INSERTed only on open/close (post-gate), so it reads 0 during a block-induced drought even when generation is fine — it measures executions, not generation.

Fix (deterministic, mirrors #281 pattern): `classifySignalActivity()` separates a real generation outage (0 preds/24h + live prices → CRITICAL) from a benign execution drought (preds flowing but 0 executed/1h → INFO). format-review.js renders 'Signals executed (1h)' and 'Signals generated (24h)' as distinct rows. Prompt §1a documents it and forbids escalating on Signals(1h)=0 alone. 6 new unit tests (14/14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent alert classification to distinguish signal generation halts from execution droughts, reducing false-positive alerts.
  * Enhanced signal metrics reporting with 24-hour generation data visibility.

* **Documentation**
  * Clarified guidelines for interpreting signal execution vs. generation metrics and their combinations.

* **Tests**
  * Added comprehensive unit tests for signal status classification logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JaviMaligno/polymarket-trader/pull/287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->