### PR TITLE
fix(migrations-003-030): supported TimescaleDB compression syntax

### DIFF
--- a/packages/data-collector/src/database/init/003_retention_policies.sql
+++ b/packages/data-collector/src/database/init/003_retention_policies.sql
@@ -6,36 +6,40 @@
 -- COMPRESSION SETTINGS (More Aggressive)
 -- ============================================
 
--- Enable compression on all hypertables with shorter intervals
+-- Enable compression on all hypertables, then attach a time-based policy.
+--
+-- NOTE (2026-06-02, daily-review #297 / migration 035): the original
+-- `timescaledb.compress_after` table option is REJECTED by the TimescaleDB
+-- version now running on the VM ("unrecognized parameter
+-- timescaledb.compress_after"). These tables were compressed when the original
+-- volume was initialised under an older version, so PROD is fine — but a fresh
+-- volume today would silently skip compression here. The supported form is
+-- `SET (timescaledb.compress, compress_orderby=...)` + add_compression_policy.
+-- All these hypertables partition on the `time` column.
+
 -- Price history: compress after 3 days (was 7)
-ALTER TABLE price_history SET (
-  timescaledb.compress_after = '3 days'
-);
+ALTER TABLE price_history SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
+SELECT add_compression_policy('price_history', INTERVAL '3 days', if_not_exists => TRUE);
 
 -- Orderbook snapshots: compress after 1 day (most voluminous)
-ALTER TABLE orderbook_snapshots SET (
-  timescaledb.compress_after = '1 day'
-);
+ALTER TABLE orderbook_snapshots SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
+SELECT add_compression_policy('orderbook_snapshots', INTERVAL '1 day', if_not_exists => TRUE);
 
 -- Trades: compress after 3 days
-ALTER TABLE trades SET (
-  timescaledb.compress_after = '3 days'
-);
+ALTER TABLE trades SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
+SELECT add_compression_policy('trades', INTERVAL '3 days', if_not_exists => TRUE);
 
 -- Paper equity history: compress after 7 days
-ALTER TABLE paper_equity_history SET (
-  timescaledb.compress_after = '7 days'
-);
+ALTER TABLE paper_equity_history SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
+SELECT add_compression_policy('paper_equity_history', INTERVAL '7 days', if_not_exists => TRUE);
 
 -- Signal predictions: compress after 3 days
-ALTER TABLE signal_predictions SET (
-  timescaledb.compress_after = '3 days'
-);
+ALTER TABLE signal_predictions SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
+SELECT add_compression_policy('signal_predictions', INTERVAL '3 days', if_not_exists => TRUE);
 
 -- Strategy performance log: compress after 7 days
-ALTER TABLE strategy_performance_log SET (
-  timescaledb.compress_after = '7 days'
-);
+ALTER TABLE strategy_performance_log SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
+SELECT add_compression_policy('strategy_performance_log', INTERVAL '7 days', if_not_exists => TRUE);
 
 -- ============================================
 -- RETENTION POLICIES (Auto-delete old data)

--- a/packages/data-collector/src/database/init/030_generator_predictions.sql
+++ b/packages/data-collector/src/database/init/030_generator_predictions.sql
@@ -40,8 +40,12 @@ CREATE INDEX IF NOT EXISTS idx_gen_predictions_market_time
 
 -- ~110k rows/day at full universe (35 markets x 11 generators x 12 cycles/h x 24h).
 -- 30-day retention keeps the table around 3.3M rows / ~250 MB compressed.
-ALTER TABLE generator_predictions SET (
-    timescaledb.compress_after = '3 days'
-);
+--
+-- NOTE (2026-06-02, daily-review #297 / migration 035): the `compress_after`
+-- table option is rejected by the current TimescaleDB version. Prod is already
+-- compressed from the original older-version init; this only matters for a fresh
+-- volume. Use SET (timescaledb.compress, compress_orderby=...) + policy instead.
+ALTER TABLE generator_predictions SET (timescaledb.compress, timescaledb.compress_orderby = 'time DESC');
+SELECT add_compression_policy('generator_predictions', INTERVAL '3 days', if_not_exists => TRUE);
 
 SELECT add_retention_policy('generator_predictions', INTERVAL '30 days', if_not_exists => TRUE);


### PR DESCRIPTION
## What
Completes the cleanup flagged by #300 (migration 035). Replaces the obsolete `SET (timescaledb.compress_after = ...)` option — rejected by the TimescaleDB version on the VM as an "unrecognized parameter" — with the supported form across:
- **003_retention_policies.sql**: all 6 hypertables (`price_history`, `orderbook_snapshots`, `trades`, `paper_equity_history`, `signal_predictions`, `strategy_performance_log`)
- **030_generator_predictions.sql**: `generator_predictions`

All partition on the `time` column → `compress_orderby = 'time DESC'`, plus `add_compression_policy(..., if_not_exists => TRUE)`.

## Runtime impact
**None — latent-only.** These tables are already compressed in prod from the original older-version volume init, and init SQL does not re-run on an existing volume. This only ensures a FRESH volume re-init compresses them correctly (today it would silently skip them). No deploy needed for correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)