### PR TITLE
fix(daily-review): FLB forward sentinel reads real cost, not flat — make it deterministic

### DIFF
--- a/scripts/coverage-alerts.js
+++ b/scripts/coverage-alerts.js
@@ -107,4 +107,106 @@ function classifySignalActivity(input) {
   return null;
 }
 
-module.exports = { detectSupplyCollapse, classifySignalActivity, DEFAULT_ALLOWED_MARKET_TYPES };
+// ── FLB forward sentinel (real-cost) ─────────────────────────────────────────
+// Watchdog #305 (2026-06-04) reported the FLB forward t-stat as 1.39, computed
+// from flb_shadow_signals.net_pnl — the FLAT 0.54% entry-cost column. PR #304
+// added net_pnl_real (the real per-signal half-spread) precisely because the
+// flat cost over-states the edge by ~half the fees plus the omitted spread. On
+// real cost the same 2026-06-04 sample was pooled t≈-0.07, and the enterable
+// subset (entry_cost_real ≤ 1% — what the executor would actually fill) was
+// -1.75%/t=-0.50. The forward sentinel lived only in the LLM prompt, so the
+// model silently picked the wrong column and framed the drop to 1.39 as
+// "watching, could cross back above 2" — implying a latent edge that does not
+// exist at realistic cost. This makes the verdict deterministic.
+const FLB_VERDICT_MIN_N = 100;
+const FLB_VERDICT_MIN_T = 2;
+
+/** Student-t for a one-sample mean: avg / (sd / sqrt(n)). Null if not computable. */
+function tStat(avg, sd, n) {
+  const a = Number(avg);
+  const s = Number(sd);
+  const k = Number(n);
+  if (!Number.isFinite(a) || !Number.isFinite(s) || !Number.isFinite(k)) return null;
+  if (k < 2 || s <= 0) return null;
+  return a / (s / Math.sqrt(k));
+}
+
+/**
+ * Deterministic FLB forward verdict from resolved flb_shadow_signals, segmented
+ * by cohort. The verdict is keyed on the TRADEABLE cohort's REAL-cost t-stat
+ * (the pre-registered build gate: n ≥ 100, t ≥ 2, avg > 0). event_long is
+ * shadow-only and never drives the verdict; the flat-cost column is reported for
+ * continuity only and is explicitly flagged when it disagrees with real cost.
+ *
+ * @param {Array<{cohort:string, n_flat?:number|string, avg_flat?:number|string, sd_flat?:number|string, n_real?:number|string, avg_real?:number|string, sd_real?:number|string, n_enterable?:number|string, avg_enterable?:number|string, sd_enterable?:number|string}>} [cohortRows]
+ * @returns {{cohorts:Array<object>, verdict:{status:string,message:string}, costDiscrepancy:(string|null)}}
+ */
+function flbForwardVerdict(cohortRows) {
+  const rows = Array.isArray(cohortRows) ? cohortRows : [];
+  const cohorts = rows.map((r) => ({
+    cohort: r.cohort,
+    n_flat: Number(r.n_flat) || 0,
+    avg_flat: Number(r.avg_flat),
+    t_flat: tStat(r.avg_flat, r.sd_flat, r.n_flat),
+    n_real: Number(r.n_real) || 0,
+    avg_real: Number(r.avg_real),
+    t_real: tStat(r.avg_real, r.sd_real, r.n_real),
+    n_enterable: Number(r.n_enterable) || 0,
+    avg_enterable: Number(r.avg_enterable),
+    t_enterable: tStat(r.avg_enterable, r.sd_enterable, r.n_enterable),
+  }));
+
+  // The flat column may not be sold as an edge: flag any cohort where flat clears
+  // the gate (t ≥ 2) but real cost does not. This is exactly the #305 failure.
+  let costDiscrepancy = null;
+  for (const c of cohorts) {
+    if (c.t_flat != null && c.t_flat >= FLB_VERDICT_MIN_T
+        && (c.t_real == null || c.t_real < FLB_VERDICT_MIN_T)) {
+      costDiscrepancy =
+        `FLB ${c.cohort}: flat-cost t=${c.t_flat.toFixed(2)} clears the gate but `
+        + `real-cost t=${c.t_real == null ? 'n/a' : c.t_real.toFixed(2)} does not. `
+        + `The flat 0.54% column over-states the edge — read net_pnl_real, not net_pnl.`;
+      break;
+    }
+  }
+
+  const tradeable = cohorts.find((c) => c.cohort === 'tradeable');
+  let verdict;
+  if (!tradeable || tradeable.n_real === 0) {
+    verdict = { status: 'no_data', message: 'No resolved tradeable FLB signals yet.' };
+  } else if (tradeable.n_real < FLB_VERDICT_MIN_N) {
+    verdict = {
+      status: 'accumulating',
+      message:
+        `FLB tradeable forward: n=${tradeable.n_real} (< ${FLB_VERDICT_MIN_N}) — accumulating. `
+        + `Real-cost t=${tradeable.t_real == null ? 'n/a' : tradeable.t_real.toFixed(2)}. `
+        + `Do NOT build the executor until n ≥ ${FLB_VERDICT_MIN_N} on real cost.`,
+    };
+  } else if (tradeable.t_real != null && tradeable.t_real >= FLB_VERDICT_MIN_T && tradeable.avg_real > 0) {
+    verdict = {
+      status: 'edge_holding',
+      message:
+        `FLB forward edge holding at REAL cost: tradeable n=${tradeable.n_real}, `
+        + `t=${tradeable.t_real.toFixed(2)}, avg=${(tradeable.avg_real * 100).toFixed(2)}% — `
+        + `candidate to build the executor.`,
+    };
+  } else {
+    verdict = {
+      status: 'no_edge_at_real_cost',
+      message:
+        `FLB tradeable forward: n=${tradeable.n_real}, real-cost `
+        + `t=${tradeable.t_real == null ? 'n/a' : tradeable.t_real.toFixed(2)}, `
+        + `avg=${(tradeable.avg_real * 100).toFixed(2)}% — no edge at realistic cost. `
+        + `Keep the executor gated off.`,
+    };
+  }
+
+  return { cohorts, verdict, costDiscrepancy };
+}
+
+module.exports = {
+  detectSupplyCollapse,
+  classifySignalActivity,
+  flbForwardVerdict,
+  DEFAULT_ALLOWED_MARKET_TYPES,
+};

