### PR TITLE
fix(migration-035): supported TimescaleDB compression syntax (compress_after rejected)

### DIFF
--- a/packages/data-collector/src/database/init/035_generator_prediction_outcomes.sql
+++ b/packages/data-collector/src/database/init/035_generator_prediction_outcomes.sql
@@ -38,5 +38,16 @@ SELECT create_hypertable('generator_prediction_outcomes', 'prediction_time',
 CREATE INDEX IF NOT EXISTS idx_gpo_type_dir_time
     ON generator_prediction_outcomes (market_type, direction, prediction_time DESC);
 
-ALTER TABLE generator_prediction_outcomes SET (timescaledb.compress_after = '3 days');
+-- Compression. NOTE: the `timescaledb.compress_after` table option used by the
+-- older migrations (003_retention_policies.sql, 030_generator_predictions.sql)
+-- is REJECTED by the TimescaleDB version now running on the VM
+-- ("unrecognized parameter timescaledb.compress_after"; verified 2026-06-02 when
+-- this migration first ran). Those tables were compressed when the original
+-- volume was initialised under an older version; a fresh volume today would
+-- silently skip their compression. The current, supported form is: enable
+-- compression on the table, then attach a time-based policy.
+ALTER TABLE generator_prediction_outcomes
+    SET (timescaledb.compress, timescaledb.compress_orderby = 'prediction_time DESC');
+SELECT add_compression_policy('generator_prediction_outcomes', INTERVAL '3 days', if_not_exists => TRUE);
+
 SELECT add_retention_policy('generator_prediction_outcomes', INTERVAL '14 days', if_not_exists => TRUE);


### PR DESCRIPTION
## What
Migration `035_generator_prediction_outcomes.sql` used `SET (timescaledb.compress_after = '3 days')`, which the TimescaleDB version on the VM **rejects** (`unrecognized parameter "timescaledb.compress_after"`). Discovered 2026-06-02 when 035 first ran — compression silently failed (fixed live on the VM via `add_compression_policy`; this brings the repo in line so a fresh volume gets it too).

Switched to the supported form:
```sql
ALTER TABLE ... SET (timescaledb.compress, timescaledb.compress_orderby = 'prediction_time DESC');
SELECT add_compression_policy(..., INTERVAL '3 days', if_not_exists => TRUE);
```

## Latent issue flagged (not fixed here)
`003_retention_policies.sql` (6 tables) and `030_generator_predictions.sql` use the same obsolete `compress_after` option. They were compressed when the original volume was initialised under an older TimescaleDB, so prod is fine — but **a fresh volume today would silently skip their compression**. A cleanup of 003/030 (each needs its time column for `compress_orderby`) is left as a separate, deliberate change. Comment in 035 documents this.

## Runtime impact
None immediate — the live VM already has correct compression on this table. This only affects fresh-volume re-inits. No deploy required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)