### PR TITLE
feat(edge-refresher): decouple measurement scope from ALLOWED_MARKET_TYPES — restore event_long edge observability

### DIFF
--- a/packages/data-collector/src/services/Scheduler.test.ts
+++ b/packages/data-collector/src/services/Scheduler.test.ts
@@ -60,6 +60,33 @@ describe('Scheduler.runJob — handler dispatch (Phase 4 hotfix 2026-05-15)', ()
     await scheduler.runJob('refresh-edge-capacity');
     expect(refreshEdgeCapacity).toHaveBeenCalledTimes(1);
   });
+
+  it('edge measurement scope is decoupled from ALLOWED_MARKET_TYPES (2026-06-01)', async () => {
+    // #290 tied the refresher's allowedTypes to the LIVE trade allowlist
+    // (ALLOWED_MARKET_TYPES) purely to dodge event_long's timeout. Migration
+    // 034's index removed that cost, so edge measurement should cover ALL types
+    // (incl. shadow-only event_long) for full observability. Reads
+    // EDGE_REFRESH_ALLOWED_TYPES instead; unset → [] → measure all discovered.
+    vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday,event_short');
+    vi.stubEnv('EDGE_REFRESH_ALLOWED_TYPES', '');
+    const scheduler = new Scheduler();
+    await scheduler.runJob('refresh-edge-capacity');
+    expect(refreshEdgeCapacity).toHaveBeenCalledWith(
+      expect.objectContaining({ allowedTypes: [] }),
+    );
+    vi.unstubAllEnvs();
+  });
+
+  it('edge measurement scope honours EDGE_REFRESH_ALLOWED_TYPES when set', async () => {
+    vi.stubEnv('ALLOWED_MARKET_TYPES', 'crypto_intraday');
+    vi.stubEnv('EDGE_REFRESH_ALLOWED_TYPES', 'event_short, event_long');
+    const scheduler = new Scheduler();
+    await scheduler.runJob('refresh-edge-capacity');
+    expect(refreshEdgeCapacity).toHaveBeenCalledWith(
+      expect.objectContaining({ allowedTypes: ['event_short', 'event_long'] }),
+    );
+    vi.unstubAllEnvs();
+  });
 });
 
 describe('Scheduler — sync-resolved-markets uses resolveOurMarkets', () => {

--- a/packages/data-collector/src/services/Scheduler.ts
+++ b/packages/data-collector/src/services/Scheduler.ts
@@ -535,7 +535,14 @@ export class Scheduler {
     // The 300s default timed out all types on 2026-05-30 under DB contention
     // (#284) → 0 upserts → generator_edge stale. See resolveEdgeRefreshConfig.
     const { sampleSize, perTypeTimeoutMs } = resolveEdgeRefreshConfig();
-    const allowedTypes = parseAllowedMarketTypes(process.env.ALLOWED_MARKET_TYPES);
+    // Edge-measurement scope is decoupled from the LIVE trade allowlist
+    // (ALLOWED_MARKET_TYPES). #290 tied the two purely to dodge event_long's
+    // 600s timeout; migration 034's generator_predictions(market_type,direction,
+    // time) index removed that cost (event_short >600s→41s), so there's no
+    // longer a reason to starve shadow-only types of edge observability. Read a
+    // dedicated EDGE_REFRESH_ALLOWED_TYPES: unset/empty → [] → measure ALL
+    // discovered types (incl. event_long); set → restrict to that list.
+    const allowedTypes = parseAllowedMarketTypes(process.env.EDGE_REFRESH_ALLOWED_TYPES);
     await refreshEdgeCapacity({
       windowDays: 7,
       horizonHours: 4,


### PR DESCRIPTION
## Context

Follow-up to #295 (which root-caused the `event_short` edge timeout to a missing `generator_predictions(market_type,direction,time)` index).

PR #290 had set the EdgeCapacityRefresher's `allowedTypes` to `ALLOWED_MARKET_TYPES` — the **live trade allowlist** — purely as a performance hack to stop `event_long` (shadow-only, largest cohort) from eating the 600s per-type timeout. With #295's index that cost is gone (`event_short` >600s→41s; `event_long` likewise cheap), so the hack now only **starves shadow-only types of edge observability** — including `event_long`, the primary FLB-eligible type.

## Change

`Scheduler.refreshEdgeCapacity()` now reads a dedicated **`EDGE_REFRESH_ALLOWED_TYPES`** env instead of `ALLOWED_MARKET_TYPES`:
- **unset / empty → `[]` → measure ALL discovered active types** (incl. `event_long`) — the pre-#290 full-observability behavior.
- set → restrict to that list.

Edge **measurement** (observability for the Phase 5 AED program) is now independent of what we **trade** live. No compose change required: leaving `EDGE_REFRESH_ALLOWED_TYPES` unset gives the desired "measure all" behavior. `crypto_intraday` (no tradeable supply) is harmless — it gets skipped when it yields no measurable cells, cheaply with the index.

## Tests
2 new `Scheduler.test.ts` cases:
- edge scope is decoupled from `ALLOWED_MARKET_TYPES` (set it, assert refresher still gets `allowedTypes: []`)
- edge scope honours `EDGE_REFRESH_ALLOWED_TYPES` when set

27/27 data-collector scheduler + refresher tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)