--- a/scripts/coverage-alerts.test.js
+++ b/scripts/coverage-alerts.test.js
@@ -9,6 +9,7 @@ const assert = require('node:assert/strict');
 const {
   detectSupplyCollapse,
   classifySignalActivity,
+  flbForwardVerdict,
   DEFAULT_ALLOWED_MARKET_TYPES,
 } = require('./coverage-alerts.js');
 
@@ -178,6 +179,128 @@ const cases = [
     fn: () => {
       assert.equal(classifySignalActivity(), null);
       assert.equal(classifySignalActivity({}), null);
+    },
+  },
+
+  // ── flbForwardVerdict — real-cost FLB forward sentinel ────────────────────
+  // Watchdog #305 (2026-06-04) reported the FLB forward t-stat as 1.39 using
+  // flb_shadow_signals.net_pnl — the FLAT 0.54% cost column. PR #304 added
+  // net_pnl_real (real per-signal half-spread); on real cost the same pooled
+  // sample is t≈-0.07 and the enterable subset (cost≤1%) is -1.75%/t=-0.50.
+  // The LLM-driven sentinel picked the wrong column, so the "watching, could
+  // cross back >2" framing was misleading. This function makes the verdict
+  // deterministic: it is keyed on the TRADEABLE cohort's REAL-cost t-stat and
+  // surfaces the flat-vs-real discrepancy so the flat number can never be sold
+  // as an edge again.
+  {
+    name: 't computed correctly from avg/sd/n',
+    fn: () => {
+      // avg=0.02, sd=0.1719, n=151 → t = 0.02/(0.1719/sqrt(151)) ≈ 1.4298
+      const { cohorts } = flbForwardVerdict([
+        { cohort: 'tradeable', n_real: 151, avg_real: 0.02, sd_real: 0.1719 },
+      ]);
+      const t = cohorts[0].t_real;
+      assert.ok(Math.abs(t - 1.4298) < 0.01, `t_real=${t}`);
+    },
+  },
+  {
+    name: 'tradeable real-cost n>=100 & t>=2 & avg>0 → edge_holding',
+    fn: () => {
+      const { verdict } = flbForwardVerdict([
+        { cohort: 'tradeable', n_real: 120, avg_real: 0.03, sd_real: 0.12 },
+        { cohort: 'event_long', n_real: 400, avg_real: 0.05, sd_real: 0.10 },
+      ]);
+      assert.equal(verdict.status, 'edge_holding');
+    },
+  },
+  {
+    name: 'tradeable real-cost n<100 → accumulating (n=5 case, the real 2026-06-04 state)',
+    fn: () => {
+      const { verdict } = flbForwardVerdict([
+        { cohort: 'tradeable', n_real: 5, avg_real: 0.018, sd_real: 0.08 },
+        { cohort: 'event_long', n_real: 146, avg_real: -0.0016, sd_real: 0.14 },
+      ]);
+      assert.equal(verdict.status, 'accumulating');
+    },
+  },
+  {
+    name: 'tradeable real-cost n>=100 but t<2 → no_edge_at_real_cost',
+    fn: () => {
+      const { verdict } = flbForwardVerdict([
+        { cohort: 'tradeable', n_real: 150, avg_real: -0.001, sd_real: 0.17 },
+      ]);
+      assert.equal(verdict.status, 'no_edge_at_real_cost');
+    },
+  },
+  {
+    name: 'flat t>=2 but real t<2 → costDiscrepancy flagged (the #305 blind-spot guard)',
+    fn: () => {
+      // The future-risk case: the flat 0.54%-cost column crosses the build gate
+      // while real cost does not. avg_flat=0.03/sd=0.12/n=151 → t≈3.07 ≥ 2.
+      const { costDiscrepancy } = flbForwardVerdict([
+        { cohort: 'tradeable', n_flat: 151, avg_flat: 0.03, sd_flat: 0.12,
+          n_real: 151, avg_real: -0.001, sd_real: 0.17 },
+      ]);
+      assert.ok(costDiscrepancy, 'expected costDiscrepancy to be truthy');
+    },
+  },
+  {
+    name: 'the actual 2026-06-04 pooled state (flat t=1.39, real t≈-0.07) → no false costDiscrepancy',
+    fn: () => {
+      // Both below the gate today, so no build decision is at stake — the guard
+      // must stay quiet. (The misleading framing is handled by the verdict text.)
+      const { costDiscrepancy } = flbForwardVerdict([
+        { cohort: 'tradeable', n_flat: 151, avg_flat: 0.0195, sd_flat: 0.171,
+          n_real: 151, avg_real: -0.001, sd_real: 0.17 },
+      ]);
+      assert.ok(!costDiscrepancy);
+    },
+  },
+  {
+    name: 'flat and real agree (both <2) → no costDiscrepancy',
+    fn: () => {
+      const { costDiscrepancy } = flbForwardVerdict([
+        { cohort: 'tradeable', n_flat: 151, avg_flat: 0.005, sd_flat: 0.17,
+          n_real: 151, avg_real: 0.004, sd_real: 0.17 },
+      ]);
+      assert.ok(!costDiscrepancy);
+    },
+  },
+  {
+    name: 'enterable subset t computed and surfaced',
+    fn: () => {
+      const { cohorts } = flbForwardVerdict([
+        { cohort: 'tradeable', n_enterable: 51, avg_enterable: -0.01745, sd_enterable: 0.245 },
+      ]);
+      assert.ok(cohorts[0].t_enterable < 0, `t_enterable=${cohorts[0].t_enterable}`);
+    },
+  },
+  {
+    name: 'string-typed json numerics handled',
+    fn: () => {
+      const { cohorts, verdict } = flbForwardVerdict([
+        { cohort: 'tradeable', n_real: '120', avg_real: '0.03', sd_real: '0.12' },
+      ]);
+      assert.ok(Number.isFinite(cohorts[0].t_real));
+      assert.equal(verdict.status, 'edge_holding');
+    },
+  },
+  {
+    name: 'missing tradeable cohort → verdict null-safe (no_data)',
+    fn: () => {
+      const { verdict } = flbForwardVerdict([
+        { cohort: 'event_long', n_real: 146, avg_real: -0.0016, sd_real: 0.14 },
+      ]);
+      assert.equal(verdict.status, 'no_data');
+    },
+  },
+  {
+    name: 'undefined/empty input does not throw',
+    fn: () => {
+      const a = flbForwardVerdict();
+      assert.equal(a.verdict.status, 'no_data');
+      assert.deepEqual(a.cohorts, []);
+      assert.ok(!a.costDiscrepancy);
     },
   },
 ];

