### PR TITLE
fix(edge-refresher): raise per-type timeout 300s→600s, env-overridable — unstall generator_edge

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -95,6 +95,13 @@ services:
       DB_POOL_MAX: "8"
       DB_IDLE_TIMEOUT_MS: "60000"
       DB_CONNECTION_TIMEOUT_MS: "30000"
+      # EdgeCapacityRefresher (nightly 02:30 UTC). Default per-type timeout raised
+      # 300s→600s after 2026-05-30: all 4 types timed out at 300s under DB
+      # contention (#284) → upserts:0 → generator_edge stale ~33h. The cost is
+      # dominated by ORDER BY random() over the window, not sampleSize, so raise
+      # the cap rather than shrink the sample. Override here without a code redeploy.
+      EDGE_REFRESH_PER_TYPE_TIMEOUT_MS: "600000"
+      EDGE_REFRESH_SAMPLE_SIZE: "10000"
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       LLM_DAILY_BUDGET_USD: "1.0"
       NEWS_MIN_ENTITY_LENGTH: "4"

--- a/packages/data-collector/src/services/EdgeCapacityRefresher.test.ts
+++ b/packages/data-collector/src/services/EdgeCapacityRefresher.test.ts
@@ -8,8 +8,37 @@ vi.mock('../database/connection.js', () => ({
   query: vi.fn(),
 }));
 
-import { computeEdgeCapacity, refreshEdgeCapacity, getLatestEdgePerCell } from './EdgeCapacityRefresher.js';
+import { computeEdgeCapacity, refreshEdgeCapacity, getLatestEdgePerCell, resolveEdgeRefreshConfig } from './EdgeCapacityRefresher.js';
 import { query } from '../database/connection.js';
