### PR TITLE
feat(flb): record realistic per-signal spread cost in shadow recorder

### DIFF
--- a/docs/superpowers/specs/2026-06-03-flb-paper-executor-design.md
+++ b/docs/superpowers/specs/2026-06-03-flb-paper-executor-design.md
@@ -309,8 +309,46 @@ REJECTED log format so the daily-review gate-fire-log query picks it up).
   paper positions remain and reconcile to resolution as designed (or are simply left — paper).
 - Code revert: separate PR; do NOT drop `flb_positions` (historical record).
 
-## 11. Verdict query (unchanged — segment by cohort)
-The build does not change the decision gate. The tradeable-cohort verdict (n ≥ 100, net ≥ +1%,
-parametric t ≥ 2 with a confirming bootstrap, plus a hold-aware annualised hurdle) remains the
-condition for *live* promotion, run on `flb_shadow_signals` AND now cross-checkable against the
-realistic-cost `flb_positions` track. Never read the pooled row as the verdict.
+## 11. Verdict query — segment by cohort AND use realistic cost
+
+The tradeable-cohort verdict (n ≥ 100, net ≥ +1%, parametric t ≥ 2 with a confirming bootstrap,
+plus a hold-aware annualised hurdle) remains the condition for *live* promotion. Two hard rules,
+both learned the hard way:
+
+1. **Never read the pooled row as the verdict** (the tradeable cohort is ~96% diluted by
+   shadow-only event_long).
+2. **Read `net_pnl_real` on the enterable subset, NOT the flat-cost `net_pnl`.** The shadow
+   recorder records both: `net_pnl` charges a flat 0.54%; `net_pnl_real = win_or_wipeout −
+   (entry_spread/2)/(1−entry_yes)` charges the actual per-signal spread, and `entry_cost_real`
+   is that spread cost. The verdict filters to `entry_cost_real <= FLB_MAX_ENTRY_COST_PCT/100`
+   (the executor's flb_0d ceiling), because the executor would not enter wider-spread signals.
+
+> **Empirical warning (2026-06-03, n=133 forward resolved).** At the flat 0.54% cost the pooled
+> forward read was +3.0%/t=2.78 — but it was an artefact. Re-costed realistically and filtered to
+> enterable signals: all 5 event_financial signals are un-enterable (real cost 5–9% ≫ 1%), and
+> the 45 enterable event_long signals average **+0.05% (≈0), P(edge>0)≈0.5**. A cheaper-sub-band
+> sweep (`scripts/flb-subband-sweep.py`) found no clean positive sub-band. The realistic-cost
+> forward edge is **not demonstrated** (not refuted either: tiny n, 2 wipeouts, in-sample +2.24%
+> stands). Hierarchical partial-pooling analysis: `scripts/flb-hierarchical-edge.py`.
+
+```sql
+WITH resolved AS (
+  SELECT net_pnl_real AS net, hold_days,
+         CASE WHEN market_type = 'event_long' THEN 'event_long (shadow-only)'
+              ELSE 'TRADEABLE (cd/ef/es)' END AS cohort
+  FROM flb_shadow_signals
+  WHERE resolved_at IS NOT NULL
+    AND entry_cost_real IS NOT NULL
+    AND entry_cost_real <= 0.01            -- executor flb_0d enterable filter
+)
+SELECT cohort, COUNT(*) n,
+       ROUND(AVG(net)::numeric, 4) avg_net_real,
+       ROUND(STDDEV_SAMP(net)::numeric, 4) sd,
+       ROUND((AVG(net) / NULLIF(STDDEV_SAMP(net) / SQRT(COUNT(*)), 0))::numeric, 2) t,
+       COUNT(*) FILTER (WHERE net > 0) wins,
+       ROUND(percentile_cont(0.5) WITHIN GROUP (ORDER BY hold_days)::numeric, 1) median_hold_days
+FROM resolved GROUP BY cohort ORDER BY cohort;
+```
+
+Also run a bootstrap on `net_pnl_real` (~10,000 resamples) — the −100% tail breaks the
+parametric t. If parametric t ≥ 2 but bootstrap P(mean>0) is not high, do NOT build.

--- a/scripts/flb-hierarchical-edge.py
+++ b/scripts/flb-hierarchical-edge.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+flb-hierarchical-edge.py
+
+Hierarchical (partial-pooling) Bayesian estimate of the per-trade FLB net edge
+per market type, from forward `flb_shadow_signals` resolutions.
+
+Why: the tradeable cohort (crypto_daily / event_financial / event_short) has too
+few resolved signals (n=5, all event_financial) to verdict on its own, while
+event_long has 128. Fully pooling them is the documented false-confidence trap;
+treating them as independent throws away the structural evidence that the
+favorite-longshot bias appears in every event type with similar monotonic
+calibration. Partial pooling is the principled middle: each type's estimate
+borrows from the others to the degree the data say they're similar.
+
+Model (eight-schools / Normal-Normal):
+    ybar_j ~ Normal(theta_j, se_j^2)          # group sample mean
+    theta_j ~ Normal(mu, tau^2)               # types drawn from a population
+    mu  ~ flat ;  tau ~ HalfNormal(0, s_tau)  # s_tau = pooling-strength prior
+
+HONESTY CHOICES (read these):
+ 1. se_j uses a POOLED per-trade variance, NOT each type's own sample sd. The
+    -100% wipeout tail (~1 in 27) is structural and has NOT yet occurred in the
+    5 event_financial trades, so event_financial's own sd is optimistically
+    small. Using the pooled sd (dominated by event_long, which HAS wipeouts)
+    stops 5 lucky draws from claiming false precision.
+ 2. Types with 0 resolutions (crypto_daily, event_short) contribute no
+    likelihood; their theta is a pure population prediction N(mu, tau^2) — i.e.
+    "we are extrapolating from other types", made explicit.
+ 3. tau (between-type heterogeneity) is barely identified with only 2 data-
+    bearing groups, so we report 3 tau-priors (tight/medium/loose) to show how
+    much the answer rests on the similarity assumption rather than data.
+
+Integration is a deterministic 2-D grid over (mu, tau) — no RNG, fully
+reproducible. Per-type theta posteriors are exact grid-weighted normal mixtures.
+
+Usage:  python scripts/flb-hierarchical-edge.py [flb_resolved.csv]
+CSV cols (no header): market_type, net_pnl, entry_yes_price, hold_days
+"""
+import sys
+import numpy as np
+
+COST_HURDLE = 0.01          # build gate: avg_net >= +1% per trade
+SHADOW_FLAT_COST = 0.0054   # the flat entry cost baked into flb_shadow_signals.net_pnl
+MAX_ENTRY_COST = 0.01       # executor flb_0d ceiling (FLB_MAX_ENTRY_COST_PCT=1.0%)
+TRADEABLE = {"crypto_daily", "event_financial", "event_short"}
+CSV = sys.argv[1] if len(sys.argv) > 1 else "flb_resolved.csv"
+
+
+def load(path):
+    """Read rows, re-cost net_pnl with the REAL per-signal half-spread, and keep
+    only signals the live executor would actually enter (flb_0d: cost<=1%, book
+    present). Returns (types, realistic_net) for survivors + a drop report."""
+    types, net, dropped = [], [], {}
+    kept_by_type, seen_by_type = {}, {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            mtype, pnl_s, yes_s, spread_s = line.split(",")[:4]
+            seen_by_type[mtype] = seen_by_type.get(mtype, 0) + 1
+            stored_net = float(pnl_s)
+            yes = float(yes_s)
+            if spread_s == "":          # no book / un-priceable -> executor rejects
+                dropped[mtype] = dropped.get(mtype, 0) + 1
+                continue
+            spread = float(spread_s)
+            no_mid = 1.0 - yes
+            real_cost = (spread / 2.0) / no_mid           # = entry_cost_pct fraction
+            if spread <= 0 or real_cost > MAX_ENTRY_COST: # flb_0d ceiling
+                dropped[mtype] = dropped.get(mtype, 0) + 1
+                continue
+            # add back the flat cost the shadow subtracted, charge the real one
+            realistic_net = stored_net + SHADOW_FLAT_COST - real_cost
+            types.append(mtype)
+            net.append(realistic_net)
+            kept_by_type[mtype] = kept_by_type.get(mtype, 0) + 1
+    return np.array(types), np.array(net), seen_by_type, kept_by_type, dropped
+
+
+def normpdf_log(x, mu, sd):
+    return -0.5 * np.log(2 * np.pi * sd * sd) - 0.5 * ((x - mu) / sd) ** 2
+
+
+def grid_posterior(ybar, se, mu_grid, tau_grid, s_tau, have_data):
+    """Return joint posterior P(mu,tau) on the grid (normalised)."""
+    MU, TAU = np.meshgrid(mu_grid, tau_grid, indexing="ij")
+    logp = np.zeros_like(MU)
+    # likelihood from data-bearing groups: ybar_j ~ N(mu, se_j^2 + tau^2)
+    for j in range(len(ybar)):
+        if not have_data[j]:
+            continue
+        sd = np.sqrt(se[j] ** 2 + TAU ** 2)
+        logp += normpdf_log(ybar[j], MU, sd)
+    # tau ~ HalfNormal(0, s_tau); mu ~ flat
+    logp += -0.5 * (TAU / s_tau) ** 2
+    logp -= logp.max()
+    post = np.exp(logp)
+    post /= post.sum()
+    return post
+
+
+def theta_posterior(ybar_j, se_j, has_data, mu_grid, tau_grid, post, theta_grid):
+    """Exact grid-weighted mixture posterior for one theta_j over theta_grid."""
+    dens = np.zeros_like(theta_grid)
+    for i, mu in enumerate(mu_grid):
+        for k, tau in enumerate(tau_grid):
+            w = post[i, k]
+            if w == 0:
+                continue
+            if has_data:
+                prec = 1.0 / se_j ** 2 + 1.0 / tau ** 2
+                m = (ybar_j / se_j ** 2 + mu / tau ** 2) / prec
+                s = np.sqrt(1.0 / prec)
+            else:
+                m, s = mu, tau
+            dens += w * np.exp(normpdf_log(theta_grid, m, s))
+    dens /= dens.sum()
+    return dens
+
+
+def summarise(theta_grid, dens):
+    mean = np.sum(theta_grid * dens)
+    cdf = np.cumsum(dens)
+    q = lambda p: theta_grid[np.searchsorted(cdf, p)]
+    p_gt0 = np.sum(dens[theta_grid > 0])
+    p_gt_hurdle = np.sum(dens[theta_grid > COST_HURDLE])
+    return mean, q(0.05), q(0.95), p_gt0, p_gt_hurdle
+
+
+def main():
+    types, pnl, seen, kept, dropped = load(CSV)
+    order = ["crypto_daily", "event_financial", "event_short", "event_long"]
+    n = {t: int(np.sum(types == t)) for t in order}
+    ybar = {t: (float(np.mean(pnl[types == t])) if n[t] > 0 else 0.0) for t in order}
+
+    print("=" * 72)
+    print("FLB hierarchical edge — REALISTIC per-signal spread cost + executor filter")
+    print("=" * 72)
+    print(f"Re-cost: realistic_net = shadow_net + {SHADOW_FLAT_COST} - (spread/2)/(1-yes)")
+    print(f"Executor filter (flb_0d): keep only signals with real entry cost <= {MAX_ENTRY_COST:.0%}\n")
+    print(f"{'type':<18}{'seen':>6}{'kept':>6}{'dropped':>9}")
+    for t in order:
+        print(f"{t:<18}{seen.get(t,0):>6}{kept.get(t,0):>6}{dropped.get(t,0):>9}")
+    if len(pnl) == 0:
+        print("\nNO signals survive the realistic-cost entry filter. The executor would")
+        print("have entered none of the resolved tradeable signals. No edge to estimate.")
+        return
+
+    sd_pool = float(np.std(pnl, ddof=1)) if len(pnl) > 1 else 0.1316
+    se = {t: (sd_pool / np.sqrt(n[t]) if n[t] > 0 else np.inf) for t in order}
+    have = {t: n[t] > 0 for t in order}
+
+    print(f"\nSurvivors: {len(pnl)}   pooled per-trade sd: {sd_pool:.4f}")
+    print(f"Build hurdle: realistic net edge > {COST_HURDLE:.0%}/trade\n")
+    print(f"{'type':<18}{'n':>4}{'real mean':>11}{'se(pooled)':>12}")
+    for t in order:
+        se_disp = f"{se[t]:.4f}" if np.isfinite(se[t]) else "  inf"
+        print(f"{t:<18}{n[t]:>4}{ybar[t]:>11.4f}{se_disp:>12}")
+    print()
+
+    mu_grid = np.linspace(-0.10, 0.20, 601)
+    tau_grid = np.linspace(1e-4, 0.20, 400)
+    theta_grid = np.linspace(-0.30, 0.40, 1401)
+
+    ybar_a = np.array([ybar[t] for t in order])
+    se_a = np.array([se[t] for t in order])
+    have_a = np.array([have[t] for t in order])
+
+    for label, s_tau in [("tight  N+(0,0.02)", 0.02),
+                         ("medium N+(0,0.05)", 0.05),
+                         ("loose  N+(0,0.10)", 0.10)]:
+        post = grid_posterior(ybar_a, se_a, mu_grid, tau_grid, s_tau, have_a)
+        # population mu posterior
+        mu_marg = post.sum(axis=1)
+        mu_mean = np.sum(mu_grid * mu_marg)
+        mu_cdf = np.cumsum(mu_marg)
+        mu_lo = mu_grid[np.searchsorted(mu_cdf, 0.05)]
+        mu_hi = mu_grid[np.searchsorted(mu_cdf, 0.95)]
+        # tau posterior mean (how much heterogeneity the data+prior support)
+        tau_marg = post.sum(axis=0)
+        tau_mean = np.sum(tau_grid * tau_marg)
+
+        print("-" * 72)
+        print(f"tau prior = {label}   (pooling strength)")
+        print(f"  population mu (typical type edge): mean {mu_mean:+.4f}  "
+              f"90% CrI [{mu_lo:+.4f}, {mu_hi:+.4f}]   posterior-mean tau {tau_mean:.4f}")
+        for t in order:
+            j = order.index(t)
+            dens = theta_posterior(ybar[t], se[t], have[t], mu_grid, tau_grid, post, theta_grid)
+            mean, lo, hi, pg0, pgh = summarise(theta_grid, dens)
+            if have[t]:
+                shrink = np.sum([post[i, k] * (tau_grid[k] ** 2 / (tau_grid[k] ** 2 + se[t] ** 2))
+                                 for i in range(len(mu_grid)) for k in range(len(tau_grid))])
+                shr = f"keeps {shrink:.0%} own data"
+            else:
+                shr = "prior-only (no data)"
+            tag = "TRADEABLE" if t in TRADEABLE else "ref"
+            print(f"  [{tag:<9}] {t:<16} edge {mean:+.4f}  90% CrI [{lo:+.4f},{hi:+.4f}]  "
+                  f"P(>0)={pg0:.2f} P(>1%)={pgh:.2f}  {shr}")
+        # tradeable predictive: a NEW tradeable-type trade ~ N(mu, tau^2)
+        pred = np.zeros_like(theta_grid)
+        for i, mu in enumerate(mu_grid):
+            for k, tau in enumerate(tau_grid):
+                w = post[i, k]
+                if w:
+                    pred += w * np.exp(normpdf_log(theta_grid, mu, tau))
+        pred /= pred.sum()
+        m, lo, hi, pg0, pgh = summarise(theta_grid, pred)
+        print(f"  => TRADEABLE predictive (new type): edge {m:+.4f}  90% CrI [{lo:+.4f},{hi:+.4f}]  "
+              f"P(>0)={pg0:.2f}  P(>1%)={pgh:.2f}")
+    print("-" * 72)
+    print("Reading it: mu is the partial-pooled 'typical type' edge (event_long-dominated).")
+    print("event_financial shrinks toward mu; crypto_daily/event_short are prior-only.")
+    print("Compare P(>0)/P(>1%) and CrI width across tau priors: the wider they move,")
+    print("the more the verdict rests on the cross-type-similarity ASSUMPTION, not data.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/flb-shadow-snapshot.js
+++ b/scripts/flb-shadow-snapshot.js
@@ -26,7 +26,12 @@
 
 const { Pool } = require('pg');
 
-const ENTRY_COST = 0.0054; // entry only — resolution settles at par
+const ENTRY_COST = 0.0054; // flat assumed entry cost (legacy net_pnl) — entry only, settles at par
+// Realistic per-signal entry cost = half-spread / NO stake = (entry_spread/2)/(1-entry_yes).
+// The flat 0.0054 masks that tail-band spreads are wide and right-skewed (OQ#1: median
+// 0.53% but mean ~3%, ~14% un-enterable). net_pnl_real charges the actual spread so the
+// forward verdict is read on what the executor would really pay; entry_cost_real lets the
+// verdict filter to the enterable subset (cost <= FLB_MAX_ENTRY_COST_PCT, default 1%).
 
 async function main() {
   const pool = new Pool({ connectionString: process.env.DATABASE_URL });
@@ -48,6 +53,10 @@ async function main() {
       net_pnl          numeric(12,6)
     )`);
 
+  // Realistic-cost columns (additive; legacy net_pnl untouched for continuity).
+  await pool.query(`ALTER TABLE flb_shadow_signals ADD COLUMN IF NOT EXISTS entry_cost_real numeric(12,6)`);
+  await pool.query(`ALTER TABLE flb_shadow_signals ADD COLUMN IF NOT EXISTS net_pnl_real    numeric(12,6)`);
+
   // Step 1 — record first-time longshot-band entries (ex-ante end_date gate).
   const ins = await pool.query(`
     INSERT INTO flb_shadow_signals (market_id, first_seen, entry_yes_price, entry_spread, end_date, market_type)
@@ -59,7 +68,7 @@ async function main() {
     ON CONFLICT (market_id) DO NOTHING`);
   console.log(`Step 1 — new signals recorded today: ${ins.rowCount}`);
 
-  // Step 2 — score signals whose market has resolved.
+  // Step 2 — score signals whose market has resolved (flat AND realistic cost).
   const upd = await pool.query(`
     UPDATE flb_shadow_signals s SET
       resolved_outcome = lower(m.resolution_outcome),
@@ -67,13 +76,31 @@ async function main() {
       hold_days        = EXTRACT(EPOCH FROM (m.resolved_at - s.first_seen::timestamptz)) / 86400,
       net_pnl          = CASE WHEN lower(m.resolution_outcome) = 'no'
                               THEN s.entry_yes_price / (1 - s.entry_yes_price) - ${ENTRY_COST}
-                              ELSE -1 - ${ENTRY_COST} END
+                              ELSE -1 - ${ENTRY_COST} END,
+      entry_cost_real  = CASE WHEN s.entry_spread IS NULL OR s.entry_spread <= 0 THEN NULL
+                              ELSE (s.entry_spread / 2.0) / (1 - s.entry_yes_price) END,
+      net_pnl_real     = CASE WHEN s.entry_spread IS NULL OR s.entry_spread <= 0 THEN NULL
+                              WHEN lower(m.resolution_outcome) = 'no'
+                              THEN s.entry_yes_price / (1 - s.entry_yes_price) - (s.entry_spread / 2.0) / (1 - s.entry_yes_price)
+                              ELSE -1 - (s.entry_spread / 2.0) / (1 - s.entry_yes_price) END
     FROM markets m
     WHERE m.id = s.market_id
       AND m.is_resolved = true
       AND lower(m.resolution_outcome) IN ('yes','no')
       AND s.resolved_outcome IS NULL`);
   console.log(`Step 2 — signals newly scored (resolved): ${upd.rowCount}`);
+
+  // Step 2b — backfill realistic-cost columns for already-resolved rows (idempotent).
+  const bf = await pool.query(`
+    UPDATE flb_shadow_signals SET
+      entry_cost_real = CASE WHEN entry_spread IS NULL OR entry_spread <= 0 THEN NULL
+                             ELSE (entry_spread / 2.0) / (1 - entry_yes_price) END,
+      net_pnl_real    = CASE WHEN entry_spread IS NULL OR entry_spread <= 0 THEN NULL
+                             WHEN resolved_outcome = 'no'
+                             THEN entry_yes_price / (1 - entry_yes_price) - (entry_spread / 2.0) / (1 - entry_yes_price)
+                             ELSE -1 - (entry_spread / 2.0) / (1 - entry_yes_price) END
+    WHERE resolved_outcome IS NOT NULL AND net_pnl_real IS NULL`);
+  if (bf.rowCount > 0) console.log(`Step 2b — backfilled realistic cost for ${bf.rowCount} prior rows`);
 
   // Step 3 — running out-of-sample stats.
   const tot = await pool.query(`SELECT COUNT(*) n,
@@ -100,6 +127,28 @@ async function main() {
     console.log(`  (in-sample backtest reference: +2.24%/trade, t=3.49 — see project_flb_strategy_design)`);
   } else {
     console.log('No resolved signals yet — accumulating. Check back as markets resolve.');
+  }
+
+  // Realistic-cost view: enterable subset only (real entry cost <= 1%), per the
+  // executor's flb_0d filter. This is the verdict-relevant number — the flat-cost
+  // net_pnl above understates the real spread and over-states the edge.
+  const MAX_COST = 0.01;
+  const rc = await pool.query(`
+    SELECT COUNT(*) n,
+      ROUND(AVG(net_pnl_real)::numeric, 4) avg_net_real,
+      ROUND(STDDEV_SAMP(net_pnl_real)::numeric, 4) sd,
+      COUNT(*) FILTER (WHERE net_pnl_real > 0) wins
+    FROM flb_shadow_signals
+    WHERE resolved_outcome IS NOT NULL AND entry_cost_real IS NOT NULL
+      AND entry_cost_real <= ${MAX_COST}`);
+  const r2 = rc.rows[0];
+  if (Number(r2.n) > 0) {
+    const n = Number(r2.n), avg = Number(r2.avg_net_real), sd = Number(r2.sd) || 0;
+    const t = sd > 0 ? avg / (sd / Math.sqrt(n)) : 0;
+    console.log('');
+    console.log(`Realistic-cost performance (enterable subset, real entry cost <= ${(MAX_COST * 100).toFixed(1)}%):`);
+    console.log(`  n=${n}  net/trade=${(avg * 100).toFixed(2)}%  t=${t.toFixed(2)}  winRate=${(100 * Number(r2.wins) / n).toFixed(1)}%`);
+    console.log('  (this is the verdict-relevant figure; flat-0.54% net above is optimistic)');
   }
 
   await pool.end();

--- a/scripts/flb-subband-sweep.py
+++ b/scripts/flb-subband-sweep.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+flb-subband-sweep.py
+
+Does a CHEAPER spread sub-band recover a positive realistic-cost FLB edge?
+Sweeps the entry-cost ceiling and, for each, reports the realistic-cost net
+edge of the surviving resolved signals per market type, with a bootstrap CI
+(the -100% wipeout tail breaks normality, so we resample rather than trust a t).
+
+realistic_net = shadow_net + 0.0054 - (spread/2)/(1-yes)
+A signal is "enterable" at ceiling c if its real entry cost <= c (book present).
+
+Usage: python scripts/flb-subband-sweep.py [flb_resolved.csv]
+CSV cols (no header): market_type, net_pnl, entry_yes_price, entry_spread
+"""
+import sys
+import numpy as np
+
+SHADOW_FLAT_COST = 0.0054
+CSV = sys.argv[1] if len(sys.argv) > 1 else "flb_resolved.csv"
+RNG = np.random.default_rng(0)
+N_BOOT = 10000
+CEILINGS = [0.0025, 0.005, 0.0075, 0.01, 0.015, 0.02, 0.05]
+
+
+def load(path):
+    rows = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            mtype, pnl_s, yes_s, spread_s = line.split(",")[:4]
+            if spread_s == "":
+                rows.append((mtype, float(pnl_s), float(yes_s), None))
+            else:
+                rows.append((mtype, float(pnl_s), float(yes_s), float(spread_s)))
+    return rows
+
+
+def real_cost(yes, spread):
+    return (spread / 2.0) / (1.0 - yes)
+
+
+def boot(net):
+    if len(net) == 0:
+        return (np.nan, np.nan, np.nan, np.nan)
+    idx = RNG.integers(0, len(net), size=(N_BOOT, len(net)))
+    means = net[idx].mean(axis=1)
+    return (float(net.mean()), float(np.percentile(means, 5)),
+            float(np.percentile(means, 95)), float((means > 0).mean()))
+
+
+def main():
+    rows = load(CSV)
+    types = sorted(set(r[0] for r in rows))
+    print("=" * 78)
+    print("FLB cheaper-sub-band sweep — realistic net edge vs entry-cost ceiling")
+    print("=" * 78)
+    print(f"Bootstrap N={N_BOOT}, seed=0. 'wipe'=YES resolutions (net<-0.5). "
+          f"P0=P(mean net>0).\n")
+
+    for c in CEILINGS:
+        print(f"--- ceiling = {c:.2%} entry cost " + "-" * 40)
+        any_data = False
+        for t in types:
+            net = []
+            wipes = 0
+            for (mt, pnl, yes, spread) in rows:
+                if mt != t or spread is None or spread <= 0:
+                    continue
+                if real_cost(yes, spread) > c:
+                    continue
+                rn = pnl + SHADOW_FLAT_COST - real_cost(yes, spread)
+                net.append(rn)
+                if rn < -0.5:
+                    wipes += 1
+            net = np.array(net)
+            if len(net) == 0:
+                continue
+            any_data = True
+            mean, lo, hi, p0 = boot(net)
+            winrate = float((net > 0).mean())
+            print(f"  {t:<16} n={len(net):>3} wipe={wipes:<2} "
+                  f"mean={mean:+.4f} 90%CI[{lo:+.4f},{hi:+.4f}] "
+                  f"P0={p0:.2f} win%={winrate:.0%}")
+        # pooled across all types (the executor trades them together)
+        netall = []
+        for (mt, pnl, yes, spread) in rows:
+            if spread is None or spread <= 0 or real_cost(yes, spread) > c:
+                continue
+            netall.append(pnl + SHADOW_FLAT_COST - real_cost(yes, spread))
+        netall = np.array(netall)
+        if len(netall):
+            mean, lo, hi, p0 = boot(netall)
+            print(f"  {'POOLED':<16} n={len(netall):>3}        "
+                  f"mean={mean:+.4f} 90%CI[{lo:+.4f},{hi:+.4f}] P0={p0:.2f}")
+        if not any_data:
+            print("  (no enterable signals at this ceiling)")
+    print("-" * 78)
+    print("Read: if the tightest ceilings (0.25-0.5%) show mean>0 with P0 high and CI")
+    print("clear of 0, a cheap sub-band has edge -> a real tradeable restriction.")
+    print("If mean stays ~0 / P0~0.5 even at the cheapest spreads, the realistic edge")
+    print("is not there. event_financial has NO enterable signals below ~5% cost.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

The FLB shadow recorder charged a **flat 0.54% entry cost**, masking that tail-band spreads are wide/right-skewed (OQ#1: median 0.53% but mean ~3%, ~14% un-enterable). This made the forward edge look like +3.0%/t=2.78 when it isn't there at realistic cost.

- Adds `entry_cost_real = (entry_spread/2)/(1-entry_yes)` and `net_pnl_real` columns to `flb_shadow_signals` (**additive**; legacy `net_pnl` untouched) + idempotent backfill.
- Recorder prints a realistic-cost line (enterable subset, real cost ≤ 1%).
- Spec §11 verdict query updated to read `net_pnl_real` on the enterable cohort.
- Adds `scripts/flb-hierarchical-edge.py` (partial-pooling estimate) and `scripts/flb-subband-sweep.py` (cost-ceiling sweep + bootstrap).

## Empirical finding (n=133, verified on VM)
Flat-cost +3.0%/t=2.78 → realistically costed + enterable-filtered: TRADEABLE cohort **0 enterable** (all 5 event_financial 5–9% real cost), event_long enterable **n=45, +0.05%, t=0.02**. Realistic-cost forward edge **not demonstrated**. Validates keeping the executor gated off.

## Test Plan
- [x] node --check + python ast-parse
- [x] columns + backfill (133 rows) applied to VM; realistic verdict query matches analysis
- [ ] after merge: daily flb-shadow-snapshot.yml populates the new columns for future resolutions

🤖 Generated with [Claude Code](https://claude.com/claude-code)