### PR TITLE
fix(flb-monitor): run-unique /tmp paths to stop cross-run rm permission failure

### DIFF
--- a/.github/workflows/flb-monitor.yml
+++ b/.github/workflows/flb-monitor.yml
@@ -75,21 +75,31 @@ jobs:
             exit 1
           fi
 
-          # Use workflow-unique paths and rm -f defensively. The GH Actions
-          # SSH identity differs from the operator's interactive identity, so
-          # a /tmp/ file written by hand would block the scp with "Permission
-          # denied".
-          $SSH --command="rm -f /tmp/flb-monitor-cost.js /tmp/flb-monitor-cal.js" > /dev/null
+          # Use run-unique /tmp paths on the VM. The OS Login POSIX user is
+          # stable within a single run but differs across runs, and /tmp has
+          # the sticky bit — so a stale file left by a previous run is owned by
+          # a different user and `rm -f` fails with "Operation not permitted"
+          # (the -f flag suppresses missing-file errors, not permission ones),
+          # aborting the step under `bash -e`. A per-run suffix guarantees scp
+          # never collides with another run's leftovers; end-of-step cleanup of
+          # our own files is best-effort (`|| true`).
+          SUFFIX="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          REMOTE_COST="/tmp/flb-monitor-cost.${SUFFIX}.js"
+          REMOTE_CAL="/tmp/flb-monitor-cal.${SUFFIX}.js"
 
-          gcloud compute scp scripts/flb-cost-realism-check.js polymarket-vm:/tmp/flb-monitor-cost.js --zone=$ZONE
-          gcloud compute scp scripts/flb-calibration-monitor.js polymarket-vm:/tmp/flb-monitor-cal.js --zone=$ZONE
+          gcloud compute scp scripts/flb-cost-realism-check.js "polymarket-vm:${REMOTE_COST}" --zone=$ZONE
+          gcloud compute scp scripts/flb-calibration-monitor.js "polymarket-vm:${REMOTE_CAL}" --zone=$ZONE
 
-          $SSH --command="docker cp /tmp/flb-monitor-cost.js polymarket-dashboard-api:/app/flb-monitor-cost.js && docker cp /tmp/flb-monitor-cal.js polymarket-dashboard-api:/app/flb-monitor-cal.js" > /dev/null
+          $SSH --command="docker cp ${REMOTE_COST} polymarket-dashboard-api:/app/flb-monitor-cost.js && docker cp ${REMOTE_CAL} polymarket-dashboard-api:/app/flb-monitor-cal.js" > /dev/null
 
           # Capture outputs to files so we can both echo them and write the summary.
           $SSH --command="docker exec polymarket-dashboard-api node /app/flb-monitor-cost.js" | tee cost.txt
           echo
           $SSH --command="docker exec polymarket-dashboard-api node /app/flb-monitor-cal.js" | tee cal.txt
+
+          # Best-effort cleanup of this run's own /tmp files (removable — we own
+          # them). Never fatal: a cleanup failure must not fail the monitor.
+          $SSH --command="rm -f ${REMOTE_COST} ${REMOTE_CAL}" > /dev/null 2>&1 || true
 
           {
             echo "## FLB Early-Failure Monitor — $(date -u +%Y-%m-%d)"


### PR DESCRIPTION
## Root Cause

The **FLB Early-Failure Monitor** has failed **every scheduled run since 2026-05-24** (7 consecutive failures; last green run was a manual `workflow_dispatch` on 2026-05-23). The cost-realism (Lever 1) and calibration-monotonicity (Lever 2) falsification checks have therefore been **silently un-evaluated for ~8 days**.

The step opened with:
```bash
$SSH --command="rm -f /tmp/flb-monitor-cost.js /tmp/flb-monitor-cal.js"
```
`/tmp` carries the sticky bit, and the OS Login POSIX user differs across runs. A file scp'd by a previous run is owned by a different user, so this run's `rm` hits:
```
rm: cannot remove '/tmp/flb-monitor-cost.js': Operation not permitted
```
`rm -f` suppresses *missing-file* errors but not *permission* errors, so it exits non-zero and `bash -e` aborts the step before the monitors run. The original comment anticipated a stale-file collision but used `rm -f` as the defense, which doesn't cover the sticky-bit permission case.

## Fix

- scp to **run-unique remote paths** (`/tmp/flb-monitor-{cost,cal}.${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.js`) — no cross-run collision is possible, so no upfront `rm` is needed.
- Drop the failing blanket `rm`.
- End-of-step cleanup removes **this run's own** files (removable) and is **best-effort** (`|| true`, `2>&1`) so a cleanup hiccup can never fail the monitor.

## Verification

Workflow-only change (no VM runtime effect). Will trigger `workflow_dispatch` after merge and confirm the run goes green with both levers' output in the run summary.

Related to #291 (FLB Role 2 reported "HEALTHY" by checking the *FLB Shadow Snapshot* workflow, missing this monitor's red status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow reliability by implementing per-run file handling for monitoring scripts to prevent permission-related conflicts across multiple workflow executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->