--- a/scripts/daily-review-prompt.md
+++ b/scripts/daily-review-prompt.md
@@ -226,18 +226,40 @@ gh run list --workflow=flb-shadow-snapshot.yml --limit 5 --json conclusion,creat
 
 ## Edge sentinel within the FLB shadow data
 
-Once there are resolved signals, check the running forward result:
+The report's **FLB Forward Sentinel (shadow OOS)** section is now **deterministic**
+(computed in `coverage-alerts.js` from the gathered `flb_forward` rows). Read its
+table and `Verdict (...)` line — do NOT recompute the t-stat from
+`AVG(net_pnl)` by hand.
 
-```sql
-SELECT COUNT(*) n, ROUND(AVG(net_pnl)::numeric,4) avg_net,
-  ROUND(STDDEV_SAMP(net_pnl)::numeric,4) sd
-FROM flb_shadow_signals WHERE resolved_outcome IS NOT NULL;
-```
+**CRITICAL — read the REAL-cost column, never the flat one.** `flb_shadow_signals`
+has two PnL columns: `net_pnl` (a flat 0.54% entry cost — legacy) and
+`net_pnl_real` (the real per-signal half-spread, added by PR #304). The flat
+column over-states the edge by ~half the fees plus the omitted spread. Watchdog
+#305 (2026-06-04) reported the forward t-stat as **1.39 from `net_pnl`** and
+framed the drop below 2.0 as "watching, could cross back" — but at real cost the
+same pooled sample was **t ≈ -0.07**, and the enterable subset (`entry_cost_real`
+≤ 1%, what the executor would actually fill) was **-1.75%/t=-0.50**. The flat
+number is a flat-cost artefact; the real-cost verdict is ~0.
 
-Compute `t = avg_net / (sd / sqrt(n))`. The in-sample reference is
-+2.24%/trade, t=3.49. **Only report a verdict once `n ≥ 100`** — below that, say
-"accumulating". If `n ≥ 100` and forward `t ≥ 2` with positive `avg_net` → flag
-**prominently** as "FLB forward edge holding — candidate to build the executor".
+Rules:
+- The verdict is keyed on the **TRADEABLE cohort at REAL cost** (the build gate:
+  n ≥ 100, real-cost t ≥ 2, avg > 0). `event_long` is shadow-only — never read it,
+  the pooled row, or any flat-cost number as the verdict.
+- In-sample reference: +2.24%/trade, t=3.49.
+- If the report shows a **flat-vs-real discrepancy ⚠️** (flat t ≥ 2 while real
+  t < 2), surface it prominently — it means the flat column is being mistaken for
+  an edge.
+- If you must run SQL manually, segment by cohort and use `net_pnl_real` on the
+  enterable subset:
+  ```sql
+  SELECT
+    CASE WHEN market_type='event_long' THEN 'event_long' ELSE 'tradeable' END AS cohort,
+    COUNT(*) FILTER (WHERE net_pnl_real IS NOT NULL) n,
+    ROUND(AVG(net_pnl_real)*100::numeric,3) avg_real_pct,
+    ROUND((AVG(net_pnl_real)/NULLIF(STDDEV_SAMP(net_pnl_real)/SQRT(COUNT(*)),0))::numeric,3) t_real,
+    COUNT(*) FILTER (WHERE entry_cost_real <= 0.01) n_enterable
+  FROM flb_shadow_signals WHERE resolved_outcome IS NOT NULL GROUP BY 1;
+  ```
 
 ## FLB Paper Executor track (`flb_cohorts` / `flb_capital` in review-data.json)
 

--- a/scripts/daily-review.sh
+++ b/scripts/daily-review.sh
@@ -508,6 +508,35 @@ flb_cohorts=$(query_json "
   ) t
 ")
 
+# 15f. FLB forward sentinel — the shadow-recorder OUT-OF-SAMPLE edge test, the
+# one live trading lead. Cohort-segmented (tradeable vs event_long) and reported
+# at BOTH the legacy flat 0.54% cost (net_pnl) and the real per-signal half-spread
+# (net_pnl_real, added by PR #304), plus the enterable subset (entry_cost_real
+# ≤ 1% — what the executor would actually fill). Watchdog #305 reported only the
+# flat number (t=1.39) and framed it as "watching, could cross back >2"; at real
+# cost the same pooled sample is t≈-0.07 and the enterable subset is -1.75%/t=-0.50.
+# The verdict (computed in coverage-alerts.js) is keyed on the TRADEABLE real-cost
+# t-stat, NEVER the flat or pooled number. Degrades gracefully if the columns or
+# table are absent (older volume): query helpers map any failure to [].
+flb_forward=$(query_json "
+  SELECT COALESCE(json_agg(t), '[]'::json) FROM (
+    SELECT
+      CASE WHEN market_type = 'event_long' THEN 'event_long' ELSE 'tradeable' END AS cohort,
+      COUNT(*) FILTER (WHERE net_pnl IS NOT NULL)::float                                            AS n_flat,
+      ROUND(AVG(net_pnl)::numeric, 6)::float                                                        AS avg_flat,
+      ROUND(STDDEV_SAMP(net_pnl)::numeric, 6)::float                                                AS sd_flat,
+      COUNT(*) FILTER (WHERE net_pnl_real IS NOT NULL)::float                                       AS n_real,
+      ROUND(AVG(net_pnl_real)::numeric, 6)::float                                                   AS avg_real,
+      ROUND(STDDEV_SAMP(net_pnl_real)::numeric, 6)::float                                           AS sd_real,
+      COUNT(*) FILTER (WHERE entry_cost_real <= 0.01 AND net_pnl_real IS NOT NULL)::float           AS n_enterable,
+      ROUND(AVG(net_pnl_real) FILTER (WHERE entry_cost_real <= 0.01)::numeric, 6)::float            AS avg_enterable,
+      ROUND(STDDEV_SAMP(net_pnl_real) FILTER (WHERE entry_cost_real <= 0.01)::numeric, 6)::float    AS sd_enterable
+    FROM flb_shadow_signals
+    WHERE resolved_outcome IS NOT NULL
+    GROUP BY 1 ORDER BY 1
+  ) t
+")
+
 # Capital line — derived from positions so it is always consistent (the
 # paper_account.flb_* columns are a cache).
 flb_capital=$(query_one "
@@ -867,6 +896,7 @@ jq -n \
   --argjson edge_measurement_freshness "$edge_measurement_freshness" \
   --argjson flb_cohorts "$flb_cohorts" \
   --argjson flb_capital "$flb_capital" \
+  --argjson flb_forward "$flb_forward" \
   --argjson review_history "$(cat "$HISTORY_FILE" 2>/dev/null | jq 'sort_by(.date) | .[-7:]' 2>/dev/null || echo "[]")" \
   '{
     generated_at: $ts,
@@ -907,5 +937,6 @@ jq -n \
     edge_measurement_freshness: $edge_measurement_freshness,
     flb_cohorts: $flb_cohorts,
     flb_capital: $flb_capital,
+    flb_forward: $flb_forward,
     review_history: $review_history
   }'

--- a/scripts/format-review.js
+++ b/scripts/format-review.js
@@ -9,7 +9,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { detectSupplyCollapse, classifySignalActivity } = require('./coverage-alerts.js');
+const { detectSupplyCollapse, classifySignalActivity, flbForwardVerdict } = require('./coverage-alerts.js');
 
 // ── Read input ──────────────────────────────────────────────────────────────
 
@@ -192,6 +192,13 @@ const coverageByType = Array.isArray(data.coverage_by_type) ? data.coverage_by_t
 // missing/empty table yields {locked_capital:0, realized_pnl:0}.
 const flbCohorts = Array.isArray(data.flb_cohorts) ? data.flb_cohorts : [];
 const flbCapital = data.flb_capital || null;
+// FLB forward sentinel — the shadow-recorder out-of-sample edge test, segmented
+// by cohort and reported at BOTH flat (net_pnl) and real (net_pnl_real) cost.
+// The verdict is keyed on the TRADEABLE real-cost t-stat. #305: the prompt-only
+// sentinel read the flat column (t=1.39) and framed it as a near-edge; at real
+// cost the same sample is t≈-0.07. Degrades to [] on an older volume.
+const flbForward = Array.isArray(data.flb_forward) ? data.flb_forward : [];
+const flbForwardResult = flbForwardVerdict(flbForward);
 // ALLOWED_MARKET_TYPES, sourced (in priority order) from the gather payload
 // (read from the running dashboard container by daily-review.sh — single source
 // of truth), then the CI env, then undefined (detectSupplyCollapse falls back to
@@ -308,6 +315,14 @@ const signalActivity = classifySignalActivity({
 });
 if (signalActivity) {
   alerts.push({ level: signalActivity.level, message: signalActivity.message });
+}
+
+// FLB flat-vs-real cost discrepancy: the flat 0.54%-cost column crosses the
+// build gate (t ≥ 2) while real cost does not. Guards against the #305 failure
+// of selling the flat number as a near-edge. Warning, not critical — the
+// executor is gated off, so this never risks capital, only a wrong build call.
+if (flbForwardResult.costDiscrepancy) {
+  alerts.push({ level: 'warning', message: flbForwardResult.costDiscrepancy });
 }
 
 // 5+ consecutive losses. The metric is a cumulative DB counter, so when the
@@ -656,6 +671,32 @@ function buildMarkdown() {
     ln();
   }
 
+  // FLB Forward Sentinel (shadow recorder OOS edge test). Reported at BOTH flat
+  // and real cost; the verdict is keyed on the TRADEABLE real-cost t-stat. #305.
+  ln(`## FLB Forward Sentinel (shadow OOS)`);
+  ln();
+  ln(`> Out-of-sample edge test from \`flb_shadow_signals\`. **The verdict uses the TRADEABLE cohort at REAL cost** (\`net_pnl_real\`, PR #304) — the flat 0.54%-cost column (\`net_pnl\`) is shown for continuity only and over-states the edge. In-sample reference: +2.24%/trade, t=3.49. Build gate: tradeable n ≥ 100, real-cost t ≥ 2.`);
+  ln();
+  if (flbForwardResult.cohorts.length > 0) {
+    const ft = (x) => (x == null || !Number.isFinite(Number(x)) ? 'N/A' : Number(x).toFixed(2));
+    const fp = (x) => (Number.isFinite(Number(x)) ? `${(Number(x) * 100).toFixed(2)}%` : 'N/A');
+    ln(`| Cohort | n | avg (real) | **t (real)** | t (flat, ref) | enterable n | enterable avg | enterable t |`);
+    ln(`|--------|---|-----------|-----------|--------------|-------------|---------------|-------------|`);
+    for (const c of flbForwardResult.cohorts) {
+      ln(`| ${c.cohort || 'N/A'} | ${fmt(c.n_real, 0)} | ${fp(c.avg_real)} | **${ft(c.t_real)}** | ${ft(c.t_flat)} | ${fmt(c.n_enterable, 0)} | ${fp(c.avg_enterable)} | ${ft(c.t_enterable)} |`);
+    }
+    ln();
+    ln(`**Verdict (${flbForwardResult.verdict.status})**: ${flbForwardResult.verdict.message}`);
+    ln();
+    if (flbForwardResult.costDiscrepancy) {
+      ln(`> ⚠️ ${flbForwardResult.costDiscrepancy}`);
+      ln();
+    }
+  } else {
+    ln(`*FLB forward: no resolved shadow signals yet (or net_pnl_real not backfilled).*`);
+    ln();
+  }
+
   // Open Positions
   ln(`## Open Positions (${openPositions.length})`);
   ln();
@@ -991,6 +1032,28 @@ function buildEmailHtml() {
     p('</table>');
   } else {
     p('<p><em>FLB: no paper positions yet.</em></p>');
+  }
+
+  // FLB Forward Sentinel (shadow OOS) — verdict keyed on tradeable real cost. #305.
+  p('<h2>FLB Forward Sentinel (shadow OOS)</h2>');
+  p('<p style="font-size:12px;color:#6a737d;margin:4px 0 8px;">Out-of-sample edge test from flb_shadow_signals. The verdict uses the TRADEABLE cohort at REAL cost (net_pnl_real, PR #304); the flat 0.54%-cost column over-states the edge and is shown for continuity only. Build gate: tradeable n &ge; 100, real-cost t &ge; 2.</p>');
+  if (flbForwardResult.cohorts.length > 0) {
+    const ft = (x) => (x == null || !Number.isFinite(Number(x)) ? 'N/A' : Number(x).toFixed(2));
+    const fp = (x) => (Number.isFinite(Number(x)) ? `${(Number(x) * 100).toFixed(2)}%` : 'N/A');
+    p('<table>');
+    p('<tr><th>Cohort</th><th>n</th><th>avg (real)</th><th>t (real)</th><th>t (flat, ref)</th><th>enterable n</th><th>enterable avg</th><th>enterable t</th></tr>');
+    for (const c of flbForwardResult.cohorts) {
+      const tr = Number(c.t_real);
+      const cls = Number.isFinite(tr) && tr >= 2 ? 'positive' : (Number.isFinite(tr) && tr < 0 ? 'negative' : '');
+      p(`<tr><td>${escapeHtml(c.cohort || 'N/A')}</td><td>${escapeHtml(fmt(c.n_real, 0))}</td><td>${escapeHtml(fp(c.avg_real))}</td><td class="${cls}">${escapeHtml(ft(c.t_real))}</td><td>${escapeHtml(ft(c.t_flat))}</td><td>${escapeHtml(fmt(c.n_enterable, 0))}</td><td>${escapeHtml(fp(c.avg_enterable))}</td><td>${escapeHtml(ft(c.t_enterable))}</td></tr>`);
+    }
+    p('</table>');
+    p(`<p><strong>Verdict (${escapeHtml(flbForwardResult.verdict.status)})</strong>: ${escapeHtml(flbForwardResult.verdict.message)}</p>`);
+    if (flbForwardResult.costDiscrepancy) {
+      p(`<p style="color:#b08800;">&#9888; ${escapeHtml(flbForwardResult.costDiscrepancy)}</p>`);
+    }
+  } else {
+    p('<p><em>FLB forward: no resolved shadow signals yet (or net_pnl_real not backfilled).</em></p>');
   }
 
   // Open positions


### PR DESCRIPTION
## Problem

Watchdog **#305** (2026-06-04) reported the FLB forward t-stat as **1.39** and framed the drop below 2.0 as *"watching, could cross back above 2"*. That number came from `flb_shadow_signals.net_pnl` — the legacy **flat 0.54% entry-cost** column.

PR #304 added `net_pnl_real` (the real per-signal half-spread) *precisely* because the flat cost over-states the edge by ~half the fees plus the omitted spread. At **real cost**, the same 2026-06-04 sample (verified first-hand on the VM):

| cohort | n | flat % / t | **real % / t** |
|---|---|---|---|
| pooled | 151 | +1.95 / **1.39** | **−0.10 / −0.07** |
| event_long (96%) | 146 | +1.76 / 1.22 | **−0.16 / −0.12** |
| event_financial (tradeable) | 5 | +7.56 / 4.85 | +1.83 / 2.87 *(n=5, noise)* |
| **enterable** (cost ≤ 1%) | 51 | — | **−1.75 / −0.50** |

So the "near-edge" framing was a flat-cost artefact; the real-cost verdict is ~0. The enterable subset (what the executor would actually fill) is *all* event_long — the 5 tradeable signals all have 5–9% real cost.

## Root cause

The forward sentinel lived **only in the LLM prompt** (`daily-review-prompt.md`), so the model silently picked the wrong column. Same failure class as #280 (supply-collapse rule prompt-only) and #286 (signal-activity rule prompt-only) — both fixed by moving the check into the deterministic `coverage-alerts.js` layer. This does the same.

## Fix

- **`coverage-alerts.js`** — `flbForwardVerdict()`: segments tradeable vs event_long, computes t at flat **and** real cost plus the enterable subset, keys the verdict on the **TRADEABLE real-cost** t-stat (build gate: n ≥ 100, t ≥ 2, avg > 0), and flags a **flat-vs-real cost discrepancy** (flat clears the gate while real does not — the future-risk guard).
- **`daily-review.sh`** — gather `flb_forward` (cohort-segmented; flat + real + enterable). Degrades to `[]` on an older volume.
- **`format-review.js`** — render *FLB Forward Sentinel (shadow OOS)* in md + HTML; warning alert when a cost discrepancy is detected.
- **`daily-review-prompt.md`** — read the deterministic sentinel; never recompute from `net_pnl`; use `net_pnl_real` on the enterable subset if running SQL by hand.

## Verification

- `node scripts/coverage-alerts.test.js` → **25/25** (10 new `flbForwardVerdict` cases, TDD).
- Gather SQL validated against the VM (valid JSON, real values reproduced).
- `format-review.js` smoke-tested with the #305 data → renders table + `Verdict (accumulating)` (tradeable n=5 < 100), no false discrepancy.

Reinforces `feedback_realistic_costs`. Validates keeping the FLB executor gated off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FLB Forward Sentinel feature for out-of-sample edge testing with deterministic verdict computation based on real-cost metrics and t-statistics.
  * New report section displays forward sentinel results including cohort stats, real/flat cost t-values, verdict status, and cost discrepancy alerts.

* **Documentation**
  * Updated guidance to base edge verdicts on real-cost metrics rather than legacy flat-cost calculations.
  * Added rules for tradeable cohort gating criteria and SQL reference for real-cost metric computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->