### PR TITLE
perf(edge-refresher): index generator_predictions(market_type,direction,time) — true fix for event_short edge timeout (#294)

### DIFF
--- a/packages/data-collector/src/database/init/034_idx_generator_predictions_type_dir_time.sql
+++ b/packages/data-collector/src/database/init/034_idx_generator_predictions_type_dir_time.sql
@@ -1,0 +1,27 @@
+-- Index generator_predictions on (market_type, direction, time) for the
+-- nightly EdgeCapacityRefresher.
+--
+-- Root cause (2026-06-01, daily-review #294): `EdgeCapacityRefresher` measures
+-- one market_type at a time via `buildPerTypeSQL`. Each per-type query filters
+-- `WHERE market_type = $1 AND direction IN ('long','short') AND time >= NOW()-7d`
+-- twice — once in the COUNT(*) InitPlan that sizes the Bernoulli sample, and
+-- once in the `sampled` CTE scan. With only (time), (signal_id,time) and
+-- (market_id,time) indexes present, both fell back to a seq-scan of the FULL
+-- 7-day window across ALL market_types (~320MB on the e2-micro), filtering down
+-- to the target type. For `event_short` (the largest cohort, ~158k predictions
+-- /7d) this blew past the 600s per-type cap → generator_edge stale 82.9h, the
+-- edge sentinel blind. (The correlated price_history forward-seek is NOT the
+-- bottleneck: it is index-served via idx_ph_market_time, ~ms/row.)
+--
+-- PRs #288/#289/#290 mis-diagnosed this: #289 attributed cost to ORDER BY
+-- random() (already removed), #291 to the price_history join, #290 shipped a
+-- containment (drop event_long) that never touched event_short's own scan cost.
+--
+-- Measured effect of this index on the VM: event_short full-sample query
+-- 40.8s (was >600s timeout). >15x, ample margin under the 600s cap.
+--
+-- NOTE: init/*.sql only runs on a FRESH volume. On the live VM this index was
+-- created manually on 2026-06-01; this migration ensures fresh installs and
+-- future volume re-inits get it too. IF NOT EXISTS makes it idempotent.
+CREATE INDEX IF NOT EXISTS idx_gen_pred_type_dir_time
+    ON generator_predictions (market_type, direction, time DESC);

--- a/packages/data-collector/src/services/EdgeCapacityRefresher.ts
+++ b/packages/data-collector/src/services/EdgeCapacityRefresher.ts
@@ -351,12 +351,15 @@ export async function refreshEdgeCapacity(options: RefreshOptions = {}): Promise
   const defaultRt = options.defaultRtCost ?? 0.01;
   const minN = options.minN ?? 50;
   const sampleSize = options.sampleSize ?? 10000;  // Pilar 1-A default
-  // Default raised 300s → 600s on 2026-05-30: all 4 types timed out at 300s
-  // under DB contention (cf #284), yielding upserts:0 → generator_edge stale
-  // ~33h. The per-type cost is dominated by `ORDER BY random()` over the full
-  // window (calibration: N=1000 ≈ N=10000 ≈ 47s), so a higher cap — not a
-  // smaller sample — is the right lever; lowering sampleSize would only cut
-  // statistical power. See resolveEdgeRefreshConfig for the env overrides.
+  // Default raised 300s → 600s on 2026-05-30 (#288). The TRUE per-type cost
+  // (root-caused 2026-06-01, #294) was the missing index on
+  // generator_predictions(market_type, direction, time): both the COUNT(*)
+  // InitPlan and the `sampled` scan seq-scanned the FULL 7-day window across
+  // all types (~320MB on e2-micro) to filter one type. Migration 034 adds that
+  // index → event_short dropped >600s timeout → ~41s. With the index, the cap
+  // is no longer the binding constraint; it remains a safety backstop. Lowering
+  // sampleSize would only cut statistical power and is NOT the right lever.
+  // See resolveEdgeRefreshConfig for the env overrides.
   const perTypeTimeoutMs = options.perTypeTimeoutMs ?? 600_000;  // 10 min
   const source = options.source ??
     `EdgeCapacityRefresher cron ${new Date().toISOString().slice(0, 10)} (sample N=${sampleSize})`;


### PR DESCRIPTION
## Problem

`event_short` `generator_edge` rows have been stale since 2026-05-29 (82.9h as of daily-review #294), leaving the edge sentinel (3b alarm) blind for the type. This is a carry-over from PRs #288/#289/#290, all of which mis-diagnosed the cause.

## Root cause (proven, not inferred)

`EdgeCapacityRefresher.buildPerTypeSQL` measures one `market_type` at a time. Each per-type query filters `WHERE market_type=$1 AND direction IN ('long','short') AND time >= NOW()-7d` **twice**:
1. the `COUNT(*)` InitPlan that sizes the Bernoulli sample, and
2. the `sampled` CTE scan.

`generator_predictions` had **no index on `market_type`/`direction`** (only `(time)`, `(signal_id,time)`, `(market_id,time)`). So both scans fell back to a **full 7-day seq-scan across ALL market_types** (~320MB on the e2-micro), filtering down to the target type. `event_short` is the **largest** cohort (~158k predictions/7d — more than event_long), so its query blew past the 600s per-type cap → `upserts:0` for that type → stale edge.

The correlated `price_history` 4h-forward seek is **not** the bottleneck — it is index-served via `idx_ph_market_time` (~ms/row). #289 was correct about price_history; #291 wrong; #290 (`drop event_long`) was containment that never touched event_short's own scan cost (its premise — "event_long is the biggest" — was also false).

## Fix

Add an index on `generator_predictions (market_type, direction, time DESC)`.

**Measured on the VM:**
| | without index | with index |
|---|---|---|
| event_short full-sample query | >600s (timeout) | **40.8s** |

>15× improvement, ample margin under the 600s cap.

## Changes
- `034_idx_generator_predictions_type_dir_time.sql` — idempotent `CREATE INDEX IF NOT EXISTS`. The index was also created **manually on the live VM on 2026-06-01** (init SQL only runs on a fresh volume), so tonight's cron already benefits; this migration covers fresh installs / future volume re-inits.
- `EdgeCapacityRefresher.ts` — correct the stale comment that blamed `ORDER BY random()` and prescribed a higher timeout cap instead of the index.

## Tests
`EdgeCapacityRefresher.test.ts` — 21/21 pass (no logic change; comment + SQL only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database query performance for edge capacity refresh operations through targeted optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->