### PR TITLE
fix(edge-refresher): materialize prediction outcomes — structural fix for event_short/event_long timeout (#297)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-edge-refresher-outcome-materialization.md
+++ b/docs/superpowers/plans/2026-06-02-edge-refresher-outcome-materialization.md
@@ -1,0 +1,817 @@
+# EdgeCapacityRefresher Outcome Materialization — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the `EdgeCapacityRefresher` 600s timeout on `event_short`/`event_long` by precomputing each prediction's 4h-forward outcome once into a dedicated table that the nightly refresher reads instead of the per-row correlated `price_history` subquery.
+
+**Architecture:** A new hypertable `generator_prediction_outcomes` is filled incrementally by an hourly job (`materializePredictionOutcomes`, in `MarketPerformanceTracker.ts`, mirroring `resolveShadowTrades`) that seeks the 4h-forward YES price on hot/uncompressed data. The refresher's `buildPerTypeSQL` is rewritten to read only this table — no `generator_predictions` heap-fetch, no `price_history` seek, no `random()` sampling. A one-shot backfill script fills the initial 7-day window.
+
+**Tech Stack:** TypeScript, TimescaleDB (hypertables, compression, retention), `pg` via `query()` helper, vitest, node-cron.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-edge-refresher-outcome-materialization-design.md`
+
+---
+
+## File Structure
+
+- **Create** `packages/data-collector/src/database/init/035_generator_prediction_outcomes.sql` — schema (hypertable + index + compression + retention).
+- **Modify** `packages/data-collector/src/services/MarketPerformanceTracker.ts` — add `materializePredictionOutcomes()`.
+- **Modify** `packages/data-collector/src/services/MarketPerformanceTracker.test.ts` — tests for the new function.
+- **Modify** `packages/data-collector/src/services/Scheduler.ts` — register the hourly cron + runJob case + handler + import.
+- **Modify** `packages/data-collector/src/services/Scheduler.test.ts` — assert the cron is registered + dispatched.
+- **Modify** `packages/data-collector/src/services/EdgeCapacityRefresher.ts` — rewrite `buildPerTypeSQL`; drop `sampleSize`; `resolveEdgeRefreshConfig` returns only `perTypeTimeoutMs`.
+- **Modify** `packages/data-collector/src/services/EdgeCapacityRefresher.test.ts` — update SQL-shape assertions; drop sampleSize assertions.
+- **Create** `scripts/backfill-prediction-outcomes.js` — one-shot offline backfill.
+
+Note on naming: `MarketPerformanceTracker.test.ts` may not exist yet. If it does not, create it with the vitest scaffold shown in Task 2 Step 1.
+
+---
+
+## Task 1: Migration — `generator_prediction_outcomes` schema
+
+**Files:**
+- Create: `packages/data-collector/src/database/init/035_generator_prediction_outcomes.sql`
+
+- [ ] **Step 1: Write the migration SQL**
+
+```sql
+-- Materialized 4h-forward outcomes for generator_predictions.
+--
+-- Root cause (daily-review #297, EXPLAIN ANALYZE 2026-06-02): the nightly
+-- EdgeCapacityRefresher recomputed a correlated price_history forward-seek per
+-- sampled prediction on every run, over compressed chunks → event_short/
+-- event_long exceeded the 600s cap. This table precomputes y1 (the YES price at
+-- prediction_time + horizon) ONCE, when the prediction matures, so the refresher
+-- reads a small purpose-built table instead. See
+-- docs/superpowers/specs/2026-06-02-edge-refresher-outcome-materialization-design.md
+--
+-- Denormalizes signal_id/direction/y0/market_type from generator_predictions.
+-- These are immutable at signal time (cold duplication, no divergence risk).
+-- market_type is stored frozen — exact parity with the refresher's current
+-- WHERE generator_predictions.market_type filter.
+
+CREATE TABLE IF NOT EXISTS generator_prediction_outcomes (
+    prediction_id    BIGINT NOT NULL,
+    prediction_time  TIMESTAMPTZ NOT NULL,
+    market_id        VARCHAR(128) NOT NULL,
+    market_type      VARCHAR(32),
+    signal_id        VARCHAR(50) NOT NULL,
+    direction        VARCHAR(8)  NOT NULL,
+    y0               NUMERIC(10,6) NOT NULL,
+    y1               NUMERIC(10,6),
+    horizon_hours    INT NOT NULL DEFAULT 4,
+    no_forward_price BOOLEAN NOT NULL DEFAULT FALSE,
+    computed_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- PK includes prediction_time: TimescaleDB requires the partition column in
+    -- every unique constraint. Mirrors generator_predictions' (time, id) PK.
+    PRIMARY KEY (prediction_time, prediction_id, horizon_hours)
+);
+
+SELECT create_hypertable('generator_prediction_outcomes', 'prediction_time',
+    chunk_time_interval => INTERVAL '1 day', if_not_exists => TRUE);
+
+-- Serves the refresher's WHERE market_type=$1 AND direction IN(...) AND
+-- prediction_time >= NOW()-7d filter directly (index-covering, no heap-fetch).
+CREATE INDEX IF NOT EXISTS idx_gpo_type_dir_time
+    ON generator_prediction_outcomes (market_type, direction, prediction_time DESC);
+
+ALTER TABLE generator_prediction_outcomes SET (timescaledb.compress_after = '3 days');
+SELECT add_retention_policy('generator_prediction_outcomes', INTERVAL '14 days', if_not_exists => TRUE);
+```
+
+- [ ] **Step 2: Verify SQL parses against the local pattern**
+
+This file is pure SQL run by `init/*.sql` on a fresh volume only. There is no unit test; correctness is validated by Task 6 (manual VM apply) and by the function tests that mock `query`. Confirm the statement ordering matches sibling files (`030_generator_predictions.sql`): `CREATE TABLE` → `create_hypertable` → indexes → compression → retention.
+
+Run: `node -e "const fs=require('fs');const s=fs.readFileSync('packages/data-collector/src/database/init/035_generator_prediction_outcomes.sql','utf8');if(!s.includes('create_hypertable'))process.exit(1);console.log('ok')"`
+Expected: `ok`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/data-collector/src/database/init/035_generator_prediction_outcomes.sql
+git commit -m "feat(edge-refresher): add generator_prediction_outcomes schema (migration 035)"
+```
+
+---
+
+## Task 2: `materializePredictionOutcomes()` — the incremental job
+
+**Files:**
+- Modify: `packages/data-collector/src/services/MarketPerformanceTracker.ts`
+- Test: `packages/data-collector/src/services/MarketPerformanceTracker.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+If `MarketPerformanceTracker.test.ts` does not exist, create it with this content. If it exists, append the new `describe` block.
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../database/connection.js', () => ({
+  query: vi.fn(),
+}));
+
+import { materializePredictionOutcomes } from './MarketPerformanceTracker.js';
+import { query } from '../database/connection.js';
+
+describe('materializePredictionOutcomes', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('materializes a matured prediction with a forward price', async () => {
+    const inserts: any[][] = [];
+    (query as any).mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('FROM generator_predictions g')) {
+        return { rows: [{
+          id: '101', time: new Date('2026-06-02T00:00:00Z'), market_id: 'm1',
+          market_type: 'event_short', signal_id: 'momentum', direction: 'long',
+          yes_price_at_signal: '0.40', age_hours: '6',
+        }]};
+      }
+      if (sql.includes('FROM price_history')) {
+        return { rows: [{ close: 0.47 }] };
+      }
+      if (sql.startsWith('INSERT INTO generator_prediction_outcomes')) {
+        inserts.push(params ?? []);
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const res = await materializePredictionOutcomes();
+    expect(res.materialized).toBe(1);
+    expect(res.noPrice).toBe(0);
+    // params: prediction_id, prediction_time, market_id, market_type,
+    //         signal_id, direction, y0, y1, horizon_hours, no_forward_price
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0][0]).toBe('101');
+    expect(inserts[0][7]).toBe(0.47);          // y1
+    expect(inserts[0][9]).toBe(false);         // no_forward_price
+  });
+
+  it('marks no_forward_price=true when matured >8h with no forward price', async () => {
+    const inserts: any[][] = [];
+    (query as any).mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('FROM generator_predictions g')) {
+        return { rows: [{
+          id: '102', time: new Date('2026-06-01T00:00:00Z'), market_id: 'm2',
+          market_type: 'event_long', signal_id: 'ofi', direction: 'short',
+          yes_price_at_signal: '0.30', age_hours: '20',
+        }]};
+      }
+      if (sql.includes('FROM price_history')) return { rows: [] }; // no forward price
+      if (sql.startsWith('INSERT INTO generator_prediction_outcomes')) {
+        inserts.push(params ?? []);
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const res = await materializePredictionOutcomes();
+    expect(res.materialized).toBe(0);
+    expect(res.noPrice).toBe(1);
+    expect(inserts[0][7]).toBe(null);          // y1
+    expect(inserts[0][9]).toBe(true);          // no_forward_price
+  });
+
+  it('skips a matured-but-young prediction (<8h) with no price yet (retried later)', async () => {
+    const inserts: any[][] = [];
+    (query as any).mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('FROM generator_predictions g')) {
+        return { rows: [{
+          id: '103', time: new Date('2026-06-02T06:00:00Z'), market_id: 'm3',
+          market_type: 'event_short', signal_id: 'hawkes', direction: 'long',
+          yes_price_at_signal: '0.50', age_hours: '6',
+        }]};
+      }
+      if (sql.includes('FROM price_history')) return { rows: [] }; // no price yet
+      if (sql.startsWith('INSERT INTO generator_prediction_outcomes')) {
+        inserts.push(params ?? []);
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const res = await materializePredictionOutcomes();
+    expect(res.materialized).toBe(0);
+    expect(res.noPrice).toBe(0);
+    expect(inserts).toHaveLength(0);           // nothing written → retried next run
+  });
+
+  it('a failing forward-seek does not abort the batch', async () => {
+    let inserts = 0;
+    (query as any).mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM generator_predictions g')) {
+        return { rows: [
+          { id: '201', time: new Date('2026-06-02T00:00:00Z'), market_id: 'mA', market_type: 'event_short', signal_id: 's', direction: 'long', yes_price_at_signal: '0.4', age_hours: '6' },
+          { id: '202', time: new Date('2026-06-02T00:00:00Z'), market_id: 'mB', market_type: 'event_short', signal_id: 's', direction: 'long', yes_price_at_signal: '0.4', age_hours: '6' },
+        ]};
+      }
+      if (sql.includes('FROM price_history')) {
+        throw new Error('simulated seek failure');
+      }
+      if (sql.startsWith('INSERT INTO generator_prediction_outcomes')) { inserts++; return { rows: [], rowCount: 1 }; }
+      return { rows: [], rowCount: 0 };
+    });
+    await expect(materializePredictionOutcomes()).resolves.toBeDefined();
+    expect(inserts).toBe(0); // both seeks failed, none inserted, no throw
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/data-collector && rtk vitest run src/services/MarketPerformanceTracker.test.ts`
+Expected: FAIL — `materializePredictionOutcomes is not a function` / not exported.
+
+- [ ] **Step 3: Implement `materializePredictionOutcomes`**
+
+Add to `packages/data-collector/src/services/MarketPerformanceTracker.ts` (after `resolveShadowTrades`, before `updateShadowCategoryPerformance`):
+
+```typescript
+/**
+ * Phase 5 / daily-review #297: materialize the 4h-forward outcome (y1) per
+ * generator_prediction ONCE, when it matures, into generator_prediction_outcomes.
+ * The nightly EdgeCapacityRefresher then reads that table instead of recomputing
+ * a correlated price_history seek per sampled row over compressed chunks (the
+ * >600s timeout root cause). Idempotent via NOT EXISTS; runs hourly on hot data.
+ *
+ * Maturity rule:
+ *  - age < horizon+1h         → not selected (too young to have a forward price).
+ *  - horizon+1h ≤ age < 8h, no price → left unwritten, retried next run (price
+ *                              may arrive late after a transient collector gap).
+ *  - age ≥ 8h, no price       → written with y1=NULL, no_forward_price=true
+ *                              (processed; never retried — market stopped quoting/resolved).
+ *  - price found              → written with y1, no_forward_price=false.
+ */
+export async function materializePredictionOutcomes(
+  opts: { horizonHours?: number } = {},
+): Promise<{ materialized: number; noPrice: number }> {
+  const horizon = opts.horizonHours ?? 4;
+
+  const pending = await query<{
+    id: string;
+    time: Date;
+    market_id: string;
+    market_type: string | null;
+    signal_id: string;
+    direction: string;
+    yes_price_at_signal: string;
+    age_hours: string;
+  }>(
+    `SELECT g.id, g.time, g.market_id, g.market_type, g.signal_id, g.direction,
+            g.yes_price_at_signal,
+            EXTRACT(EPOCH FROM (NOW() - g.time)) / 3600.0 AS age_hours
+     FROM generator_predictions g
+     WHERE g.time >= NOW() - INTERVAL '8 days'
+       AND g.time <  NOW() - INTERVAL '${horizon + 1} hours'
+       AND g.direction IN ('long','short')
+       AND NOT EXISTS (
+         SELECT 1 FROM generator_prediction_outcomes o
+         WHERE o.prediction_id = g.id AND o.horizon_hours = $1
+       )`,
+    [horizon],
+  );
+
+  if (pending.rows.length === 0) {
+    return { materialized: 0, noPrice: 0 };
+  }
+
+  logger.info({ count: pending.rows.length, horizon }, 'Materializing prediction outcomes');
+
+  let materialized = 0;
+  let noPrice = 0;
+
+  for (const row of pending.rows) {
+    try {
+      const fwd = await query<{ close: number }>(
+        `SELECT close::float AS close FROM price_history
+         WHERE market_id = $1
+           AND time >= $2::timestamptz + INTERVAL '${horizon} hours'
+           AND time <  $2::timestamptz + INTERVAL '${horizon + 1} hours'
+         ORDER BY time ASC LIMIT 1`,
+        [row.market_id, row.time],
+      );
+
+      const y1 = fwd.rows.length > 0 ? Number(fwd.rows[0].close) : null;
+      const ageHours = Number(row.age_hours);
+
+      if (y1 === null && ageHours < 8) {
+        // Too young to give up; leave unwritten so the next run retries.
+        continue;
+      }
+
+      await query(
+        `INSERT INTO generator_prediction_outcomes
+           (prediction_id, prediction_time, market_id, market_type, signal_id,
+            direction, y0, y1, horizon_hours, no_forward_price)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+         ON CONFLICT (prediction_time, prediction_id, horizon_hours) DO NOTHING`,
+        [row.id, row.time, row.market_id, row.market_type, row.signal_id,
+         row.direction, Number(row.yes_price_at_signal), y1, horizon, y1 === null],
+      );
+
+      if (y1 === null) noPrice++; else materialized++;
+    } catch (err) {
+      logger.warn({ predictionId: row.id, err: (err as Error).message },
+        'materializePredictionOutcomes: row failed (non-fatal)');
+    }
+  }
+
+  logger.info({ materialized, noPrice }, 'Prediction outcomes materialized');
+  return { materialized, noPrice };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/data-collector && rtk vitest run src/services/MarketPerformanceTracker.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/data-collector/src/services/MarketPerformanceTracker.ts packages/data-collector/src/services/MarketPerformanceTracker.test.ts
+git commit -m "feat(edge-refresher): materializePredictionOutcomes incremental job"
+```
+
+---
+
+## Task 3: Register the hourly cron in `Scheduler.ts`
+
+**Files:**
+- Modify: `packages/data-collector/src/services/Scheduler.ts` (import ~line 15; defineJob block ~line 108-121; runJob switch ~line 255-279; handlers ~line 521-555)
+- Test: `packages/data-collector/src/services/Scheduler.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `Scheduler.test.ts`. The existing mock of `../database/connection.js` already covers `query`. Add a mock for the new function on `MarketPerformanceTracker`. Add near the top imports if not present:
+
+```typescript
+vi.mock('./MarketPerformanceTracker.js', () => ({
+  updateCategoryPriors: vi.fn().mockResolvedValue(undefined),
+  updateShadowCategoryPerformance: vi.fn().mockResolvedValue(undefined),
+  resolveShadowTrades: vi.fn().mockResolvedValue(undefined),
+  materializePredictionOutcomes: vi.fn().mockResolvedValue({ materialized: 0, noPrice: 0 }),
+}));
+```
+
+Then add the test:
+
+```typescript
+import { materializePredictionOutcomes } from './MarketPerformanceTracker.js';
+
+describe('Scheduler — materialize-prediction-outcomes cron', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('runJob("materialize-prediction-outcomes") invokes materializePredictionOutcomes', async () => {
+    const scheduler = new Scheduler();
+    await scheduler.runJob('materialize-prediction-outcomes');
+    expect(materializePredictionOutcomes).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers the job at hourly :15', () => {
+    const scheduler = new Scheduler();
+    const job = (scheduler as any).jobs.get('materialize-prediction-outcomes');
+    expect(job).toBeDefined();
+    expect(job.schedule).toBe('15 * * * *');
+  });
+});
+```
+
+Note: the job registry is `this.jobs` (a `Map<string, {name, schedule, task, ...}>` populated by `defineJob` at line 127-139), so `(scheduler as any).jobs.get('materialize-prediction-outcomes').schedule` is the correct access path.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/data-collector && rtk vitest run src/services/Scheduler.test.ts`
+Expected: FAIL — job not registered / `materializePredictionOutcomes` not called (falls through to default handler).
+
+- [ ] **Step 3: Implement — import, defineJob, runJob case, handler**
+
+3a. Add to the `MarketPerformanceTracker` import (~line 15, alongside `resolveShadowTrades`):
+
+```typescript
+  materializePredictionOutcomes,
+```
+
+3b. Add a `defineJob` line in the registration block (after line 119, the `refresh-edge-capacity` line):
+
+```typescript
+    // daily-review #297: materialize 4h-forward outcomes hourly so the nightly
+    // refresher reads a precomputed table instead of a per-row price_history
+    // seek. :15 to avoid colliding with the :00/:30 jobs.
+    this.defineJob('materialize-prediction-outcomes', '15 * * * *', this.materializePredictionOutcomes.bind(this));
+```
+
+3c. Add a case in the `runJob` switch (after the `refresh-edge-capacity` case at line 273). The #224 lesson: a job with no switch case fires but silently no-ops.
+
+```typescript
+        case 'materialize-prediction-outcomes':
+          await this.materializePredictionOutcomes();
+          break;
+```
+
+3d. Add the private handler (near `refreshEdgeCapacity` at ~line 533):
+
+```typescript
+  /**
+   * daily-review #297: incremental materialization of generator_prediction_outcomes.
+   * Hourly at :15. Cheap (only matured-in-last-hour predictions on hot data).
+   */
+  private async materializePredictionOutcomes(): Promise<void> {
+    await materializePredictionOutcomes();
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/data-collector && rtk vitest run src/services/Scheduler.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/data-collector/src/services/Scheduler.ts packages/data-collector/src/services/Scheduler.test.ts
+git commit -m "feat(edge-refresher): hourly materialize-prediction-outcomes cron + runJob case"
+```
+
+---
+
+## Task 4: Rewrite `buildPerTypeSQL` to read outcomes; drop sampling
+
+**Files:**
+- Modify: `packages/data-collector/src/services/EdgeCapacityRefresher.ts` (`buildPerTypeSQL` ~line 145-205; `measureCellsForType` ~line 215; `refreshEdgeCapacity` `sampleSize` plumbing ~line 344-440; `resolveEdgeRefreshConfig` ~line 331)
+- Test: `packages/data-collector/src/services/EdgeCapacityRefresher.test.ts`
+
+- [ ] **Step 1: Update the failing tests (new SQL shape, no sampling)**
+
+In `EdgeCapacityRefresher.test.ts`:
+
+4a. Replace the `resolveEdgeRefreshConfig` describe block (lines 14-41) with one that expects only `perTypeTimeoutMs`:
+
+```typescript
+describe('resolveEdgeRefreshConfig (env-overridable per-type timeout backstop)', () => {
+  it('empty env → default timeout 600s', () => {
+    expect(resolveEdgeRefreshConfig({})).toEqual({ perTypeTimeoutMs: 600_000 });
+  });
+  it('valid env value is honored', () => {
+    expect(resolveEdgeRefreshConfig({ EDGE_REFRESH_PER_TYPE_TIMEOUT_MS: '900000' }))
+      .toEqual({ perTypeTimeoutMs: 900_000 });
+  });
+  it('invalid env values fall back to default', () => {
+    expect(resolveEdgeRefreshConfig({ EDGE_REFRESH_PER_TYPE_TIMEOUT_MS: '0' }).perTypeTimeoutMs).toBe(600_000);
+    expect(resolveEdgeRefreshConfig({ EDGE_REFRESH_PER_TYPE_TIMEOUT_MS: 'abc' }).perTypeTimeoutMs).toBe(600_000);
+  });
+});
+```
+
+4b. In the integration block, every mock branch that matches `sql.includes('FROM generator_predictions')` for the PER-TYPE query must change to `sql.includes('FROM generator_prediction_outcomes')`. Update these branches in the tests at lines 136, 173, 202, 224, 238, 276, 302, 321. (The `SELECT DISTINCT market_type` branch stays as-is — it still reads `markets`.)
+
+4c. Replace the two SQL-shape tests (lines 190-229) with:
+
+```typescript
+  it('per-type SQL reads generator_prediction_outcomes with window + horizon filter, no price_history, no random()', async () => {
+    const capturedSql: string[] = [];
+    (query as any).mockImplementation(async (sql: string) => {
+      if (typeof sql === 'string' && sql.includes('SELECT DISTINCT market_type')) {
+        return { rows: [{ market_type: 'event_long' }] };
+      }
+      if (typeof sql === 'string') capturedSql.push(sql);
+      return { rows: [], rowCount: 0 };
+    });
+
+    await refreshEdgeCapacity({ windowDays: 3, horizonHours: 6, minN: 100 });
+
+    const stmt = capturedSql.find(s => s.includes('FROM generator_prediction_outcomes'));
+    expect(stmt).toBeDefined();
+    expect(stmt).toContain("INTERVAL '3 days'");
+    expect(stmt).toContain('horizon_hours = 6');
+    expect(stmt).toContain('y1 IS NOT NULL');
+    expect(stmt).not.toContain('price_history');
+    expect(stmt).not.toContain('random()');
+    expect(stmt).not.toContain('FROM generator_predictions g');
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/data-collector && rtk vitest run src/services/EdgeCapacityRefresher.test.ts`
+Expected: FAIL — SQL still contains `price_history`/`random()`; `resolveEdgeRefreshConfig` still returns `sampleSize`.
+
+- [ ] **Step 3: Rewrite `buildPerTypeSQL`**
+
+Replace the entire `buildPerTypeSQL` function (lines 145-205) with:
+
+```typescript
+/**
+ * Build the t-stat SQL for a single market_type, reading the precomputed
+ * generator_prediction_outcomes table (daily-review #297). No price_history
+ * seek, no sampling — the table is small and index-served by
+ * idx_gpo_type_dir_time. gross_edge uses y0/y1 already present per row.
+ *
+ * `${marketType}` is NOT interpolated — it binds through $1. Only numeric
+ * server-controlled values (windowDays, horizonHours) interpolate.
+ */
+function buildPerTypeSQL(marketType: string, windowDays: number, horizonHours: number): string {
+  return `
+    WITH edges AS (
+      SELECT signal_id, market_type, direction,
+             CASE WHEN direction='long' THEN y1 - y0 ELSE y0 - y1 END AS gross_edge
+      FROM generator_prediction_outcomes
+      WHERE prediction_time >= NOW() - INTERVAL '${windowDays} days'
+        AND market_type = $1
+        AND direction IN ('long','short')
+        AND horizon_hours = ${horizonHours}
+        AND y1 IS NOT NULL
+    )
+    SELECT
+      signal_id, market_type, direction,
+      COUNT(*)::int AS n,
+      (AVG(gross_edge) * 100)::float AS gross_pct,
+      CASE WHEN STDDEV(gross_edge) > 0 THEN
+        (AVG(gross_edge) * SQRT(COUNT(*)) / STDDEV(gross_edge))::float
+      END AS t_gross
+    FROM edges
+    GROUP BY 1, 2, 3
+  `;
+}
+```
+
+- [ ] **Step 4: Update `measureCellsForType` and `refreshEdgeCapacity` to drop sampleSize**
+
+4a. In `measureCellsForType` (line 215), remove the `sampleSize` parameter and update the `buildPerTypeSQL` call:
+
+```typescript
+async function measureCellsForType(
+  marketType: string,
+  windowDays: number,
+  horizonHours: number,
+  timeoutMs: number,
+): Promise<Cell[] | null> {
+  const sql = buildPerTypeSQL(marketType, windowDays, horizonHours);
+  // ... rest unchanged (Promise.race timeout, row mapping) ...
+```
+
+4b. In `RefreshOptions` (line 67-84), remove the `sampleSize?: number;` field and its comment block (lines 74-78).
+
+4c. In `refreshEdgeCapacity` (line 344): remove the `sampleSize` const (line 353) and update the `measureCellsForType` call (line 388) and the `persistCellsToHistory` call. `persistCellsToHistory` currently takes `sampleSize` and writes it to `generator_edge.sample_size`. Pass `null` (the column is nullable; sampling is gone). Update the `source` default string (line 364-365) to drop `(sample N=...)`:
+
+```typescript
+  const source = options.source ??
+    `EdgeCapacityRefresher cron ${new Date().toISOString().slice(0, 10)} (full)`;
+```
+
+Update the call (line 388):
+
+```typescript
+    const cells = await measureCellsForType(marketType, windowDays, horizonHours, perTypeTimeoutMs);
+```
+
+Update the `persistCellsToHistory` call (line 405-407) — pass `null` for the sampleSize arg:
+
+```typescript
+    await persistCellsToHistory(
+      cells, rtForType, windowDays, horizonHours, null, source, minN,
+    ).catch((err) => {
+```
+
+4d. Rewrite `resolveEdgeRefreshConfig` (lines 331-342) to return only the timeout:
+
+```typescript
+export function resolveEdgeRefreshConfig(
+  env: Record<string, string | undefined> = process.env,
+): { perTypeTimeoutMs: number } {
+  const posIntOr = (raw: string | undefined, def: number): number => {
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? Math.floor(n) : def;
+  };
+  return {
+    perTypeTimeoutMs: posIntOr(env.EDGE_REFRESH_PER_TYPE_TIMEOUT_MS, 600_000),
+  };
+}
+```
+
+4e. Update the `refreshEdgeCapacity` destructure of options to drop `sampleSize` (line 353 area). Remove the line `const sampleSize = options.sampleSize ?? 10000;` and the long comment above `perTypeTimeoutMs` referencing sampleSize; keep `const perTypeTimeoutMs = options.perTypeTimeoutMs ?? 600_000;`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/data-collector && rtk vitest run src/services/EdgeCapacityRefresher.test.ts`
+Expected: PASS. (`computeEdgeCapacity`/`getLatestEdgePerCell`/persistence tests unchanged and still green.)
+
+- [ ] **Step 6: Update `Scheduler.refreshEdgeCapacity` caller (sampleSize removed)**
+
+In `Scheduler.ts` `refreshEdgeCapacity` handler (~line 533-555): `resolveEdgeRefreshConfig()` now returns only `{ perTypeTimeoutMs }`. Update the destructure and the `refreshEdgeCapacity({...})` call to no longer pass `sampleSize`:
+
+```typescript
+    const { perTypeTimeoutMs } = resolveEdgeRefreshConfig();
+    const allowedTypes = parseAllowedMarketTypes(process.env.EDGE_REFRESH_ALLOWED_TYPES);
+    await refreshEdgeCapacity({
+      windowDays: 7,
+      horizonHours: 4,
+      defaultRtCost: 0.01,
+      minN: 50,
+      perTypeTimeoutMs,
+      allowedTypes,
+    });
+```
+
+Update the `Scheduler.test.ts` mock of `resolveEdgeRefreshConfig` (line 14) to return `{ perTypeTimeoutMs: 600_000 }` (drop `sampleSize`).
+
+- [ ] **Step 7: Run the full data-collector suite**
+
+Run: `cd packages/data-collector && rtk vitest run src/services/EdgeCapacityRefresher.test.ts src/services/Scheduler.test.ts src/services/MarketPerformanceTracker.test.ts`
+Expected: PASS across all three.
+
+- [ ] **Step 8: Typecheck**
+
+Run: `cd packages/data-collector && rtk tsc --noEmit`
+Expected: no errors (catches any missed `sampleSize` reference).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/data-collector/src/services/EdgeCapacityRefresher.ts packages/data-collector/src/services/EdgeCapacityRefresher.test.ts packages/data-collector/src/services/Scheduler.ts packages/data-collector/src/services/Scheduler.test.ts
+git commit -m "feat(edge-refresher): read generator_prediction_outcomes; drop price_history seek + sampling"
+```
+
+---
+
+## Task 5: One-shot backfill script
+
+**Files:**
+- Create: `scripts/backfill-prediction-outcomes.js`
+
+- [ ] **Step 1: Write the script**
+
+Mirrors the `materializePredictionOutcomes` SQL but without the 8-day floor (covers the full 7-day window the refresher reads) and without a per-row maturity skip (all rows are old enough at backfill time). Plain Node + `pg`, like sibling scripts.
+
+```javascript
+#!/usr/bin/env node
+/**
+ * One-shot backfill for generator_prediction_outcomes (daily-review #297).
+ *
+ * Run ONCE on the VM after deploying the materialization job + creating the
+ * table, to fill the initial 7-day window the EdgeCapacityRefresher reads.
+ * This pass touches compressed price_history chunks (expensive), so it runs
+ * offline without the cron's 600s cap. The hourly job keeps the table current
+ * thereafter.
+ *
+ *   NODE_TLS_REJECT_UNAUTHORIZED=0 DATABASE_URL="postgres://..." \
+ *     node scripts/backfill-prediction-outcomes.js [--window-days 8] [--horizon 4]
+ */
+const { Pool } = require('pg');
+
+function arg(name, def) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : def;
+}
+
+async function main() {
+  const windowDays = parseInt(arg('window-days', '8'), 10);
+  const horizon = parseInt(arg('horizon', '4'), 10);
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+  const pending = await pool.query(
+    `SELECT g.id, g.time, g.market_id, g.market_type, g.signal_id, g.direction,
+            g.yes_price_at_signal
+     FROM generator_predictions g
+     WHERE g.time >= NOW() - INTERVAL '${windowDays} days'
+       AND g.time <  NOW() - INTERVAL '${horizon + 1} hours'
+       AND g.direction IN ('long','short')
+       AND NOT EXISTS (
+         SELECT 1 FROM generator_prediction_outcomes o
+         WHERE o.prediction_id = g.id AND o.horizon_hours = $1
+       )`,
+    [horizon],
+  );
+
+  console.log(`Backfilling ${pending.rows.length} predictions (window ${windowDays}d, horizon ${horizon}h)`);
+  let materialized = 0, noPrice = 0, errors = 0;
+
+  for (const row of pending.rows) {
+    try {
+      const fwd = await pool.query(
+        `SELECT close::float AS close FROM price_history
+         WHERE market_id = $1
+           AND time >= $2::timestamptz + INTERVAL '${horizon} hours'
+           AND time <  $2::timestamptz + INTERVAL '${horizon + 1} hours'
+         ORDER BY time ASC LIMIT 1`,
+        [row.market_id, row.time],
+      );
+      const y1 = fwd.rows.length > 0 ? Number(fwd.rows[0].close) : null;
+      await pool.query(
+        `INSERT INTO generator_prediction_outcomes
+           (prediction_id, prediction_time, market_id, market_type, signal_id,
+            direction, y0, y1, horizon_hours, no_forward_price)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+         ON CONFLICT (prediction_time, prediction_id, horizon_hours) DO NOTHING`,
+        [row.id, row.time, row.market_id, row.market_type, row.signal_id,
+         row.direction, Number(row.yes_price_at_signal), y1, horizon, y1 === null],
+      );
+      if (y1 === null) noPrice++; else materialized++;
+      if ((materialized + noPrice) % 5000 === 0) {
+        console.log(`  ... ${materialized + noPrice}/${pending.rows.length}`);
+      }
+    } catch (e) {
+      errors++;
+      if (errors <= 10) console.error(`  row ${row.id} failed: ${e.message}`);
+    }
+  }
+
+  console.log(`Done: materialized=${materialized} noPrice=${noPrice} errors=${errors}`);
+  await pool.end();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });
+```
+
+- [ ] **Step 2: Lint-check (syntax only — no DB locally)**
+
+Run: `node --check scripts/backfill-prediction-outcomes.js`
+Expected: no output (valid syntax).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/backfill-prediction-outcomes.js
+git commit -m "feat(edge-refresher): one-shot backfill-prediction-outcomes script"
+```
+
+---
+
+## Task 6: Deploy + verify on VM (manual, post-merge)
+
+**Not code — operational. Do after the PR merges and CI builds the data-collector image.**
+
+- [ ] **Step 1: Create the table + index manually on the VM** (init SQL only runs on a fresh volume)
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command \
+  "docker cp - polymarket-timescaledb:/tmp/035.sql < /home/Usuario/polymarket-trader/packages/data-collector/src/database/init/035_generator_prediction_outcomes.sql 2>/dev/null; \
+   docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -f /tmp/035.sql"
+```
+
+If `docker cp -` is awkward, `git pull` on the VM first, then `docker cp` the file path. Expected: `CREATE TABLE`, `create_hypertable`, `CREATE INDEX`, `ALTER TABLE`, retention policy added.
+
+- [ ] **Step 2: Pull the new image + restart data-collector**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command \
+  "cd /home/Usuario/polymarket-trader && git pull && docker compose -f docker-compose.gcp.yml pull data-collector && docker compose -f docker-compose.gcp.yml up -d --remove-orphans"
+```
+
+- [ ] **Step 3: Run the backfill**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command \
+  "docker exec polymarket-data-collector sh -c 'DATABASE_URL=\"\$DATABASE_URL\" node /app/scripts/backfill-prediction-outcomes.js --window-days 8 --horizon 4'"
+```
+(If `scripts/` is not bundled into the data-collector image, copy it in first via `docker cp`, or run the equivalent from the host with the container `DATABASE_URL`.) Expected: `Done: materialized=<n> noPrice=<m> errors=<small>`.
+
+- [ ] **Step 4: Sanity-check the table is populated per type**
+
+```sql
+SELECT market_type, COUNT(*) n, COUNT(*) FILTER (WHERE y1 IS NOT NULL) with_y1
+FROM generator_prediction_outcomes
+WHERE prediction_time >= NOW() - INTERVAL '7 days'
+GROUP BY 1 ORDER BY 1;
+```
+Expected: all 4 active types present with `with_y1 > 0` (event_short the largest).
+
+- [ ] **Step 5: Time the refresher end-to-end** (the binding lesson from #297 — measure the WHOLE query, not a sub-part)
+
+```sql
+\timing on
+-- run the rewritten buildPerTypeSQL for event_short manually:
+WITH edges AS (
+  SELECT signal_id, market_type, direction,
+         CASE WHEN direction='long' THEN y1 - y0 ELSE y0 - y1 END AS gross_edge
+  FROM generator_prediction_outcomes
+  WHERE prediction_time >= NOW() - INTERVAL '7 days'
+    AND market_type = 'event_short' AND direction IN ('long','short')
+    AND horizon_hours = 4 AND y1 IS NOT NULL
+)
+SELECT signal_id, COUNT(*), AVG(gross_edge)*100,
+       AVG(gross_edge)*SQRT(COUNT(*))/NULLIF(STDDEV(gross_edge),0)
+FROM edges GROUP BY 1;
+```
+Expected: well under 1s.
+
+- [ ] **Step 6: Carry-over verification (next 02:30 UTC cron)**
+
+The morning after deploy, in the daily-autoreview session, run:
+```sql
+SELECT market_type, MAX(measured_at), NOW()-MAX(measured_at) staleness
+FROM generator_edge GROUP BY 1 ORDER BY 2 DESC;
+```
+Expected: all 4 types (incl. event_short, event_long) < 24h stale. Also confirm the cron log shows no `TIMEOUT` and the full refresher run < 60s. Update the ⏰ memory item with the verdict.
+
+---
+
+## Self-Review notes (completed)
+
+- **Spec coverage:** schema (Task 1), materialization job + maturity/no-price rules (Task 2), hourly cron + runJob case (Task 3), refresher rewrite + sampling removal (Task 4), backfill (Task 5), deploy/verify incl. end-to-end timing (Task 6). All spec sections mapped.
+- **Type consistency:** `materializePredictionOutcomes(): {materialized, noPrice}` used identically in Task 2 (def), Task 3 (mock/handler). `buildPerTypeSQL(marketType, windowDays, horizonHours)` 3-arg signature consistent across Task 4 def + `measureCellsForType` call. `resolveEdgeRefreshConfig(): {perTypeTimeoutMs}` consistent in Task 4d def + Task 6 Scheduler caller + Scheduler.test mock.
+- **No placeholders:** every code step shows full code; SQL shape assertions name exact strings.
+- **Known fragility:** Task 3's `vi.mock('./MarketPerformanceTracker.js')` is module-wide — it must export every symbol `Scheduler.ts` imports from that module (listed in the mock) or unrelated Scheduler tests break. Task 6 notes the `scripts/` image-bundling caveat.
+```

--- a/docs/superpowers/specs/2026-06-02-edge-refresher-outcome-materialization-design.md
+++ b/docs/superpowers/specs/2026-06-02-edge-refresher-outcome-materialization-design.md
@@ -24,6 +24,10 @@ The full query was **always** >600s, before and after #295. `event_short` times 
 
 NOT urgent in capital terms: `event_short` is blocked in both directions (#275/#277), `event_long` is shadow-only. This is degraded **edge-sentinel observability**, not capital loss — which is why this gets a designed structural fix rather than a reactive nightly patch.
 
+### Relevance to trading outcomes (honest causal chain)
+
+This fix does **not** open trades by itself. Its value is upstream of trading: `market_type_edge_capacity` / `generator_edge` are the cost-aware edge signals that (a) feed `MarketScorer.tradeabilityScore` and market rotation, and (b) drive the daily-review edge sentinel that flags `(signal, type, direction)` cells with `t_net > 0` as candidates to unblock. With `event_short`/`event_long` stale for 5 days and `event_financial` one slow night from also timing out, the system is **blind to whether any explorable edge exists in those cohorts** — it cannot distinguish "no edge" from "not measured". Restoring (and making robust + deterministic) this measurement is the prerequisite for *discovering* better trades, not a source of edge in itself. Concretely, a faster/complete refresh also means the sampling removal raises per-cell `n`, so a genuine edge cell crosses the `t_net` significance bar sooner and with less run-to-run noise. Any actual trade-enabling decision (e.g. lifting an `event_short` direction block) remains a separate, evidence-gated step.
+
 ## Approach (chosen: A — materialized outcomes)
 
 Move the expensive 4h-forward price lookup **out of the nightly refresh** and into a deferred, incremental job that computes each prediction's outcome **once**, when it matures. The refresher then reads a small, purpose-built table — no `generator_predictions` heap-fetch, no `price_history` correlated subquery.

--- a/docs/superpowers/specs/2026-06-02-edge-refresher-outcome-materialization-design.md
+++ b/docs/superpowers/specs/2026-06-02-edge-refresher-outcome-materialization-design.md
@@ -1,0 +1,159 @@
+# EdgeCapacityRefresher — Outcome Materialization (structural timeout fix)
+
+**Date:** 2026-06-02
+**Status:** Design approved, pending implementation plan
+**Origin:** daily-review #297 — `event_short`/`event_long` `generator_edge` stale 5 days; PRs #288/#289/#290/#295 all mis-diagnosed.
+
+## Problem
+
+The nightly `EdgeCapacityRefresher` (02:30 UTC) measures per-`(signal, market_type, direction)` cost-aware edge from `generator_predictions` × 4h-forward `price_history` drift. For `event_short` and `event_long` the per-type query exceeds the 600s cap and is skipped, leaving `generator_edge` stale and the edge sentinel partially blind for those types.
+
+### Root cause (EXPLAIN ANALYZE on the VM, 2026-06-02)
+
+`buildPerTypeSQL` (with `sampleSize=10000`) has three cost components. PR #295's `(market_type, direction, time)` index fixed only the cheapest:
+
+1. **`COUNT(*)` InitPlan** — 80ms, Index-Only Scan. ✅ Fixed by #295.
+2. **Sampled CTE scan — 39.9s** (measured). An Index *Scan* (not Index-Only) heap-fetching all ~171k `event_short` rows in the 7-day window, because the SELECT projects `signal_id/market_id/time/yes_price_at_signal` (not in the index) and `random()` is a post-heap Filter. `read=19036` disk blocks on the e2-micro. **This 39.9s is exactly the "40.8s" measured on 2026-06-01 and mistaken for the whole query.**
+3. **`price_history` 4h-forward correlated subquery × ~10,068 sampled rows** — each sampled row triggers a `ChunkAppend` over multiple *compressed* `price_history` chunks (ColumnarScan + decompression), with no startup chunk-exclusion (the predicate `s.time + 4h` is correlated). Estimated full-query cost: 1.27M (29× the sampled scan alone). **This is the bulk of the >560s and the index does not touch it.**
+
+The full query was **always** >600s, before and after #295. `event_short` times out where `event_financial` (508s) does not because it is the largest cohort: 171,835 preds/7d (130,143 long + 41,692 short) vs `event_financial` 126,095.
+
+**Methodology lesson (binding for verification):** measuring one CTE/subplan in isolation and reporting it as the whole-query time produced a false "fixed, proven" two days running. Never claim a perf fix works from a partial-query timing — measure the COMPLETE query end-to-end.
+
+### Severity
+
+NOT urgent in capital terms: `event_short` is blocked in both directions (#275/#277), `event_long` is shadow-only. This is degraded **edge-sentinel observability**, not capital loss — which is why this gets a designed structural fix rather than a reactive nightly patch.
+
+## Approach (chosen: A — materialized outcomes)
+
+Move the expensive 4h-forward price lookup **out of the nightly refresh** and into a deferred, incremental job that computes each prediction's outcome **once**, when it matures. The refresher then reads a small, purpose-built table — no `generator_predictions` heap-fetch, no `price_history` correlated subquery.
+
+Rationale vs alternatives:
+- **B (minimal outcomes table + JOIN):** eliminates the price seek (#3) but keeps the 40s/type heap-fetch on `generator_predictions` (#2) and JOINs across compressed chunks. Rejected — leaves the secondary cost and less future margin.
+- **C (covering index only):** fixes #2 (40s→ms) but not #3 (>560s). Rejected — does not address the dominant cost; proven ineffective in spirit by #295 today.
+
+The materialization job pays the price seek on **hot, uncompressed data** (`compress_after = '3 days'`; matured predictions are 4-5h old), so its seeks are ~ms. The only expensive pass over compressed chunks is the one-shot backfill, run offline without the cap.
+
+### Why the denormalization is safe
+
+The outcomes table duplicates `signal_id`, `direction`, `y0`, `market_type` from `generator_predictions`. These are **immutable** (fixed at signal time), so there is no divergence risk — it is "cold" duplication that costs only space (~50-100 MB, compressible). `market_type` is the only field that can change (reclassification), but the **current refresher already filters on the frozen `generator_predictions.market_type`**, so storing it frozen here is exact parity, not a new bug. Attributing by *current* `market_type` instead is a deliberate, separate follow-up — explicitly out of scope here.
+
+## Component 1 — Schema (migration `035`)
+
+```sql
+CREATE TABLE IF NOT EXISTS generator_prediction_outcomes (
+    prediction_id    BIGINT NOT NULL,          -- logical FK to generator_predictions.id
+    prediction_time  TIMESTAMPTZ NOT NULL,     -- = generator_predictions.time (partition key + 7d window filter)
+    market_id        VARCHAR(128) NOT NULL,
+    market_type      VARCHAR(32),              -- frozen, parity with current refresher
+    signal_id        VARCHAR(50) NOT NULL,
+    direction        VARCHAR(8)  NOT NULL,
+    y0               NUMERIC(10,6) NOT NULL,    -- yes_price_at_signal
+    y1               NUMERIC(10,6),             -- YES price at +horizon (NULL if no forward match)
+    horizon_hours    INT NOT NULL DEFAULT 4,
+    no_forward_price BOOLEAN NOT NULL DEFAULT FALSE,  -- matured but never got a forward price → stop retrying
+    computed_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- PK includes prediction_time because TimescaleDB requires the partition
+    -- column in every unique constraint. Mirrors generator_predictions' (time, id) PK.
+    PRIMARY KEY (prediction_time, prediction_id, horizon_hours)
+);
+
+SELECT create_hypertable('generator_prediction_outcomes', 'prediction_time',
+    chunk_time_interval => INTERVAL '1 day', if_not_exists => TRUE);
+
+CREATE INDEX IF NOT EXISTS idx_gpo_type_dir_time
+    ON generator_prediction_outcomes (market_type, direction, prediction_time DESC);
+
+ALTER TABLE generator_prediction_outcomes SET (timescaledb.compress_after = '3 days');
+SELECT add_retention_policy('generator_prediction_outcomes', INTERVAL '14 days', if_not_exists => TRUE);
+```
+
+Hypertable (not a plain table) so it inherits TimescaleDB compression + retention — meaningful on the e2-micro's 350 MB TimescaleDB budget. Size estimate: ~110k preds/day × 14d ≈ 1.5M rows (no heavy `metadata` column); compressed after 3d. Consequence for the job's idempotency guard: the unique target is `(prediction_time, prediction_id, horizon_hours)`, so the `ON CONFLICT` clause must name all three (the job knows `prediction_time = g.time`). The `NOT EXISTS` pre-check is the primary idempotency mechanism; `ON CONFLICT ... DO NOTHING` is the secondary guard.
+
+**Init-SQL gotcha:** `init/*.sql` only runs on a fresh volume. After merge, create the table + index **manually on the live VM** (as was done for migration 034).
+
+## Component 2 — Materialization job
+
+New `materializePredictionOutcomes()` in `packages/data-collector/src/services/MarketPerformanceTracker.ts`, beside `resolveShadowTrades` (same idempotent deferred-outcome pattern).
+
+1. Select matured, not-yet-materialized predictions:
+   ```sql
+   SELECT g.id, g.time, g.market_id, g.market_type, g.signal_id, g.direction, g.yes_price_at_signal
+   FROM generator_predictions g
+   WHERE g.time >= NOW() - INTERVAL '8 days'      -- 7d window + margin
+     AND g.time <  NOW() - INTERVAL '5 hours'      -- matured: horizon(4h) + 1h
+     AND g.direction IN ('long','short')
+     AND NOT EXISTS (SELECT 1 FROM generator_prediction_outcomes o
+                     WHERE o.prediction_id = g.id AND o.horizon_hours = 4)
+   ```
+2. For each, seek the forward price (hot/uncompressed data → ~ms):
+   ```sql
+   SELECT close FROM price_history
+   WHERE market_id = $market_id
+     AND time >= $g_time + INTERVAL '4 hours'
+     AND time <  $g_time + INTERVAL '5 hours'
+   ORDER BY time ASC LIMIT 1
+   ```
+3. Insert outcome (`y1` if matched; else `y1=NULL`). `ON CONFLICT (prediction_time, prediction_id, horizon_hours) DO NOTHING` (must name the full hypertable PK).
+
+**No-forward-price rule:** a prediction may mature yet never get a forward price (market stopped quoting, resolved, data gap). To avoid eternal retries:
+- 5h ≤ age < 8h with no price → leave unmaterialized, retry next run (price may arrive late).
+- age ≥ 8h with no price → write `y1=NULL, no_forward_price=true` (processed; never retried).
+
+**Error handling:** per-row try/catch (log + continue), like `persistCellsToHistory`. One bad seek never aborts the batch.
+
+**Schedule:** hourly cron in `Scheduler.ts`. Each run processes only the ~4-5k predictions that matured in the last hour — distributed cost, never a 600s burst.
+
+## Component 3 — Refresher rewrite
+
+`buildPerTypeSQL` in `EdgeCapacityRefresher.ts` reads **only** the outcomes table:
+
+```sql
+WITH edges AS (
+  SELECT signal_id, market_type, direction,
+         CASE WHEN direction='long' THEN y1 - y0 ELSE y0 - y1 END AS gross_edge
+  FROM generator_prediction_outcomes
+  WHERE prediction_time >= NOW() - INTERVAL '7 days'
+    AND market_type = $1
+    AND direction IN ('long','short')
+    AND y1 IS NOT NULL
+)
+SELECT signal_id, market_type, direction,
+       COUNT(*)::int AS n,
+       (AVG(gross_edge)*100)::float AS gross_pct,
+       CASE WHEN STDDEV(gross_edge)>0
+            THEN (AVG(gross_edge)*SQRT(COUNT(*))/STDDEV(gross_edge))::float END AS t_gross
+FROM edges GROUP BY 1,2,3;
+```
+
+`idx_gpo_type_dir_time` serves the WHERE directly; scan is proportional to the materialized cohort, with no heap-fetch of absent columns and no `price_history` decompression.
+
+**Sampling removed:** the materialized table is cheap to scan in full, so `sampleSize` / the `random()` filter / the `COUNT(*)` InitPlan are dropped. Benefits: higher statistical power (full cohort `n` per cell instead of ~385), and **deterministic** results (today's sampling adds ±1% run-to-run variance). `EDGE_REFRESH_SAMPLE_SIZE` becomes obsolete (plan decides clean removal vs read-but-unused transition). `perTypeTimeoutMs` is kept as a now-ample safety backstop.
+
+**Unchanged:** `persistCellsToHistory`, `computeEdgeCapacity`, `getLatestEdgePerCell` — they still receive the same `Cell[]`. Only the raw-data source changes. `event_financial` (today 508s) gets the speedup for free (same table).
+
+## Testing (TDD, one test per step)
+
+- `MarketPerformanceTracker.test.ts` — `materializePredictionOutcomes()`: (a) materializes a matured prediction with a forward price; (b) marks `no_forward_price=true` when age ≥ 8h with no price; (c) idempotent (no dup on second run); (d) skips not-yet-matured (<5h) predictions.
+- `EdgeCapacityRefresher.test.ts` — `buildPerTypeSQL` emits SQL with no `price_history` and no `random()`; `computeEdgeCapacity` / `persistCellsToHistory` regression (same `Cell[]` → same upserts).
+- `Scheduler.test.ts` — the new hourly materialization cron is registered; the refresher no longer passes `sampleSize`.
+
+## Deployment order
+
+1. Merge + deploy code; create table + index manually on VM.
+2. Run one-shot `scripts/backfill-prediction-outcomes.js` on VM → fills the 7d window (touches compressed chunks; offline, no cap).
+3. Hourly cron keeps the table current thereafter.
+4. Next 02:30 UTC refresher reads the populated table → `event_short`/`event_long` edge fresh.
+5. **Carry-over verification (new ⏰):** next day, `generator_edge` < 24h stale for all 4 types AND measure the **full** refresher end-to-end time (not a sub-query — today's lesson).
+
+## Success criteria
+
+- All 4 types (incl. `event_short`, `event_long`) with `generator_edge` < 24h stale.
+- Full refresher run < 60s total.
+- Per-cell `n` ≥ today's (no loss of statistical power; sampling removal should increase it).
+
+## Out of scope (deliberate)
+
+- Attributing edge by *current* `market_type` instead of frozen (separate follow-up).
+- Multiple horizons (schema supports it via `horizon_hours` PK component, but only 4h is built).
+- Touching live trading, gates, or the FLB executor (separate track).

--- a/packages/data-collector/src/database/init/035_generator_prediction_outcomes.sql
+++ b/packages/data-collector/src/database/init/035_generator_prediction_outcomes.sql
@@ -1,0 +1,42 @@
+-- Materialized 4h-forward outcomes for generator_predictions.
+--
+-- Root cause (daily-review #297, EXPLAIN ANALYZE 2026-06-02): the nightly
+-- EdgeCapacityRefresher recomputed a correlated price_history forward-seek per
+-- sampled prediction on every run, over compressed chunks → event_short/
+-- event_long exceeded the 600s cap. This table precomputes y1 (the YES price at
+-- prediction_time + horizon) ONCE, when the prediction matures, so the refresher
+-- reads a small purpose-built table instead. See
+-- docs/superpowers/specs/2026-06-02-edge-refresher-outcome-materialization-design.md
+--
+-- Denormalizes signal_id/direction/y0/market_type from generator_predictions.
+-- These are immutable at signal time (cold duplication, no divergence risk).
+-- market_type is stored frozen — exact parity with the refresher's current
+-- WHERE generator_predictions.market_type filter.
+
+CREATE TABLE IF NOT EXISTS generator_prediction_outcomes (
+    prediction_id    BIGINT NOT NULL,
+    prediction_time  TIMESTAMPTZ NOT NULL,
+    market_id        VARCHAR(128) NOT NULL,
+    market_type      VARCHAR(32),
+    signal_id        VARCHAR(50) NOT NULL,
+    direction        VARCHAR(8)  NOT NULL,
+    y0               NUMERIC(10,6) NOT NULL,
+    y1               NUMERIC(10,6),
+    horizon_hours    INT NOT NULL DEFAULT 4,
+    no_forward_price BOOLEAN NOT NULL DEFAULT FALSE,
+    computed_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- PK includes prediction_time: TimescaleDB requires the partition column in
+    -- every unique constraint. Mirrors generator_predictions' (time, id) PK.
+    PRIMARY KEY (prediction_time, prediction_id, horizon_hours)
+);
+
+SELECT create_hypertable('generator_prediction_outcomes', 'prediction_time',
+    chunk_time_interval => INTERVAL '1 day', if_not_exists => TRUE);
+
+-- Serves the refresher's WHERE market_type=$1 AND direction IN(...) AND
+-- prediction_time >= NOW()-7d filter directly (index-covering, no heap-fetch).
+CREATE INDEX IF NOT EXISTS idx_gpo_type_dir_time
+    ON generator_prediction_outcomes (market_type, direction, prediction_time DESC);
+
+ALTER TABLE generator_prediction_outcomes SET (timescaledb.compress_after = '3 days');
+SELECT add_retention_policy('generator_prediction_outcomes', INTERVAL '14 days', if_not_exists => TRUE);

--- a/packages/data-collector/src/services/EdgeCapacityRefresher.test.ts
+++ b/packages/data-collector/src/services/EdgeCapacityRefresher.test.ts
@@ -11,32 +11,17 @@ vi.mock('../database/connection.js', () => ({
 import { computeEdgeCapacity, refreshEdgeCapacity, getLatestEdgePerCell, resolveEdgeRefreshConfig } from './EdgeCapacityRefresher.js';
 import { query } from '../database/connection.js';
 
-describe('resolveEdgeRefreshConfig (env-overridable; #284-driven timeout bump)', () => {
-  // 2026-05-30: all 4 types timed out at the old 300s per-type cap under DB
-  // contention (cf #284) → 0 upserts → generator_edge stale ~33h. The cost is
-  // dominated by ORDER BY random() over the window, not sampleSize, so the fix
-  // is a higher (env-overridable) timeout, not a smaller sample.
-  it('empty env → defaults (sample 10000, timeout raised to 600s)', () => {
-    const got = resolveEdgeRefreshConfig({});
-    expect(got).toEqual({ sampleSize: 10000, perTypeTimeoutMs: 600_000 });
+describe('resolveEdgeRefreshConfig (env-overridable per-type timeout backstop)', () => {
+  it('empty env → default timeout 600s', () => {
+    expect(resolveEdgeRefreshConfig({})).toEqual({ perTypeTimeoutMs: 600_000 });
   });
-
-  it('valid env values are honored', () => {
-    const got = resolveEdgeRefreshConfig({
-      EDGE_REFRESH_SAMPLE_SIZE: '5000',
-      EDGE_REFRESH_PER_TYPE_TIMEOUT_MS: '900000',
-    });
-    expect(got).toEqual({ sampleSize: 5000, perTypeTimeoutMs: 900_000 });
+  it('valid env value is honored', () => {
+    expect(resolveEdgeRefreshConfig({ EDGE_REFRESH_PER_TYPE_TIMEOUT_MS: '900000' }))
+      .toEqual({ perTypeTimeoutMs: 900_000 });
   });
-
-  it('invalid env values (non-numeric, zero, negative) fall back to defaults', () => {
-    expect(resolveEdgeRefreshConfig({ EDGE_REFRESH_SAMPLE_SIZE: 'abc' }).sampleSize).toBe(10000);
+  it('invalid env values fall back to default', () => {
     expect(resolveEdgeRefreshConfig({ EDGE_REFRESH_PER_TYPE_TIMEOUT_MS: '0' }).perTypeTimeoutMs).toBe(600_000);
-    expect(resolveEdgeRefreshConfig({ EDGE_REFRESH_SAMPLE_SIZE: '-5' }).sampleSize).toBe(10000);
-  });
-
-  it('fractional env values are floored', () => {
-    expect(resolveEdgeRefreshConfig({ EDGE_REFRESH_SAMPLE_SIZE: '7500.9' }).sampleSize).toBe(7500);
+    expect(resolveEdgeRefreshConfig({ EDGE_REFRESH_PER_TYPE_TIMEOUT_MS: 'abc' }).perTypeTimeoutMs).toBe(600_000);
   });
 });
 
@@ -133,7 +118,7 @@ describe('refreshEdgeCapacity (integration, Phase 5 Pilar 1-A per-type sampling)
         ]};
       }
       // Per-type t-stat query: returns cells for the specific market_type param
-      if (typeof sql === 'string' && sql.includes('FROM generator_predictions')) {
+      if (typeof sql === 'string' && sql.includes('FROM generator_prediction_outcomes')) {
         const mt = String(params?.[0]);
         if (mt === 'crypto_intraday') {
           return { rows: [
@@ -170,7 +155,7 @@ describe('refreshEdgeCapacity (integration, Phase 5 Pilar 1-A per-type sampling)
           { market_type: 'event_financial' },
         ]};
       }
-      if (typeof sql === 'string' && sql.includes('FROM generator_predictions')) {
+      if (typeof sql === 'string' && sql.includes('FROM generator_prediction_outcomes')) {
         const mt = String(params?.[0]);
         if (mt === 'event_long') throw new Error('simulated DB error');
         return { rows: [
@@ -187,7 +172,7 @@ describe('refreshEdgeCapacity (integration, Phase 5 Pilar 1-A per-type sampling)
     expect(perType.has('event_financial')).toBe(true);
   });
 
-  it('passes window / horizon / sampleSize into the per-type SQL', async () => {
+  it('per-type SQL reads generator_prediction_outcomes with window + horizon filter, no price_history, no random()', async () => {
     const capturedSql: string[] = [];
     (query as any).mockImplementation(async (sql: string) => {
       if (typeof sql === 'string' && sql.includes('SELECT DISTINCT market_type')) {
@@ -197,35 +182,16 @@ describe('refreshEdgeCapacity (integration, Phase 5 Pilar 1-A per-type sampling)
       return { rows: [], rowCount: 0 };
     });
 
-    await refreshEdgeCapacity({ windowDays: 3, horizonHours: 6, minN: 100, sampleSize: 5000 });
+    await refreshEdgeCapacity({ windowDays: 3, horizonHours: 6, minN: 100 });
 
-    const selectStmt = capturedSql.find(s => s.includes('FROM generator_predictions'));
-    expect(selectStmt).toBeDefined();
-    expect(selectStmt).toContain("INTERVAL '3 days'");
-    expect(selectStmt).toContain("INTERVAL '6 hours'");
-    expect(selectStmt).toContain("INTERVAL '7 hours'");
-    // Single-scan Bernoulli sample (no full ORDER BY random() sort, which spilled
-    // to disk on the e2-micro and caused the 2026-05-30 timeout — see #288).
-    expect(selectStmt).toContain('random() < LEAST(1.0,');
-    expect(selectStmt).toContain('5000::float');
-    expect(selectStmt).not.toContain('ORDER BY random()');
-  });
-
-  it('uses sampleSize=10000 by default, via single-scan Bernoulli (not ORDER BY random)', async () => {
-    const capturedSql: string[] = [];
-    (query as any).mockImplementation(async (sql: string) => {
-      if (typeof sql === 'string' && sql.includes('SELECT DISTINCT market_type')) {
-        return { rows: [{ market_type: 'event_long' }] };
-      }
-      if (typeof sql === 'string') capturedSql.push(sql);
-      return { rows: [], rowCount: 0 };
-    });
-    await refreshEdgeCapacity();
-    const selectStmt = capturedSql.find(s => s.includes('FROM generator_predictions'));
-    expect(selectStmt).toContain('10000::float');
-    expect(selectStmt).not.toContain('ORDER BY random()');
-    // Bernoulli fraction is derived from a COUNT(*) of the same slice, capped at 1.0.
-    expect(selectStmt).toContain('SELECT COUNT(*) FROM generator_predictions');
+    const stmt = capturedSql.find(s => s.includes('FROM generator_prediction_outcomes'));
+    expect(stmt).toBeDefined();
+    expect(stmt).toContain("INTERVAL '3 days'");
+    expect(stmt).toContain('horizon_hours = 6');
+    expect(stmt).toContain('y1 IS NOT NULL');
+    expect(stmt).not.toContain('price_history');
+    expect(stmt).not.toContain('random()');
+    expect(stmt).not.toContain('FROM generator_predictions g');
   });
 
   // ─── Phase 5 Pilar 1-B: generator_edge persistence ──────────────────
@@ -235,7 +201,7 @@ describe('refreshEdgeCapacity (integration, Phase 5 Pilar 1-A per-type sampling)
       if (typeof sql === 'string' && sql.includes('SELECT DISTINCT market_type')) {
         return { rows: [{ market_type: 'event_long' }] };
       }
-      if (typeof sql === 'string' && sql.includes('FROM generator_predictions')) {
+      if (typeof sql === 'string' && sql.includes('FROM generator_prediction_outcomes')) {
         return { rows: [
           // cell with positive t_gross → t_net should be t_gross × (gross-rtPct)/gross
           { signal_id: 'spread_compression', market_type: 'event_long', direction: 'long', n: 99, gross_pct: 0.88, t_gross: 1.71 },
@@ -273,7 +239,7 @@ describe('refreshEdgeCapacity (integration, Phase 5 Pilar 1-A per-type sampling)
           { market_type: 'event_financial' },
         ]};
       }
-      if (typeof sql === 'string' && sql.includes('FROM generator_predictions')) {
+      if (typeof sql === 'string' && sql.includes('FROM generator_prediction_outcomes')) {
         queriedTypes.push(String(params?.[0]));
         return { rows: [
           { signal_id: 'momentum', market_type: String(params?.[0]), direction: 'long', n: 100, gross_pct: 0.5, t_gross: 2 },
@@ -299,7 +265,7 @@ describe('refreshEdgeCapacity (integration, Phase 5 Pilar 1-A per-type sampling)
       if (typeof sql === 'string' && sql.includes('SELECT DISTINCT market_type')) {
         return { rows: [{ market_type: 'crypto_daily' }, { market_type: 'event_long' }] };
       }
-      if (typeof sql === 'string' && sql.includes('FROM generator_predictions')) {
+      if (typeof sql === 'string' && sql.includes('FROM generator_prediction_outcomes')) {
         queriedTypes.push(String(params?.[0]));
         return { rows: [
           { signal_id: 'momentum', market_type: String(params?.[0]), direction: 'long', n: 100, gross_pct: 0.5, t_gross: 2 },
@@ -318,7 +284,7 @@ describe('refreshEdgeCapacity (integration, Phase 5 Pilar 1-A per-type sampling)
       if (typeof sql === 'string' && sql.includes('SELECT DISTINCT market_type')) {
         return { rows: [{ market_type: 'event_long' }] };
       }
-      if (typeof sql === 'string' && sql.includes('FROM generator_predictions')) {
+      if (typeof sql === 'string' && sql.includes('FROM generator_prediction_outcomes')) {
         return { rows: [
           { signal_id: 'mean_reversion', market_type: 'event_long', direction: 'long', n: 200, gross_pct: 0.5, t_gross: 3 },
         ]};

--- a/packages/data-collector/src/services/EdgeCapacityRefresher.test.ts
+++ b/packages/data-collector/src/services/EdgeCapacityRefresher.test.ts
@@ -105,7 +105,7 @@ describe('computeEdgeCapacity (TS port)', () => {
   });
 });
 
-describe('refreshEdgeCapacity (integration, Phase 5 Pilar 1-A per-type sampling)', () => {
+describe('refreshEdgeCapacity (integration, reads generator_prediction_outcomes)', () => {
   beforeEach(() => { vi.clearAllMocks(); });
 
   it('iterates types from markets and UPSERTs one row per type with measurable cells', async () => {

--- a/packages/data-collector/src/services/EdgeCapacityRefresher.ts
+++ b/packages/data-collector/src/services/EdgeCapacityRefresher.ts
@@ -71,11 +71,6 @@ export interface RefreshOptions {
   rtCostMap?: Map<string, number>;
   minN?: number;
   source?: string;
-  // Phase 5 Pilar 1-A (2026-05-15): per-type sampling avoids the LATERAL
-  // bulk-query timeout on e2-micro. Calibration found N=10k → 47-150s,
-  // 14 cells visible. The original bulk query never completed for event_long
-  // (122k predictions × per-row price seek).
-  sampleSize?: number;  // null/undefined = no sampling (full data, legacy)
   perTypeTimeoutMs?: number;  // skip a type that exceeds this; default 300s
   // If non-empty, only measure types in this list — skips non-traded types
   // (e.g. event_long) that always time out and waste the nightly cron window.
@@ -127,70 +122,25 @@ async function persistCellsToHistory(
 }
 
 /**
- * Build the t-stat SQL for a single market_type with optional sampling.
+ * Build the t-stat SQL for a single market_type, reading the precomputed
+ * generator_prediction_outcomes table (daily-review #297). No price_history
+ * seek, no sampling — the table is small and index-served by
+ * idx_gpo_type_dir_time. gross_edge uses y0/y1 already present per row.
  *
- * Sampling method (2026-05-30, replaces the original `ORDER BY random() LIMIT N`):
- * single-scan Bernoulli. The old approach materialised every row in the window,
- * assigned random() to each, and top-N sorted — an O(N log N) sort that on the
- * e2-micro (small work_mem) spilled to disk and blew past the 300s timeout for
- * all types on 2026-05-30 (#288 raised the cap; this removes the fixed cost).
- *
- * Instead we keep each row independently with probability `sampleSize / |slice|`
- * (capped at 1.0), where `|slice|` is a one-shot scalar COUNT(*) of the same
- * window/type/direction filter (a non-correlated InitPlan, evaluated once). No
- * sort, no full materialisation — two sequential scans of cost O(N). The sample
- * size is ~Binomial(|slice|, p) so it varies by ~√(Np(1-p)) (≈±1% at N=10k),
- * statistically equivalent to without-replacement sampling for the t-stat.
+ * `${marketType}` is NOT interpolated — it binds through $1. Only numeric
+ * server-controlled values (windowDays, horizonHours) interpolate.
  */
-function buildPerTypeSQL(marketType: string, windowDays: number, horizonHours: number, sampleSize: number | null): string {
-  const sampledCTE = sampleSize
-    ? `sampled AS (
-         SELECT g.id, g.signal_id, g.market_type, g.direction,
-                g.market_id, g.time, g.yes_price_at_signal
-         FROM generator_predictions g
-         WHERE g.time >= NOW() - INTERVAL '${windowDays} days'
-           AND g.direction IN ('long','short')
-           AND g.market_type = $1
-           AND random() < LEAST(1.0, ${sampleSize}::float / GREATEST((
-             SELECT COUNT(*) FROM generator_predictions gp
-             WHERE gp.time >= NOW() - INTERVAL '${windowDays} days'
-               AND gp.direction IN ('long','short')
-               AND gp.market_type = $1
-           )::float, 1))
-       )`
-    : `sampled AS (
-         SELECT g.id, g.signal_id, g.market_type, g.direction,
-                g.market_id, g.time, g.yes_price_at_signal
-         FROM generator_predictions g
-         WHERE g.time >= NOW() - INTERVAL '${windowDays} days'
-           AND g.direction IN ('long','short')
-           AND g.market_type = $1
-       )`;
-
-  // Note: `${marketType}` is NOT interpolated below — it goes through $1 binding
-  // to prevent SQL injection. Only numeric server-controlled values interpolate.
+function buildPerTypeSQL(marketType: string, windowDays: number, horizonHours: number): string {
   return `
-    WITH ${sampledCTE},
-    outcomes AS (
-      SELECT
-        s.signal_id,
-        s.market_type,
-        s.direction,
-        s.yes_price_at_signal::numeric AS y0,
-        (
-          SELECT p.close::numeric
-          FROM price_history p
-          WHERE p.market_id = s.market_id
-            AND p.time >= s.time + INTERVAL '${horizonHours} hours'
-            AND p.time <  s.time + INTERVAL '${horizonHours + 1} hours'
-          ORDER BY p.time ASC LIMIT 1
-        ) AS y1
-      FROM sampled s
-    ),
-    edges AS (
+    WITH edges AS (
       SELECT signal_id, market_type, direction,
              CASE WHEN direction='long' THEN y1 - y0 ELSE y0 - y1 END AS gross_edge
-      FROM outcomes WHERE y1 IS NOT NULL
+      FROM generator_prediction_outcomes
+      WHERE prediction_time >= NOW() - INTERVAL '${windowDays} days'
+        AND market_type = $1
+        AND direction IN ('long','short')
+        AND horizon_hours = ${horizonHours}
+        AND y1 IS NOT NULL
     )
     SELECT
       signal_id, market_type, direction,
@@ -216,10 +166,9 @@ async function measureCellsForType(
   marketType: string,
   windowDays: number,
   horizonHours: number,
-  sampleSize: number | null,
   timeoutMs: number,
 ): Promise<Cell[] | null> {
-  const sql = buildPerTypeSQL(marketType, windowDays, horizonHours, sampleSize);
+  const sql = buildPerTypeSQL(marketType, windowDays, horizonHours);
   const start = Date.now();
   try {
     // Race the query against a timeout. If the timeout fires first we reject
@@ -324,19 +273,19 @@ export async function getLatestEdgePerCell(): Promise<Array<{
  * config out) so it is unit-testable without process/timing mocks. Invalid
  * values (non-numeric, ≤0) fall back to the calibrated defaults.
  *
- * - `EDGE_REFRESH_SAMPLE_SIZE` (default 10000) — predictions sampled per type.
- * - `EDGE_REFRESH_PER_TYPE_TIMEOUT_MS` (default 600000) — per-type query cap;
- *   raised from 300s after the 2026-05-30 stall (#284 DB contention).
+ * - `EDGE_REFRESH_PER_TYPE_TIMEOUT_MS` (default 600000) — per-type query cap.
+ *   A safety backstop only: now that the per-type query reads the precomputed
+ *   generator_prediction_outcomes table (no price_history seek, no sampling),
+ *   it is no longer the binding constraint.
  */
 export function resolveEdgeRefreshConfig(
   env: Record<string, string | undefined> = process.env,
-): { sampleSize: number; perTypeTimeoutMs: number } {
+): { perTypeTimeoutMs: number } {
   const posIntOr = (raw: string | undefined, def: number): number => {
     const n = Number(raw);
     return Number.isFinite(n) && n > 0 ? Math.floor(n) : def;
   };
   return {
-    sampleSize: posIntOr(env.EDGE_REFRESH_SAMPLE_SIZE, 10000),
     perTypeTimeoutMs: posIntOr(env.EDGE_REFRESH_PER_TYPE_TIMEOUT_MS, 600_000),
   };
 }
@@ -350,19 +299,9 @@ export async function refreshEdgeCapacity(options: RefreshOptions = {}): Promise
   const horizonHours = options.horizonHours ?? 4;
   const defaultRt = options.defaultRtCost ?? 0.01;
   const minN = options.minN ?? 50;
-  const sampleSize = options.sampleSize ?? 10000;  // Pilar 1-A default
-  // Default raised 300s → 600s on 2026-05-30 (#288). The TRUE per-type cost
-  // (root-caused 2026-06-01, #294) was the missing index on
-  // generator_predictions(market_type, direction, time): both the COUNT(*)
-  // InitPlan and the `sampled` scan seq-scanned the FULL 7-day window across
-  // all types (~320MB on e2-micro) to filter one type. Migration 034 adds that
-  // index → event_short dropped >600s timeout → ~41s. With the index, the cap
-  // is no longer the binding constraint; it remains a safety backstop. Lowering
-  // sampleSize would only cut statistical power and is NOT the right lever.
-  // See resolveEdgeRefreshConfig for the env overrides.
   const perTypeTimeoutMs = options.perTypeTimeoutMs ?? 600_000;  // 10 min
   const source = options.source ??
-    `EdgeCapacityRefresher cron ${new Date().toISOString().slice(0, 10)} (sample N=${sampleSize})`;
+    `EdgeCapacityRefresher cron ${new Date().toISOString().slice(0, 10)} (full)`;
 
   // Discover types that have any active markets — there's no point measuring
   // a cohort with zero supply (Phase 4 lesson: crypto_intraday went from 2.14
@@ -385,7 +324,7 @@ export async function refreshEdgeCapacity(options: RefreshOptions = {}): Promise
   const skipped: string[] = [];
 
   for (const marketType of types) {
-    const cells = await measureCellsForType(marketType, windowDays, horizonHours, sampleSize, perTypeTimeoutMs);
+    const cells = await measureCellsForType(marketType, windowDays, horizonHours, perTypeTimeoutMs);
     if (cells === null) {
       skipped.push(marketType);
       continue;
@@ -403,7 +342,7 @@ export async function refreshEdgeCapacity(options: RefreshOptions = {}): Promise
     // Best-effort; failure to insert one row should NOT abort the type.
     const rtForType = options.rtCostMap?.get(marketType) ?? defaultRt;
     await persistCellsToHistory(
-      cells, rtForType, windowDays, horizonHours, sampleSize, source, minN,
+      cells, rtForType, windowDays, horizonHours, null, source, minN,
     ).catch((err) => {
       logger.warn({ marketType, err: (err as Error).message }, 'persistCellsToHistory failed (non-fatal)');
     });
@@ -433,7 +372,7 @@ export async function refreshEdgeCapacity(options: RefreshOptions = {}): Promise
   }
 
   logger.info(
-    { upserts, types: [...perTypeAcc.keys()], skipped, sampleSize, perTypeTimeoutMs },
+    { upserts, types: [...perTypeAcc.keys()], skipped, perTypeTimeoutMs },
     'edge_capacity refreshed',
   );
   return { upserts, perType: perTypeAcc, skipped };

--- a/packages/data-collector/src/services/EdgeCapacityRefresher.ts
+++ b/packages/data-collector/src/services/EdgeCapacityRefresher.ts
@@ -206,14 +206,12 @@ async function measureCellsForType(
 }
 
 /**
- * Refresh `market_type_edge_capacity` table by iterating over distinct
- * market_types with active markets, sampling N=sampleSize predictions per
- * type, and upserting the computed edge_capacity. Returns the upserted
- * entries (useful for tests + logging).
- *
- * Phase 5 Pilar 1-A (2026-05-15): rewrote from bulk-query to per-type
- * sampling. Calibrated N=10000 takes 47-150s/type on e2-micro. perTypeTimeoutMs
- * caps each type at 300s so a slow type doesn't block the others.
+ * Refresh `market_type_edge_capacity` by iterating over distinct market_types
+ * with active markets, reading the precomputed generator_prediction_outcomes
+ * table per type (daily-review #297 — no sampling, no price_history seek), and
+ * upserting the computed edge_capacity. Returns the upserted entries (useful
+ * for tests + logging). perTypeTimeoutMs is a safety backstop only (the read is
+ * now index-served and fast).
  */
 /**
  * Phase 5 Pilar 1-B reporting helper: latest measurement per (signal, type,

--- a/packages/data-collector/src/services/MarketPerformanceTracker.test.ts
+++ b/packages/data-collector/src/services/MarketPerformanceTracker.test.ts
@@ -202,6 +202,21 @@ describe('materializePredictionOutcomes', () => {
     expect(inserts).toHaveLength(0);
   });
 
+  it('the pending-select excludes already-materialized predictions (idempotency guard)', async () => {
+    let pendingSql = '';
+    (query as any).mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM generator_predictions g')) {
+        pendingSql = sql;
+        return { rows: [] };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+    await materializePredictionOutcomes();
+    expect(pendingSql).toContain('NOT EXISTS');
+    expect(pendingSql).toContain('FROM generator_prediction_outcomes o');
+    expect(pendingSql).toContain('o.prediction_id = g.id');
+  });
+
   it('a failing forward-seek does not abort the batch', async () => {
     let inserts = 0;
     (query as any).mockImplementation(async (sql: string) => {

--- a/packages/data-collector/src/services/MarketPerformanceTracker.test.ts
+++ b/packages/data-collector/src/services/MarketPerformanceTracker.test.ts
@@ -6,7 +6,7 @@ vi.mock('../database/connection.js', () => ({
 }));
 
 import { query } from '../database/connection.js';
-import { updateShadowCategoryPerformance } from './MarketPerformanceTracker.js';
+import { updateShadowCategoryPerformance, materializePredictionOutcomes } from './MarketPerformanceTracker.js';
 
 describe('computePrior', () => {
   it('returns 1.0 for sharpe = 0 (neutral)', () => {
@@ -118,5 +118,106 @@ describe('updateShadowCategoryPerformance', () => {
     await updateShadowCategoryPerformance();
 
     expect(query).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('materializePredictionOutcomes', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('materializes a matured prediction with a forward price', async () => {
+    const inserts: any[][] = [];
+    (query as any).mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('FROM generator_predictions g')) {
+        return { rows: [{
+          id: '101', time: new Date('2026-06-02T00:00:00Z'), market_id: 'm1',
+          market_type: 'event_short', signal_id: 'momentum', direction: 'long',
+          yes_price_at_signal: '0.40', age_hours: '6',
+        }]};
+      }
+      if (sql.includes('FROM price_history')) {
+        return { rows: [{ close: 0.47 }] };
+      }
+      if (sql.startsWith('INSERT INTO generator_prediction_outcomes')) {
+        inserts.push(params ?? []);
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const res = await materializePredictionOutcomes();
+    expect(res.materialized).toBe(1);
+    expect(res.noPrice).toBe(0);
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0][0]).toBe('101');
+    expect(inserts[0][7]).toBe(0.47);          // y1
+    expect(inserts[0][9]).toBe(false);         // no_forward_price
+  });
+
+  it('marks no_forward_price=true when matured >8h with no forward price', async () => {
+    const inserts: any[][] = [];
+    (query as any).mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('FROM generator_predictions g')) {
+        return { rows: [{
+          id: '102', time: new Date('2026-06-01T00:00:00Z'), market_id: 'm2',
+          market_type: 'event_long', signal_id: 'ofi', direction: 'short',
+          yes_price_at_signal: '0.30', age_hours: '20',
+        }]};
+      }
+      if (sql.includes('FROM price_history')) return { rows: [] };
+      if (sql.startsWith('INSERT INTO generator_prediction_outcomes')) {
+        inserts.push(params ?? []);
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const res = await materializePredictionOutcomes();
+    expect(res.materialized).toBe(0);
+    expect(res.noPrice).toBe(1);
+    expect(inserts[0][7]).toBe(null);          // y1
+    expect(inserts[0][9]).toBe(true);          // no_forward_price
+  });
+
+  it('skips a matured-but-young prediction (<8h) with no price yet (retried later)', async () => {
+    const inserts: any[][] = [];
+    (query as any).mockImplementation(async (sql: string, params?: unknown[]) => {
+      if (sql.includes('FROM generator_predictions g')) {
+        return { rows: [{
+          id: '103', time: new Date('2026-06-02T06:00:00Z'), market_id: 'm3',
+          market_type: 'event_short', signal_id: 'hawkes', direction: 'long',
+          yes_price_at_signal: '0.50', age_hours: '6',
+        }]};
+      }
+      if (sql.includes('FROM price_history')) return { rows: [] };
+      if (sql.startsWith('INSERT INTO generator_prediction_outcomes')) {
+        inserts.push(params ?? []);
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    const res = await materializePredictionOutcomes();
+    expect(res.materialized).toBe(0);
+    expect(res.noPrice).toBe(0);
+    expect(inserts).toHaveLength(0);
+  });
+
+  it('a failing forward-seek does not abort the batch', async () => {
+    let inserts = 0;
+    (query as any).mockImplementation(async (sql: string) => {
+      if (sql.includes('FROM generator_predictions g')) {
+        return { rows: [
+          { id: '201', time: new Date('2026-06-02T00:00:00Z'), market_id: 'mA', market_type: 'event_short', signal_id: 's', direction: 'long', yes_price_at_signal: '0.4', age_hours: '6' },
+          { id: '202', time: new Date('2026-06-02T00:00:00Z'), market_id: 'mB', market_type: 'event_short', signal_id: 's', direction: 'long', yes_price_at_signal: '0.4', age_hours: '6' },
+        ]};
+      }
+      if (sql.includes('FROM price_history')) {
+        throw new Error('simulated seek failure');
+      }
+      if (sql.startsWith('INSERT INTO generator_prediction_outcomes')) { inserts++; return { rows: [], rowCount: 1 }; }
+      return { rows: [], rowCount: 0 };
+    });
+    await expect(materializePredictionOutcomes()).resolves.toBeDefined();
+    expect(inserts).toBe(0);
   });
 });

--- a/packages/data-collector/src/services/MarketPerformanceTracker.ts
+++ b/packages/data-collector/src/services/MarketPerformanceTracker.ts
@@ -101,6 +101,98 @@ export async function resolveShadowTrades(): Promise<void> {
   logger.info({ resolved: result.rows.length }, 'Shadow trades resolved');
 }
 
+/**
+ * Phase 5 / daily-review #297: materialize the 4h-forward outcome (y1) per
+ * generator_prediction ONCE, when it matures, into generator_prediction_outcomes.
+ * The nightly EdgeCapacityRefresher then reads that table instead of recomputing
+ * a correlated price_history seek per sampled row over compressed chunks (the
+ * >600s timeout root cause). Idempotent via NOT EXISTS; runs hourly on hot data.
+ *
+ * Maturity rule:
+ *  - age < horizon+1h         → not selected (too young to have a forward price).
+ *  - horizon+1h ≤ age < 8h, no price → left unwritten, retried next run (price
+ *                              may arrive late after a transient collector gap).
+ *  - age ≥ 8h, no price       → written with y1=NULL, no_forward_price=true
+ *                              (processed; never retried — market stopped quoting/resolved).
+ *  - price found              → written with y1, no_forward_price=false.
+ */
+export async function materializePredictionOutcomes(
+  opts: { horizonHours?: number } = {},
+): Promise<{ materialized: number; noPrice: number }> {
+  const horizon = opts.horizonHours ?? 4;
+
+  const pending = await query<{
+    id: string;
+    time: Date;
+    market_id: string;
+    market_type: string | null;
+    signal_id: string;
+    direction: string;
+    yes_price_at_signal: string;
+    age_hours: string;
+  }>(
+    `SELECT g.id, g.time, g.market_id, g.market_type, g.signal_id, g.direction,
+            g.yes_price_at_signal,
+            EXTRACT(EPOCH FROM (NOW() - g.time)) / 3600.0 AS age_hours
+     FROM generator_predictions g
+     WHERE g.time >= NOW() - INTERVAL '8 days'
+       AND g.time <  NOW() - INTERVAL '${horizon + 1} hours'
+       AND g.direction IN ('long','short')
+       AND NOT EXISTS (
+         SELECT 1 FROM generator_prediction_outcomes o
+         WHERE o.prediction_id = g.id AND o.horizon_hours = $1
+       )`,
+    [horizon],
+  );
+
+  if (pending.rows.length === 0) {
+    return { materialized: 0, noPrice: 0 };
+  }
+
+  logger.info({ count: pending.rows.length, horizon }, 'Materializing prediction outcomes');
+
+  let materialized = 0;
+  let noPrice = 0;
+
+  for (const row of pending.rows) {
+    try {
+      const fwd = await query<{ close: number }>(
+        `SELECT close::float AS close FROM price_history
+         WHERE market_id = $1
+           AND time >= $2::timestamptz + INTERVAL '${horizon} hours'
+           AND time <  $2::timestamptz + INTERVAL '${horizon + 1} hours'
+         ORDER BY time ASC LIMIT 1`,
+        [row.market_id, row.time],
+      );
+
+      const y1 = fwd.rows.length > 0 ? Number(fwd.rows[0].close) : null;
+      const ageHours = Number(row.age_hours);
+
+      if (y1 === null && ageHours < 8) {
+        continue;
+      }
+
+      await query(
+        `INSERT INTO generator_prediction_outcomes
+           (prediction_id, prediction_time, market_id, market_type, signal_id,
+            direction, y0, y1, horizon_hours, no_forward_price)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+         ON CONFLICT (prediction_time, prediction_id, horizon_hours) DO NOTHING`,
+        [row.id, row.time, row.market_id, row.market_type, row.signal_id,
+         row.direction, Number(row.yes_price_at_signal), y1, horizon, y1 === null],
+      );
+
+      if (y1 === null) noPrice++; else materialized++;
+    } catch (err) {
+      logger.warn({ predictionId: row.id, err: (err as Error).message },
+        'materializePredictionOutcomes: row failed (non-fatal)');
+    }
+  }
+
+  logger.info({ materialized, noPrice }, 'Prediction outcomes materialized');
+  return { materialized, noPrice };
+}
+
 export async function updateShadowCategoryPerformance(): Promise<void> {
   const haircutRaw = parseFloat(process.env.SHADOW_HAIRCUT ?? '0.33');
   const minN = parseInt(process.env.CATEGORY_MIN_SHADOW_N ?? '30', 10);

--- a/packages/data-collector/src/services/Scheduler.test.ts
+++ b/packages/data-collector/src/services/Scheduler.test.ts
@@ -18,7 +18,7 @@ vi.mock('./EdgeCapacityRefresher.js', () => ({
   refreshEdgeCapacity: vi.fn().mockResolvedValue({ upserts: 0, perType: new Map() }),
   // Scheduler.refreshEdgeCapacity() resolves env-overridable knobs through this
   // before invoking refreshEdgeCapacity (#284 timeout fix).
-  resolveEdgeRefreshConfig: vi.fn().mockReturnValue({ sampleSize: 10000, perTypeTimeoutMs: 600_000 }),
+  resolveEdgeRefreshConfig: vi.fn().mockReturnValue({ perTypeTimeoutMs: 600_000 }),
 }));
 
 // Mock GammaCollector module so syncResolvedMarkets tests don't hit network/DB.

--- a/packages/data-collector/src/services/Scheduler.test.ts
+++ b/packages/data-collector/src/services/Scheduler.test.ts
@@ -5,6 +5,13 @@ vi.mock('../database/connection.js', () => ({
   getPool: vi.fn(),
 }));
 
+vi.mock('./MarketPerformanceTracker.js', () => ({
+  updateCategoryPriors: vi.fn().mockResolvedValue(undefined),
+  updateShadowCategoryPerformance: vi.fn().mockResolvedValue(undefined),
+  resolveShadowTrades: vi.fn().mockResolvedValue(undefined),
+  materializePredictionOutcomes: vi.fn().mockResolvedValue({ materialized: 0, noPrice: 0 }),
+}));
+
 // Mock the EdgeCapacityRefresher module so runJob('refresh-edge-capacity')
 // can be exercised without hitting the real SQL pipeline.
 vi.mock('./EdgeCapacityRefresher.js', () => ({
@@ -24,6 +31,7 @@ import { computeRealizedVolatility } from './Scheduler.js';
 import { Scheduler } from './Scheduler.js';
 import { refreshEdgeCapacity } from './EdgeCapacityRefresher.js';
 import * as gammaModule from '../collectors/GammaCollector.js';
+import { materializePredictionOutcomes } from './MarketPerformanceTracker.js';
 
 describe('computeRealizedVolatility', () => {
   beforeEach(() => {
@@ -102,5 +110,22 @@ describe('Scheduler — sync-resolved-markets uses resolveOurMarkets', () => {
     // not just the handler body.
     await scheduler.runJob('sync-resolved-markets');
     expect(resolveOurMarkets).toHaveBeenCalled();
+  });
+});
+
+describe('Scheduler — materialize-prediction-outcomes cron', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('runJob("materialize-prediction-outcomes") invokes materializePredictionOutcomes', async () => {
+    const scheduler = new Scheduler();
+    await scheduler.runJob('materialize-prediction-outcomes');
+    expect(materializePredictionOutcomes).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers the job at hourly :15', () => {
+    const scheduler = new Scheduler();
+    const job = (scheduler as any).jobs.get('materialize-prediction-outcomes');
+    expect(job).toBeDefined();
+    expect(job.schedule).toBe('15 * * * *');
   });
 });

--- a/packages/data-collector/src/services/Scheduler.ts
+++ b/packages/data-collector/src/services/Scheduler.ts
@@ -13,6 +13,7 @@ import {
   updateCategoryPriors,
   updateShadowCategoryPerformance,
   resolveShadowTrades,
+  materializePredictionOutcomes,
 } from './MarketPerformanceTracker.js';
 import { refreshEdgeCapacity, resolveEdgeRefreshConfig } from './EdgeCapacityRefresher.js';
 import { NewsCollector } from '../collectors/NewsCollector.js';
@@ -117,6 +118,10 @@ export class Scheduler {
     // before compute-market-priors so both data sources are fresh for the next
     // MarketScorer cycle. See docs/plans/2026-05-13-phase4-edge-aware-scorer-design.md.
     this.defineJob('refresh-edge-capacity', '30 2 * * *', this.refreshEdgeCapacity.bind(this));  // Daily at 02:30 UTC
+    // daily-review #297: materialize 4h-forward outcomes hourly so the nightly
+    // refresher reads a precomputed table instead of a per-row price_history
+    // seek. :15 to avoid colliding with the :00/:30 jobs.
+    this.defineJob('materialize-prediction-outcomes', '15 * * * *', this.materializePredictionOutcomes.bind(this));
     this.defineJob('collect-news', '*/15 * * * *', this.collectNews.bind(this));  // News pipeline every 15 minutes
     this.defineJob('compute-realized-volatility', '*/15 * * * *', computeRealizedVolatility);  // Every 15 min
   }
@@ -270,6 +275,9 @@ export class Scheduler {
           // fell through to 'No handler for job' (lastDuration=0ms, no
           // upserts). Discovered 2026-05-15 in the daily-autoreview validation.
           await this.refreshEdgeCapacity();
+          break;
+        case 'materialize-prediction-outcomes':
+          await this.materializePredictionOutcomes();
           break;
         case 'collect-news':
           await this.collectNews();
@@ -552,6 +560,14 @@ export class Scheduler {
       perTypeTimeoutMs,
       allowedTypes,
     });
+  }
+
+  /**
+   * daily-review #297: incremental materialization of generator_prediction_outcomes.
+   * Hourly at :15. Cheap (only matured-in-last-hour predictions on hot data).
+   */
+  private async materializePredictionOutcomes(): Promise<void> {
+    await materializePredictionOutcomes();
   }
 
   /**

--- a/packages/data-collector/src/services/Scheduler.ts
+++ b/packages/data-collector/src/services/Scheduler.ts
@@ -539,10 +539,10 @@ export class Scheduler {
    * later pass a measured per-type cost map from scripts/measure-rt-cost.js.
    */
   private async refreshEdgeCapacity(): Promise<void> {
-    // sampleSize / perTypeTimeoutMs are env-overridable (defaults 10000 / 600s).
-    // The 300s default timed out all types on 2026-05-30 under DB contention
-    // (#284) → 0 upserts → generator_edge stale. See resolveEdgeRefreshConfig.
-    const { sampleSize, perTypeTimeoutMs } = resolveEdgeRefreshConfig();
+    // perTypeTimeoutMs is env-overridable (default 600s) — a safety backstop now
+    // that the per-type query reads generator_prediction_outcomes (no
+    // price_history seek, no sampling). See resolveEdgeRefreshConfig.
+    const { perTypeTimeoutMs } = resolveEdgeRefreshConfig();
     // Edge-measurement scope is decoupled from the LIVE trade allowlist
     // (ALLOWED_MARKET_TYPES). #290 tied the two purely to dodge event_long's
     // 600s timeout; migration 034's generator_predictions(market_type,direction,
@@ -556,7 +556,6 @@ export class Scheduler {
       horizonHours: 4,
       defaultRtCost: 0.01,
       minN: 50,
-      sampleSize,
       perTypeTimeoutMs,
       allowedTypes,
     });

--- a/scripts/backfill-prediction-outcomes.js
+++ b/scripts/backfill-prediction-outcomes.js
@@ -25,7 +25,8 @@ async function main() {
 
   const pending = await pool.query(
     `SELECT g.id, g.time, g.market_id, g.market_type, g.signal_id, g.direction,
-            g.yes_price_at_signal
+            g.yes_price_at_signal,
+            EXTRACT(EPOCH FROM (NOW() - g.time)) / 3600.0 AS age_hours
      FROM generator_predictions g
      WHERE g.time >= NOW() - INTERVAL '${windowDays} days'
        AND g.time <  NOW() - INTERVAL '${horizon + 1} hours'
@@ -51,6 +52,10 @@ async function main() {
         [row.market_id, row.time],
       );
       const y1 = fwd.rows.length > 0 ? Number(fwd.rows[0].close) : null;
+      const ageHours = Number(row.age_hours);
+      if (y1 === null && ageHours < 8) {
+        continue; // too young to give up; the hourly job will retry once matured
+      }
       await pool.query(
         `INSERT INTO generator_prediction_outcomes
            (prediction_id, prediction_time, market_id, market_type, signal_id,

--- a/scripts/backfill-prediction-outcomes.js
+++ b/scripts/backfill-prediction-outcomes.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * One-shot backfill for generator_prediction_outcomes (daily-review #297).
+ *
+ * Run ONCE on the VM after deploying the materialization job + creating the
+ * table, to fill the initial 7-day window the EdgeCapacityRefresher reads.
+ * This pass touches compressed price_history chunks (expensive), so it runs
+ * offline without the cron's 600s cap. The hourly job keeps the table current
+ * thereafter.
+ *
+ *   NODE_TLS_REJECT_UNAUTHORIZED=0 DATABASE_URL="postgres://..." \
+ *     node scripts/backfill-prediction-outcomes.js [--window-days 8] [--horizon 4]
+ */
+const { Pool } = require('pg');
+
+function arg(name, def) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : def;
+}
+
+async function main() {
+  const windowDays = parseInt(arg('window-days', '8'), 10);
+  const horizon = parseInt(arg('horizon', '4'), 10);
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+  const pending = await pool.query(
+    `SELECT g.id, g.time, g.market_id, g.market_type, g.signal_id, g.direction,
+            g.yes_price_at_signal
+     FROM generator_predictions g
+     WHERE g.time >= NOW() - INTERVAL '${windowDays} days'
+       AND g.time <  NOW() - INTERVAL '${horizon + 1} hours'
+       AND g.direction IN ('long','short')
+       AND NOT EXISTS (
+         SELECT 1 FROM generator_prediction_outcomes o
+         WHERE o.prediction_id = g.id AND o.horizon_hours = $1
+       )`,
+    [horizon],
+  );
+
+  console.log(`Backfilling ${pending.rows.length} predictions (window ${windowDays}d, horizon ${horizon}h)`);
+  let materialized = 0, noPrice = 0, errors = 0;
+
+  for (const row of pending.rows) {
+    try {
+      const fwd = await pool.query(
+        `SELECT close::float AS close FROM price_history
+         WHERE market_id = $1
+           AND time >= $2::timestamptz + INTERVAL '${horizon} hours'
+           AND time <  $2::timestamptz + INTERVAL '${horizon + 1} hours'
+         ORDER BY time ASC LIMIT 1`,
+        [row.market_id, row.time],
+      );
+      const y1 = fwd.rows.length > 0 ? Number(fwd.rows[0].close) : null;
+      await pool.query(
+        `INSERT INTO generator_prediction_outcomes
+           (prediction_id, prediction_time, market_id, market_type, signal_id,
+            direction, y0, y1, horizon_hours, no_forward_price)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+         ON CONFLICT (prediction_time, prediction_id, horizon_hours) DO NOTHING`,
+        [row.id, row.time, row.market_id, row.market_type, row.signal_id,
+         row.direction, Number(row.yes_price_at_signal), y1, horizon, y1 === null],
+      );
+      if (y1 === null) noPrice++; else materialized++;
+      if ((materialized + noPrice) % 5000 === 0) {
+        console.log(`  ... ${materialized + noPrice}/${pending.rows.length}`);
+      }
+    } catch (e) {
+      errors++;
+      if (errors <= 10) console.error(`  row ${row.id} failed: ${e.message}`);
+    }
+  }
+
+  console.log(`Done: materialized=${materialized} noPrice=${noPrice} errors=${errors}`);
+  await pool.end();
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Problem

Daily-review **#297** flagged the long-running `event_short`/`event_long` `generator_edge` staleness (5 days) as still unfixed despite PRs #288/#289/#290/#295. **EXPLAIN ANALYZE on the VM proved the carry-over from #294 REFUTED**: PR #295's index fixed only the `COUNT(*)` InitPlan (80ms). The dominant costs the index never touched:

1. **Sampled CTE scan ~40s** — Index *Scan* (not Index-Only) heap-fetching all ~171k `event_short` rows (projects non-indexed columns + `random()` post-heap Filter). *This 40s was exactly what #294 mistook for the whole query.*
2. **`price_history` 4h-forward correlated subquery × ~10k sampled rows** over compressed chunks (est. cost 1.27M) — the bulk of the >600s.

`event_short` (largest cohort, 171,835 preds/7d) times out where `event_financial` (508s) doesn't.

## Fix (structural — design + plan in `docs/superpowers/`)

Precompute each prediction's 4h-forward outcome **once**, when it matures, into a new hypertable `generator_prediction_outcomes` (migration 035), via an hourly incremental job (`materializePredictionOutcomes`, mirroring `resolveShadowTrades`). The job seeks on **hot/uncompressed** data (cheap). The refresher's `buildPerTypeSQL` is rewritten to read **only** that table — no `price_history` seek, no `random()` sampling. Sampling removal also raises per-cell `n` and makes the measurement deterministic.

## Changes
- `035_generator_prediction_outcomes.sql` — hypertable + `(market_type,direction,prediction_time)` index + compress(3d) + retention(14d).
- `materializePredictionOutcomes()` — idempotent (`NOT EXISTS`), maturity/no-forward-price rules, per-row try/catch.
- Hourly cron `materialize-prediction-outcomes` (`15 * * * *`) + runJob case (avoids the #224 silent-no-op bug).
- `buildPerTypeSQL` rewritten; `sampleSize`/`EDGE_REFRESH_SAMPLE_SIZE` removed; `resolveEdgeRefreshConfig` returns only `perTypeTimeoutMs`.
- `scripts/backfill-prediction-outcomes.js` — one-shot offline backfill (with the 8h no-price gate).

## Tests
42 tests across 3 suites pass; `tsc --noEmit` clean. Edge math is bit-for-bit parity with the original (verified by final review).

## Not in scope / honest framing
This restores edge **observability** (prerequisite to discover tradeable cells); it does **not** open trades by itself (`event_short` blocked both dirs #275/#277, `event_long` shadow-only).

## Deploy (post-merge, manual — Task 6 of the plan)
1. Create table+index manually on VM (init SQL only runs on fresh volume).
2. Run `backfill-prediction-outcomes.js` (fills 7d window).
3. Verify next 02:30 UTC cron: `generator_edge` < 24h fresh for all 4 types + **full** refresher run < 60s (measure the whole query, not a sub-part — the #297 lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edge capacity refresh reliability by eliminating sampling and optimizing queries through precomputed prediction outcomes, reducing timeout issues.

* **New Features**
  * Introduced hourly prediction outcome materialization to automatically precompute and cache 4-hour forward outcomes.

* **Documentation**
  * Added design documentation and implementation plan for the outcome materialization system.

* **Chores**
  * Added database schema and backfill utilities for prediction outcome materialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->