### PR TITLE
fix(edge-refresher): bulk-batched materialization (row-at-a-time saturated e2-micro)

### DIFF
--- a/packages/data-collector/src/services/MarketPerformanceTracker.test.ts
+++ b/packages/data-collector/src/services/MarketPerformanceTracker.test.ts
@@ -121,118 +121,68 @@ describe('updateShadowCategoryPerformance', () => {
   });
 });
 
-describe('materializePredictionOutcomes', () => {
+describe('materializePredictionOutcomes (bulk, batched — 2026-06-02 scale fix)', () => {
   beforeEach(() => { vi.clearAllMocks(); });
 
-  it('materializes a matured prediction with a forward price', async () => {
-    const inserts: any[][] = [];
-    (query as any).mockImplementation(async (sql: string, params?: unknown[]) => {
-      if (sql.includes('FROM generator_predictions g')) {
-        return { rows: [{
-          id: '101', time: new Date('2026-06-02T00:00:00Z'), market_id: 'm1',
-          market_type: 'event_short', signal_id: 'momentum', direction: 'long',
-          yes_price_at_signal: '0.40', age_hours: '6',
-        }]};
-      }
-      if (sql.includes('FROM price_history')) {
-        return { rows: [{ close: 0.47 }] };
-      }
-      if (sql.startsWith('INSERT INTO generator_prediction_outcomes')) {
-        inserts.push(params ?? []);
-        return { rows: [], rowCount: 1 };
+  it('counts materialized (y1 present) vs noPrice (no_forward_price) from the bulk INSERT RETURNING', async () => {
+    let calls = 0;
+    (query as any).mockImplementation(async (sql: string) => {
+      if (sql.includes('INSERT INTO generator_prediction_outcomes')) {
+        calls++;
+        return { rows: [{ no_price: false }, { no_price: false }, { no_price: true }] };
       }
       return { rows: [], rowCount: 0 };
     });
-
-    const res = await materializePredictionOutcomes();
-    expect(res.materialized).toBe(1);
-    expect(res.noPrice).toBe(0);
-    expect(inserts).toHaveLength(1);
-    expect(inserts[0][0]).toBe('101');
-    expect(inserts[0][7]).toBe(0.47);          // y1
-    expect(inserts[0][9]).toBe(false);         // no_forward_price
-  });
-
-  it('marks no_forward_price=true when matured >8h with no forward price', async () => {
-    const inserts: any[][] = [];
-    (query as any).mockImplementation(async (sql: string, params?: unknown[]) => {
-      if (sql.includes('FROM generator_predictions g')) {
-        return { rows: [{
-          id: '102', time: new Date('2026-06-01T00:00:00Z'), market_id: 'm2',
-          market_type: 'event_long', signal_id: 'ofi', direction: 'short',
-          yes_price_at_signal: '0.30', age_hours: '20',
-        }]};
-      }
-      if (sql.includes('FROM price_history')) return { rows: [] };
-      if (sql.startsWith('INSERT INTO generator_prediction_outcomes')) {
-        inserts.push(params ?? []);
-        return { rows: [], rowCount: 1 };
-      }
-      return { rows: [], rowCount: 0 };
-    });
-
-    const res = await materializePredictionOutcomes();
-    expect(res.materialized).toBe(0);
+    const res = await materializePredictionOutcomes({ batchSize: 5000 });
+    expect(res.materialized).toBe(2);
     expect(res.noPrice).toBe(1);
-    expect(inserts[0][7]).toBe(null);          // y1
-    expect(inserts[0][9]).toBe(true);          // no_forward_price
+    expect(res.batches).toBe(1);   // 3 rows < batchSize → drained after one batch
+    expect(calls).toBe(1);         // ONE server-side query, not per-row round trips
   });
 
-  it('skips a matured-but-young prediction (<8h) with no price yet (retried later)', async () => {
-    const inserts: any[][] = [];
-    (query as any).mockImplementation(async (sql: string, params?: unknown[]) => {
-      if (sql.includes('FROM generator_predictions g')) {
-        return { rows: [{
-          id: '103', time: new Date('2026-06-02T06:00:00Z'), market_id: 'm3',
-          market_type: 'event_short', signal_id: 'hawkes', direction: 'long',
-          yes_price_at_signal: '0.50', age_hours: '6',
-        }]};
-      }
-      if (sql.includes('FROM price_history')) return { rows: [] };
-      if (sql.startsWith('INSERT INTO generator_prediction_outcomes')) {
-        inserts.push(params ?? []);
-        return { rows: [], rowCount: 1 };
+  it('does the work server-side: one bulk INSERT...SELECT...LEFT JOIN LATERAL with the idempotency + maturity guards', async () => {
+    let sqlSeen = '';
+    (query as any).mockImplementation(async (sql: string) => {
+      if (sql.includes('INSERT INTO generator_prediction_outcomes')) { sqlSeen = sql; return { rows: [] }; }
+      return { rows: [], rowCount: 0 };
+    });
+    await materializePredictionOutcomes({ horizonHours: 4 });
+    expect(sqlSeen).toContain('LEFT JOIN LATERAL');
+    expect(sqlSeen).toContain('FROM price_history');
+    expect(sqlSeen).toContain('NOT EXISTS');
+    expect(sqlSeen).toContain('FROM generator_prediction_outcomes o');
+    expect(sqlSeen).toContain('o.prediction_id = g.id');
+    expect(sqlSeen).toContain('LIMIT');
+    expect(sqlSeen).toContain("INTERVAL '8 hours'");  // verdict age = horizon(4) + 4
+    expect(sqlSeen).toContain("INTERVAL '4 hours'");  // forward window start
+    expect(sqlSeen).toContain("INTERVAL '5 hours'");  // forward window end
+  });
+
+  it('caps work at maxBatches when every batch comes back full (does not drain the whole backlog in one tick)', async () => {
+    let calls = 0;
+    (query as any).mockImplementation(async (sql: string) => {
+      if (sql.includes('INSERT INTO generator_prediction_outcomes')) {
+        calls++;
+        return { rows: [{ no_price: false }, { no_price: false }] };  // full batch (== batchSize)
       }
       return { rows: [], rowCount: 0 };
     });
+    const res = await materializePredictionOutcomes({ batchSize: 2, maxBatches: 3 });
+    expect(calls).toBe(3);          // stopped by maxBatches, NOT by drain
+    expect(res.batches).toBe(3);
+    expect(res.materialized).toBe(6);
+  });
 
+  it('stops immediately when the first batch is empty (no backlog)', async () => {
+    let calls = 0;
+    (query as any).mockImplementation(async (sql: string) => {
+      if (sql.includes('INSERT INTO generator_prediction_outcomes')) { calls++; return { rows: [] }; }
+      return { rows: [], rowCount: 0 };
+    });
     const res = await materializePredictionOutcomes();
+    expect(calls).toBe(1);
+    expect(res.batches).toBe(0);
     expect(res.materialized).toBe(0);
     expect(res.noPrice).toBe(0);
-    expect(inserts).toHaveLength(0);
-  });
-
-  it('the pending-select excludes already-materialized predictions (idempotency guard)', async () => {
-    let pendingSql = '';
-    (query as any).mockImplementation(async (sql: string) => {
-      if (sql.includes('FROM generator_predictions g')) {
-        pendingSql = sql;
-        return { rows: [] };
-      }
-      return { rows: [], rowCount: 0 };
-    });
-    await materializePredictionOutcomes();
-    expect(pendingSql).toContain('NOT EXISTS');
-    expect(pendingSql).toContain('FROM generator_prediction_outcomes o');
-    expect(pendingSql).toContain('o.prediction_id = g.id');
-  });
-
-  it('a failing forward-seek does not abort the batch', async () => {
-    let inserts = 0;
-    (query as any).mockImplementation(async (sql: string) => {
-      if (sql.includes('FROM generator_predictions g')) {
-        return { rows: [
-          { id: '201', time: new Date('2026-06-02T00:00:00Z'), market_id: 'mA', market_type: 'event_short', signal_id: 's', direction: 'long', yes_price_at_signal: '0.4', age_hours: '6' },
-          { id: '202', time: new Date('2026-06-02T00:00:00Z'), market_id: 'mB', market_type: 'event_short', signal_id: 's', direction: 'long', yes_price_at_signal: '0.4', age_hours: '6' },
-        ]};
-      }
-      if (sql.includes('FROM price_history')) {
-        throw new Error('simulated seek failure');
-      }
-      if (sql.startsWith('INSERT INTO generator_prediction_outcomes')) { inserts++; return { rows: [], rowCount: 1 }; }
-      return { rows: [], rowCount: 0 };
-    });
-    await expect(materializePredictionOutcomes()).resolves.toBeDefined();
-    expect(inserts).toBe(0);
   });
 });

--- a/packages/data-collector/src/services/MarketPerformanceTracker.ts
+++ b/packages/data-collector/src/services/MarketPerformanceTracker.ts
@@ -106,91 +106,88 @@ export async function resolveShadowTrades(): Promise<void> {
  * generator_prediction ONCE, when it matures, into generator_prediction_outcomes.
  * The nightly EdgeCapacityRefresher then reads that table instead of recomputing
  * a correlated price_history seek per sampled row over compressed chunks (the
- * >600s timeout root cause). Idempotent via NOT EXISTS; runs hourly on hot data.
+ * >600s timeout root cause). Idempotent via NOT EXISTS.
  *
- * Maturity rule:
- *  - age < horizon+1h         → not selected (too young to have a forward price).
- *  - horizon+1h ≤ age < 8h, no price → left unwritten, retried next run (price
- *                              may arrive late after a transient collector gap).
- *  - age ≥ 8h, no price       → written with y1=NULL, no_forward_price=true
- *                              (processed; never retried — market stopped quoting/resolved).
- *  - price found              → written with y1, no_forward_price=false.
+ * SCALE LESSON (2026-06-02 deploy): the first version did one round-trip JS
+ * seek per prediction. Against the real backlog (~557k rows over 8d) that melted
+ * the e2-micro (load avg 19, ~2 rows materialized). This version does the work
+ * SERVER-SIDE in bulk via `INSERT ... SELECT ... LEFT JOIN LATERAL`, and caps
+ * each invocation at `maxBatches × batchSize` rows so the backlog drains over a
+ * few hours of hourly ticks without saturating the VM. In steady state only the
+ * ~hour's worth of newly-matured rows remain, so a single small batch suffices.
+ *
+ * Maturity rule (simplified to avoid re-selecting young no-price rows every tick):
+ *  - age < horizon+4h  → not selected yet (waits for a later tick).
+ *  - age ≥ horizon+4h  → written: y1 if a forward price exists, else
+ *                        y1=NULL, no_forward_price=true (terminal, never retried).
  */
 export async function materializePredictionOutcomes(
-  opts: { horizonHours?: number } = {},
-): Promise<{ materialized: number; noPrice: number }> {
+  opts: { horizonHours?: number; batchSize?: number; maxBatches?: number } = {},
+): Promise<{ materialized: number; noPrice: number; batches: number }> {
   const horizon = opts.horizonHours ?? 4;
-
-  const pending = await query<{
-    id: string;
-    time: Date;
-    market_id: string;
-    market_type: string | null;
-    signal_id: string;
-    direction: string;
-    yes_price_at_signal: string;
-    age_hours: string;
-  }>(
-    `SELECT g.id, g.time, g.market_id, g.market_type, g.signal_id, g.direction,
-            g.yes_price_at_signal,
-            EXTRACT(EPOCH FROM (NOW() - g.time)) / 3600.0 AS age_hours
-     FROM generator_predictions g
-     WHERE g.time >= NOW() - INTERVAL '8 days'
-       AND g.time <  NOW() - INTERVAL '${horizon + 1} hours'
-       AND g.direction IN ('long','short')
-       AND NOT EXISTS (
-         SELECT 1 FROM generator_prediction_outcomes o
-         WHERE o.prediction_id = g.id AND o.horizon_hours = $1
-       )`,
-    [horizon],
-  );
-
-  if (pending.rows.length === 0) {
-    return { materialized: 0, noPrice: 0 };
-  }
-
-  logger.info({ count: pending.rows.length, horizon }, 'Materializing prediction outcomes');
+  const batchSize = opts.batchSize ?? 5000;
+  const maxBatches = opts.maxBatches ?? 4;
+  // Rows reach a verdict once the [+horizon, +horizon+1h) forward window is well
+  // in the past. horizon+4h gives a comfortable margin for late-arriving prices.
+  const verdictAgeHours = horizon + 4;
 
   let materialized = 0;
   let noPrice = 0;
+  let batches = 0;
 
-  for (const row of pending.rows) {
-    try {
-      const fwd = await query<{ close: number }>(
-        `SELECT close::float AS close FROM price_history
-         WHERE market_id = $1
-           AND time >= $2::timestamptz + INTERVAL '${horizon} hours'
-           AND time <  $2::timestamptz + INTERVAL '${horizon + 1} hours'
-         ORDER BY time ASC LIMIT 1`,
-        [row.market_id, row.time],
-      );
-
-      const y1 = fwd.rows.length > 0 ? Number(fwd.rows[0].close) : null;
-      const ageHours = Number(row.age_hours);
-
-      if (y1 === null && ageHours < 8) {
-        continue;
-      }
-
-      await query(
-        `INSERT INTO generator_prediction_outcomes
+  for (let b = 0; b < maxBatches; b++) {
+    const res = await query<{ no_price: boolean }>(
+      `WITH batch AS (
+         SELECT g.id, g.time, g.market_id, g.market_type, g.signal_id,
+                g.direction, g.yes_price_at_signal
+         FROM generator_predictions g
+         WHERE g.time >= NOW() - INTERVAL '8 days'
+           AND g.time <  NOW() - INTERVAL '${verdictAgeHours} hours'
+           AND g.direction IN ('long','short')
+           AND NOT EXISTS (
+             SELECT 1 FROM generator_prediction_outcomes o
+             WHERE o.prediction_id = g.id AND o.horizon_hours = $1
+           )
+         ORDER BY g.time
+         LIMIT ${batchSize}
+       ),
+       resolved AS (
+         SELECT b.*, fwd.close AS y1
+         FROM batch b
+         LEFT JOIN LATERAL (
+           SELECT p.close FROM price_history p
+           WHERE p.market_id = b.market_id
+             AND p.time >= b.time + INTERVAL '${horizon} hours'
+             AND p.time <  b.time + INTERVAL '${horizon + 1} hours'
+           ORDER BY p.time ASC LIMIT 1
+         ) fwd ON true
+       ),
+       ins AS (
+         INSERT INTO generator_prediction_outcomes
            (prediction_id, prediction_time, market_id, market_type, signal_id,
             direction, y0, y1, horizon_hours, no_forward_price)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
-         ON CONFLICT (prediction_time, prediction_id, horizon_hours) DO NOTHING`,
-        [row.id, row.time, row.market_id, row.market_type, row.signal_id,
-         row.direction, Number(row.yes_price_at_signal), y1, horizon, y1 === null],
-      );
+         SELECT id, time, market_id, market_type, signal_id, direction,
+                yes_price_at_signal::numeric, y1::numeric, $1, (y1 IS NULL)
+         FROM resolved
+         ON CONFLICT (prediction_time, prediction_id, horizon_hours) DO NOTHING
+         RETURNING no_forward_price AS no_price
+       )
+       SELECT no_price FROM ins`,
+      [horizon],
+    );
 
-      if (y1 === null) noPrice++; else materialized++;
-    } catch (err) {
-      logger.warn({ predictionId: row.id, err: (err as Error).message },
-        'materializePredictionOutcomes: row failed (non-fatal)');
+    if (res.rows.length === 0) break;
+    batches++;
+    for (const r of res.rows) {
+      if (r.no_price) noPrice++; else materialized++;
     }
+    if (res.rows.length < batchSize) break;  // backlog drained
   }
 
-  logger.info({ materialized, noPrice }, 'Prediction outcomes materialized');
-  return { materialized, noPrice };
+  if (batches > 0) {
+    logger.info({ materialized, noPrice, batches, batchSize }, 'Prediction outcomes materialized');
+  }
+  return { materialized, noPrice, batches };
 }
 
 export async function updateShadowCategoryPerformance(): Promise<void> {

--- a/scripts/backfill-prediction-outcomes.js
+++ b/scripts/backfill-prediction-outcomes.js
@@ -1,15 +1,18 @@
 #!/usr/bin/env node
 /**
- * One-shot backfill for generator_prediction_outcomes (daily-review #297).
+ * Throttled one-shot backfill for generator_prediction_outcomes (daily-review #297).
  *
- * Run ONCE on the VM after deploying the materialization job + creating the
- * table, to fill the initial 7-day window the EdgeCapacityRefresher reads.
- * This pass touches compressed price_history chunks (expensive), so it runs
- * offline without the cron's 600s cap. The hourly job keeps the table current
- * thereafter.
+ * Bulk, server-side INSERT...SELECT...LEFT JOIN LATERAL in batches with a pause
+ * between them. The FIRST version did a per-row JS round-trip seek and melted the
+ * e2-micro on the ~557k backlog (load avg 19, ~2 rows/min). This version pushes
+ * the work into ONE SQL statement per batch and sleeps between batches so the VM
+ * stays responsive. The hourly `materializePredictionOutcomes` job also drains the
+ * backlog on its own (capped per tick); this script just speeds up the initial fill.
+ *
+ * Safe to run detached on the VM. Tune --batch / --sleep-ms down if load climbs.
  *
  *   NODE_TLS_REJECT_UNAUTHORIZED=0 DATABASE_URL="postgres://..." \
- *     node scripts/backfill-prediction-outcomes.js [--window-days 8] [--horizon 4]
+ *     node scripts/backfill-prediction-outcomes.js [--window-days 8] [--horizon 4] [--batch 5000] [--sleep-ms 10000]
  */
 const { Pool } = require('pg');
 
@@ -17,65 +20,70 @@ function arg(name, def) {
   const i = process.argv.indexOf(`--${name}`);
   return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : def;
 }
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 async function main() {
   const windowDays = parseInt(arg('window-days', '8'), 10);
   const horizon = parseInt(arg('horizon', '4'), 10);
+  const batchSize = parseInt(arg('batch', '5000'), 10);
+  const sleepMs = parseInt(arg('sleep-ms', '10000'), 10);
+  const verdictAge = horizon + 4;
   const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
-  const pending = await pool.query(
-    `SELECT g.id, g.time, g.market_id, g.market_type, g.signal_id, g.direction,
-            g.yes_price_at_signal,
-            EXTRACT(EPOCH FROM (NOW() - g.time)) / 3600.0 AS age_hours
-     FROM generator_predictions g
-     WHERE g.time >= NOW() - INTERVAL '${windowDays} days'
-       AND g.time <  NOW() - INTERVAL '${horizon + 1} hours'
-       AND g.direction IN ('long','short')
-       AND NOT EXISTS (
-         SELECT 1 FROM generator_prediction_outcomes o
-         WHERE o.prediction_id = g.id AND o.horizon_hours = $1
-       )`,
-    [horizon],
-  );
+  console.log(`Backfill start: window ${windowDays}d, horizon ${horizon}h, batch ${batchSize}, sleep ${sleepMs}ms`);
+  let totalMat = 0, totalNoPrice = 0, batch = 0;
 
-  console.log(`Backfilling ${pending.rows.length} predictions (window ${windowDays}d, horizon ${horizon}h)`);
-  let materialized = 0, noPrice = 0, errors = 0;
-
-  for (const row of pending.rows) {
-    try {
-      const fwd = await pool.query(
-        `SELECT close::float AS close FROM price_history
-         WHERE market_id = $1
-           AND time >= $2::timestamptz + INTERVAL '${horizon} hours'
-           AND time <  $2::timestamptz + INTERVAL '${horizon + 1} hours'
-         ORDER BY time ASC LIMIT 1`,
-        [row.market_id, row.time],
-      );
-      const y1 = fwd.rows.length > 0 ? Number(fwd.rows[0].close) : null;
-      const ageHours = Number(row.age_hours);
-      if (y1 === null && ageHours < 8) {
-        continue; // too young to give up; the hourly job will retry once matured
-      }
-      await pool.query(
-        `INSERT INTO generator_prediction_outcomes
+  for (;;) {
+    const res = await pool.query(
+      `WITH batch AS (
+         SELECT g.id, g.time, g.market_id, g.market_type, g.signal_id,
+                g.direction, g.yes_price_at_signal
+         FROM generator_predictions g
+         WHERE g.time >= NOW() - INTERVAL '${windowDays} days'
+           AND g.time <  NOW() - INTERVAL '${verdictAge} hours'
+           AND g.direction IN ('long','short')
+           AND NOT EXISTS (
+             SELECT 1 FROM generator_prediction_outcomes o
+             WHERE o.prediction_id = g.id AND o.horizon_hours = $1
+           )
+         ORDER BY g.time
+         LIMIT ${batchSize}
+       ),
+       resolved AS (
+         SELECT b.*, fwd.close AS y1
+         FROM batch b
+         LEFT JOIN LATERAL (
+           SELECT p.close FROM price_history p
+           WHERE p.market_id = b.market_id
+             AND p.time >= b.time + INTERVAL '${horizon} hours'
+             AND p.time <  b.time + INTERVAL '${horizon + 1} hours'
+           ORDER BY p.time ASC LIMIT 1
+         ) fwd ON true
+       ),
+       ins AS (
+         INSERT INTO generator_prediction_outcomes
            (prediction_id, prediction_time, market_id, market_type, signal_id,
             direction, y0, y1, horizon_hours, no_forward_price)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
-         ON CONFLICT (prediction_time, prediction_id, horizon_hours) DO NOTHING`,
-        [row.id, row.time, row.market_id, row.market_type, row.signal_id,
-         row.direction, Number(row.yes_price_at_signal), y1, horizon, y1 === null],
-      );
-      if (y1 === null) noPrice++; else materialized++;
-      if ((materialized + noPrice) % 5000 === 0) {
-        console.log(`  ... ${materialized + noPrice}/${pending.rows.length}`);
-      }
-    } catch (e) {
-      errors++;
-      if (errors <= 10) console.error(`  row ${row.id} failed: ${e.message}`);
-    }
+         SELECT id, time, market_id, market_type, signal_id, direction,
+                yes_price_at_signal::numeric, y1::numeric, $1, (y1 IS NULL)
+         FROM resolved
+         ON CONFLICT (prediction_time, prediction_id, horizon_hours) DO NOTHING
+         RETURNING no_forward_price AS no_price
+       )
+       SELECT no_price FROM ins`,
+      [horizon],
+    );
+
+    if (res.rows.length === 0) break;
+    batch++;
+    totalNoPrice += res.rows.filter((r) => r.no_price).length;
+    totalMat += res.rows.filter((r) => !r.no_price).length;
+    console.log(`  batch ${batch}: +${res.rows.length} (materialized=${totalMat} noPrice=${totalNoPrice})`);
+    if (res.rows.length < batchSize) break;
+    await sleep(sleepMs);
   }
 
-  console.log(`Done: materialized=${materialized} noPrice=${noPrice} errors=${errors}`);
+  console.log(`Done: materialized=${totalMat} noPrice=${totalNoPrice} batches=${batch}`);
   await pool.end();
 }
 


### PR DESCRIPTION
## Incident (deploy of #298)
The row-at-a-time `materializePredictionOutcomes` did one JS round-trip `price_history` seek per prediction. Against the real backlog (**557,948 rows / 8d**, not the ~tens-of-thousands estimated) it saturated the e2-micro (**load avg 19**, ~2 rows materialized) and the hourly cron + backfill would each repeat it.

## Fix
- **Bulk server-side** `INSERT ... SELECT ... LEFT JOIN LATERAL` — one statement per batch, no per-row round trips.
- **Capped per invocation** at `maxBatches × batchSize` (default 4×5000) so each hourly tick is bounded; the backlog drains over a few hours instead of melting the VM in one go. Steady state only has ~an hour's matured rows.
- **Maturity simplified** to `age ≥ horizon+4h` (verdict written: `y1`, else `no_forward_price=true`) — avoids re-selecting young no-price rows every tick.
- **Backfill script** likewise bulk + throttled (sleep between batches), safe to run detached.

14 tests pass, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced data materialization performance through optimized batch processing.
  * Added configurable tuning options for backfill operations to support better resource management.
  * Improved handling of edge cases when forward-price data is unavailable.
  * Added progress tracking metrics for backfill operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->