+
+describe('resolveEdgeRefreshConfig (env-overridable; #284-driven timeout bump)', () => {
+  // 2026-05-30: all 4 types timed out at the old 300s per-type cap under DB
+  // contention (cf #284) → 0 upserts → generator_edge stale ~33h. The cost is
+  // dominated by ORDER BY random() over the window, not sampleSize, so the fix
+  // is a higher (env-overridable) timeout, not a smaller sample.
+  it('empty env → defaults (sample 10000, timeout raised to 600s)', () => {
+    const got = resolveEdgeRefreshConfig({});
+    expect(got).toEqual({ sampleSize: 10000, perTypeTimeoutMs: 600_000 });
+  });
+
+  it('valid env values are honored', () => {
+    const got = resolveEdgeRefreshConfig({
+      EDGE_REFRESH_SAMPLE_SIZE: '5000',
+      EDGE_REFRESH_PER_TYPE_TIMEOUT_MS: '900000',
+    });
+    expect(got).toEqual({ sampleSize: 5000, perTypeTimeoutMs: 900_000 });
+  });
+
+  it('invalid env values (non-numeric, zero, negative) fall back to defaults', () => {
+    expect(resolveEdgeRefreshConfig({ EDGE_REFRESH_SAMPLE_SIZE: 'abc' }).sampleSize).toBe(10000);
+    expect(resolveEdgeRefreshConfig({ EDGE_REFRESH_PER_TYPE_TIMEOUT_MS: '0' }).perTypeTimeoutMs).toBe(600_000);
+    expect(resolveEdgeRefreshConfig({ EDGE_REFRESH_SAMPLE_SIZE: '-5' }).sampleSize).toBe(10000);
+  });
+
+  it('fractional env values are floored', () => {
+    expect(resolveEdgeRefreshConfig({ EDGE_REFRESH_SAMPLE_SIZE: '7500.9' }).sampleSize).toBe(7500);
+  });
+});
 
 describe('computeEdgeCapacity (TS port)', () => {
   it('empty input → empty map', () => {

--- a/packages/data-collector/src/services/EdgeCapacityRefresher.ts
+++ b/packages/data-collector/src/services/EdgeCapacityRefresher.ts
@@ -306,6 +306,28 @@ export async function getLatestEdgePerCell(): Promise<Array<{
     .sort((a, b) => (b.t_net ?? -Infinity) - (a.t_net ?? -Infinity));
 }
 
+/**
+ * Resolve the env-overridable knobs for the nightly refresh. Pure (env in →
+ * config out) so it is unit-testable without process/timing mocks. Invalid
+ * values (non-numeric, ≤0) fall back to the calibrated defaults.
+ *
+ * - `EDGE_REFRESH_SAMPLE_SIZE` (default 10000) — predictions sampled per type.
+ * - `EDGE_REFRESH_PER_TYPE_TIMEOUT_MS` (default 600000) — per-type query cap;
+ *   raised from 300s after the 2026-05-30 stall (#284 DB contention).
+ */
+export function resolveEdgeRefreshConfig(
+  env: Record<string, string | undefined> = process.env,
+): { sampleSize: number; perTypeTimeoutMs: number } {
+  const posIntOr = (raw: string | undefined, def: number): number => {
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : def;
+  };
+  return {
+    sampleSize: posIntOr(env.EDGE_REFRESH_SAMPLE_SIZE, 10000),
+    perTypeTimeoutMs: posIntOr(env.EDGE_REFRESH_PER_TYPE_TIMEOUT_MS, 600_000),
+  };
+}
+
 export async function refreshEdgeCapacity(options: RefreshOptions = {}): Promise<{
   upserts: number;
   perType: Map<string, EdgeCapacityEntry>;
@@ -316,7 +338,13 @@ export async function refreshEdgeCapacity(options: RefreshOptions = {}): Promise
   const defaultRt = options.defaultRtCost ?? 0.01;
   const minN = options.minN ?? 50;
   const sampleSize = options.sampleSize ?? 10000;  // Pilar 1-A default
-  const perTypeTimeoutMs = options.perTypeTimeoutMs ?? 300_000;  // 5 min
+  // Default raised 300s → 600s on 2026-05-30: all 4 types timed out at 300s
+  // under DB contention (cf #284), yielding upserts:0 → generator_edge stale
+  // ~33h. The per-type cost is dominated by `ORDER BY random()` over the full
+  // window (calibration: N=1000 ≈ N=10000 ≈ 47s), so a higher cap — not a
+  // smaller sample — is the right lever; lowering sampleSize would only cut
+  // statistical power. See resolveEdgeRefreshConfig for the env overrides.
+  const perTypeTimeoutMs = options.perTypeTimeoutMs ?? 600_000;  // 10 min
   const source = options.source ??
     `EdgeCapacityRefresher cron ${new Date().toISOString().slice(0, 10)} (sample N=${sampleSize})`;
 

--- a/packages/data-collector/src/services/Scheduler.test.ts
+++ b/packages/data-collector/src/services/Scheduler.test.ts
@@ -9,6 +9,9 @@ vi.mock('../database/connection.js', () => ({
 // can be exercised without hitting the real SQL pipeline.
 vi.mock('./EdgeCapacityRefresher.js', () => ({
   refreshEdgeCapacity: vi.fn().mockResolvedValue({ upserts: 0, perType: new Map() }),
+  // Scheduler.refreshEdgeCapacity() resolves env-overridable knobs through this
+  // before invoking refreshEdgeCapacity (#284 timeout fix).
+  resolveEdgeRefreshConfig: vi.fn().mockReturnValue({ sampleSize: 10000, perTypeTimeoutMs: 600_000 }),
 }));
 
 // Mock GammaCollector module so syncResolvedMarkets tests don't hit network/DB.

--- a/packages/data-collector/src/services/Scheduler.ts
+++ b/packages/data-collector/src/services/Scheduler.ts
@@ -14,7 +14,7 @@ import {
   updateShadowCategoryPerformance,
   resolveShadowTrades,
 } from './MarketPerformanceTracker.js';
-import { refreshEdgeCapacity } from './EdgeCapacityRefresher.js';
+import { refreshEdgeCapacity, resolveEdgeRefreshConfig } from './EdgeCapacityRefresher.js';
 import { NewsCollector } from '../collectors/NewsCollector.js';
 
 const logger = pino({ name: 'scheduler' });
@@ -531,11 +531,17 @@ export class Scheduler {
    * later pass a measured per-type cost map from scripts/measure-rt-cost.js.
    */
   private async refreshEdgeCapacity(): Promise<void> {
+    // sampleSize / perTypeTimeoutMs are env-overridable (defaults 10000 / 600s).
+    // The 300s default timed out all types on 2026-05-30 under DB contention
+    // (#284) → 0 upserts → generator_edge stale. See resolveEdgeRefreshConfig.
+    const { sampleSize, perTypeTimeoutMs } = resolveEdgeRefreshConfig();
     await refreshEdgeCapacity({
       windowDays: 7,
       horizonHours: 4,
       defaultRtCost: 0.01,
       minN: 50,
+      sampleSize,
+      perTypeTimeoutMs,
     });
   }
 


### PR DESCRIPTION
## Problem

On 2026-05-30 both daily-review pipelines flagged `generator_edge` as stale ~33h and called it a missed cron cycle. It wasn't: `refresh-edge-capacity` ran on schedule (02:50 UTC, `lastError:null`), but **every per-type `measureCellsForType` hit the 300s timeout** (crypto_daily, event_financial, event_short, event_long) → `upserts:0, skipped:[all 4]` → `generator_edge` and `market_type_edge_capacity` frozen since 05-29.

## Root cause

The per-type query cost is dominated by `ORDER BY random() LIMIT N` over the full `windowDays` slice plus the per-row `price_history` seek. Calibration (`N=1000 ≈ N=10000 ≈ 47s`) shows the **fixed scan dominates, not `sampleSize`**. DB contention (cf #284) pushed the calibrated 47–100s past the 300s cap. So the correct lever is a **higher timeout, not a smaller sample** (shrinking the sample wouldn't help the fixed cost and would cut statistical power).

## Fix

- `perTypeTimeoutMs` default **300_000 → 600_000** in `refreshEdgeCapacity`.
- `resolveEdgeRefreshConfig(env)` — pure, env-overridable knobs (`EDGE_REFRESH_SAMPLE_SIZE`, `EDGE_REFRESH_PER_TYPE_TIMEOUT_MS`) with validation (non-numeric / ≤0 → default). `Scheduler` wires it.
- `docker-compose.gcp.yml` documents both vars (override without a code redeploy).
- 4 new unit tests; existing `sampleSize`-default + `runJob` regression tests stay green.

## Follow-up (not this PR)

Replace `ORDER BY random()` with a single-scan probabilistic sample to remove the fixed cost entirely, so 600s has real headroom. Filed as the structural fix if 600s proves insufficient under sustained contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)