### PR TITLE
fix(daily-review): summarize test output in Claude prompt — kill "Prompt is too long"

### DIFF
--- a/.github/workflows/daily-trade-review-claude.yml
+++ b/.github/workflows/daily-trade-review-claude.yml
@@ -174,7 +174,13 @@ jobs:
             echo "You have access to gh CLI (authenticated), gcloud CLI, and node."
             echo ""
             echo "=== PRE-REVIEW TEST STATE ==="
-            cat test-results.txt
+            # Summarize, don't dump: the raw test-results.txt is ~6.6k lines /
+            # 440 KB (~110k tokens) of pino noise + per-test stdout. cat-ing it
+            # whole overflowed the Sonnet context ("Prompt is too long", #308).
+            # The summarizer keeps counts + failures (~10 lines); full log is a
+            # CI artifact. Fail-soft to the raw tail if the script is missing.
+            node scripts/summarize-test-output.js test-results.txt 2>/dev/null \
+              || tail -40 test-results.txt
             echo "==========================="
             echo ""
             echo "IMPORTANT: Create the GitHub Issue and implement fixes as PRs (deploy to VM to verify each, then rollback to main). Do NOT send email or Slack — the workflow handles notifications automatically."

--- a/scripts/summarize-test-output.js
+++ b/scripts/summarize-test-output.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * summarize-test-output — collapse a full `pnpm test` log down to its
+ * pass/fail summary plus any real failures, so the daily-review workflow can
+ * embed test state in the Claude prompt without overflowing the model context.
+ *
+ * Background: daily-review #308 (2026-06-05) filed an auto-stub because the
+ * Claude analysis step died with "Prompt is too long" at +17s. The raw
+ * test-results.txt was 6,623 lines / 439 KB (~110k tokens) — dominated by pino
+ * log lines and per-test stdout/stderr from *passing* simulated-error tests —
+ * and was `cat`-ed wholesale into the prompt. The prompt only needs the test
+ * VERDICT (counts + failures), not the firehose. This keeps a few hundred
+ * relevant lines; the full log still ships as a CI artifact for debugging.
+ *
+ * Usage (CLI):  node scripts/summarize-test-output.js test-results.txt
+ *               cat test-results.txt | node scripts/summarize-test-output.js
+ */
+
+// Strip ANSI escape sequences (colour codes vitest emits) so matching is robust.
+// eslint-disable-next-line no-control-regex
+const ANSI = /\x1b\[[0-9;]*m/g;
+
+// Lines worth keeping. Matched against the ANSI-stripped, trimmed line.
+const KEEP = [
+  /^={3,}.*={3,}$/,                       // === SECTION HEADERS ===
+  /\bTest Files\b/,                        // vitest "Test Files  N passed"
+  /^Tests\b/,                              // vitest "Tests  N passed | M skipped"
+  /\bTests\s+\d/,                          //   (with leading indent)
+  /\bDuration\b/,                          // vitest "Duration  16.72s"
+  /\bFAIL\b/,                              // failing file marker
+  /\bfailed\b/,                            // "N failed", "tests failed"
+  /^Unit:\s/,                              // workflow status footer
+  /\bIntegration:\s/,                      // workflow status footer
+  /^[✗×❯⎯]/,                               // failure markers / error rule lines
+  /^\s*[✗×]/,                              // indented failure markers
+  /AssertionError|Expected:|Received:/,    // assertion failure bodies
+];
+
+// Lines to always drop even if they happen to match a KEEP pattern — pino JSON
+// logs and per-test stdout/stderr from passing tests are pure noise.
+const DROP = [
+  /^\{.*"level":\s*\d+.*\}$/,              // pino JSON log line
+  /^(stdout|stderr)\s*\|/,                 // vitest per-test stream header
+  /Direction multiplier updated/,
+  /Failed to execute trade/,
+  /Risk check failed|TRADING HALTED|Position check failed/,
+  /\[OptimizationScheduler\]/,
+  /\[SignalSigmaCache\]/,
+  /\[AutoExecutor\]/,
+  /treating as failed trial/,             // simulated-failure test stdout (not a real test failure)
+];
+
+function summarizeTestOutput(raw, { maxLines = 200 } = {}) {
+  if (!raw || typeof raw !== 'string') return '';
+  const kept = [];
+  let truncated = false;
+
+  for (const original of raw.split('\n')) {
+    const line = original.replace(ANSI, '');
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (DROP.some((re) => re.test(trimmed))) continue;
+    if (!KEEP.some((re) => re.test(trimmed))) continue;
+
+    if (kept.length >= maxLines) {
+      truncated = true;
+      break;
+    }
+    kept.push(line.replace(/\s+$/, ''));
+  }
+
+  if (truncated) {
+    kept.push(`... [truncated — ${maxLines}-line cap reached; full log in CI artifacts]`);
+  }
+  return kept.join('\n');
+}
+
+module.exports = { summarizeTestOutput };
+
+// CLI entry point.
+if (require.main === module) {
+  const fs = require('node:fs');
+  const file = process.argv[2];
+  let raw = '';
+  try {
+    raw = file ? fs.readFileSync(file, 'utf8') : fs.readFileSync(0, 'utf8');
+  } catch (err) {
+    console.error(`summarize-test-output: cannot read input: ${err.message}`);
+    process.exit(0); // Fail soft — never block the review on a missing log.
+  }
+  process.stdout.write(summarizeTestOutput(raw) + '\n');
+}

--- a/scripts/summarize-test-output.test.js
+++ b/scripts/summarize-test-output.test.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for summarizeTestOutput — collapses the full `pnpm test` log
+ * (6.6k lines / 440 KB of pino noise + per-test stdout/stderr) down to the
+ * pass/fail summary + any real failures, so it can be embedded in the
+ * daily-review Claude prompt without blowing the model context window.
+ *
+ * Added 2026-06-05 after daily-review #308 filed an auto-stub: the Claude
+ * analysis step died with "Prompt is too long" at +17s — the raw
+ * test-results.txt (~110k tokens) was being `cat`-ed wholesale into the prompt.
+ */
+const assert = require('node:assert/strict');
+const { summarizeTestOutput } = require('./summarize-test-output.js');
+
+// Minimal ANSI helpers to mirror vitest's coloured output.
+const DIM = '\x1b[2m';
+const GREEN = '\x1b[32m';
+const RESET = '\x1b[39m';
+
+const cases = [
+  {
+    name: 'preserves the vitest "Test Files ... passed" summary line',
+    fn: () => {
+      const raw = [
+        `${DIM} Test Files ${RESET} ${GREEN}102 passed${RESET} | 1 skipped (103)`,
+        '{"level":30,"msg":"Direction multiplier updated"}',
+      ].join('\n');
+      const out = summarizeTestOutput(raw);
+      assert.match(out, /Test Files/);
+      assert.match(out, /102 passed/);
+    },
+  },
+  {
+    name: 'preserves the "Tests ... passed | skipped" line',
+    fn: () => {
+      const raw = ` Tests  1233 passed | 16 skipped (1249)`;
+      assert.match(summarizeTestOutput(raw), /1233 passed/);
+    },
+  },
+  {
+    name: 'preserves === section headers ===',
+    fn: () => {
+      const raw = '=== UNIT TESTS 2026-06-05 11:17 UTC ===\nnoise\n=== INTEGRATION TESTS ===';
+      const out = summarizeTestOutput(raw);
+      assert.match(out, /=== UNIT TESTS/);
+      assert.match(out, /=== INTEGRATION TESTS ===/);
+    },
+  },
+  {
+    name: 'drops pino JSON log lines',
+    fn: () => {
+      const raw = [
+        '{"level":30,"time":123,"name":"weighted-average-combiner","msg":"Direction multiplier updated"}',
+        ' Tests  5 passed (5)',
+      ].join('\n');
+      const out = summarizeTestOutput(raw);
+      assert.doesNotMatch(out, /Direction multiplier updated/);
+      assert.match(out, /5 passed/);
+    },
+  },
+  {
+    name: 'drops per-test stdout/stderr noise lines',
+    fn: () => {
+      const raw = [
+        `${DIM}stdout${RESET} | packages/dashboard/src/services/OptimizationScheduler.test.ts > some test`,
+        '[OptimizationScheduler] Trial 1 (id=0): empty params — treating as failed trial',
+        '[RiskManager] Risk check failed: Error: connection timeout',
+        'Failed to execute trade: TypeError: Cannot read properties of undefined (reading \'id\')',
+        ' Test Files  1 passed (1)',
+      ].join('\n');
+      const out = summarizeTestOutput(raw);
+      assert.doesNotMatch(out, /OptimizationScheduler\] Trial/);
+      assert.doesNotMatch(out, /Failed to execute trade/);
+      assert.doesNotMatch(out, /Risk check failed/);
+      assert.match(out, /1 passed/);
+    },
+  },
+  {
+    name: 'preserves real failures (FAIL lines and ✗/× markers)',
+    fn: () => {
+      const raw = [
+        ' FAIL  packages/dashboard/src/foo.test.ts > does a thing',
+        `   ${DIM}✗${RESET} broken assertion`,
+        ' Tests  1 failed | 4 passed (5)',
+      ].join('\n');
+      const out = summarizeTestOutput(raw);
+      assert.match(out, /FAIL/);
+      assert.match(out, /1 failed/);
+    },
+  },
+  {
+    name: 'preserves the Unit:/Integration: status footer',
+    fn: () => {
+      const raw = 'noise\nUnit: pass, Integration: pass';
+      assert.match(summarizeTestOutput(raw), /Unit: pass, Integration: pass/);
+    },
+  },
+  {
+    name: 'collapses a large noisy log to a small summary',
+    fn: () => {
+      const noise = Array.from({ length: 5000 }, (_, i) =>
+        `{"level":30,"time":${i},"msg":"Direction multiplier updated"}`).join('\n');
+      const raw = [
+        '=== UNIT TESTS ===',
+        noise,
+        ' Test Files  102 passed | 1 skipped (103)',
+        ' Tests  1233 passed | 16 skipped (1249)',
+        ' Duration  16.72s',
+      ].join('\n');
+      const out = summarizeTestOutput(raw);
+      // Must shrink by at least 50x and stay well under the line cap.
+      assert.ok(out.length < raw.length / 50, `expected big shrink, got ${out.length} vs ${raw.length}`);
+      assert.match(out, /102 passed/);
+      assert.match(out, /1233 passed/);
+    },
+  },
+  {
+    name: 'respects a hard line cap even when many lines match',
+    fn: () => {
+      const manyFails = Array.from({ length: 500 }, (_, i) => ` FAIL  test-${i}.ts > case`).join('\n');
+      const out = summarizeTestOutput(manyFails, { maxLines: 120 });
+      const lineCount = out.split('\n').filter(Boolean).length;
+      assert.ok(lineCount <= 122, `expected <=122 lines (120 + truncation notice), got ${lineCount}`);
+      assert.match(out, /truncat/i);
+    },
+  },
+  {
+    name: 'empty / undefined input does not throw',
+    fn: () => {
+      assert.equal(typeof summarizeTestOutput(''), 'string');
+      assert.equal(typeof summarizeTestOutput(undefined), 'string');
+    },
+  },
+];
+
+let failed = 0;
+for (const c of cases) {
+  try {
+    c.fn();
+    console.log(`  ✓ ${c.name}`);
+  } catch (err) {
+    failed += 1;
+    console.error(`  ✗ ${c.name}\n    ${err.message}`);
+  }
+}
+if (failed > 0) {
+  console.error(`\n${failed}/${cases.length} tests failed`);
+  process.exit(1);
+}
+console.log(`\n${cases.length}/${cases.length} tests passed`);


### PR DESCRIPTION
## Problem

Daily-review **#308** (2026-06-05) filed an [auto-stub](https://github.com/JaviMaligno/polymarket-trader/issues/308) instead of a review. The `Run Claude Code Analysis` step died **17 seconds in** with `Prompt is too long` (`claude-output.log` = 19 bytes = exactly that string). It is the **initial prompt** that overflows — not in-session context growth.

## Root cause

The step `cat`-ed the full `test-results.txt` straight into the Claude prompt (workflow lines 176-178). On the #308 run that file was **6,623 lines / 439 KB (~110k tokens)** — dominated by pino log lines (`Direction multiplier updated` ×100s) and per-test stdout/stderr from *passing* simulated-error tests. The prompt only needs the test **verdict**, not the firehose.

This is **not** caused by #306 (which added ~1 KB to `daily-review-prompt.md`). It is a latent structural fragility: the prompt sat near the limit and the test log crossed it.

## Fix

`scripts/summarize-test-output.js` — strips ANSI, keeps the vitest pass/fail counts, `=== section headers ===`, durations and any real failures (`FAIL`, `✗`, assertion bodies), and drops the log noise. Wired into the workflow in place of `cat`, with a fail-soft fallback to `tail -40` if the script is ever missing. The full `test-results.txt` still ships as a CI artifact.

### Evidence (real #308 log)

| | input | output |
|---|---|---|
| bytes | 439,317 | **533** (825x smaller) |
| lines | 6,623 | 10 |
| full prompt tokens | ~116k | **~7k** |

Preserved verbatim: `Test Files 102 passed | 1 skipped`, `Tests 1233 passed | 16 skipped`, integration `12 passed`, both `=== … ===` headers, durations.

## Tests

`scripts/summarize-test-output.test.js` — 10/10 (TDD): preserves summary/headers/failures, drops pino + per-test noise, 50x+ shrink on a large log, hard line cap, empty-input safety.

## Notes / not in scope

- Latent cosmetic bug noticed but **left out** to keep this PR tight: the `Unit: , Integration:` footer is empty because the workflow interpolates `steps.pre_tests.outputs.*` inside the same step that defines them. Harmless — the vitest counts (which the summarizer keeps) carry the real signal.
- Touches `.github/` → not eligible for daily-review auto-merge; merge manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved daily review workflow efficiency by implementing optimized test output summarization instead of full log inclusion.
  * Added fallback mechanism for graceful handling of summarization failures.

* **Tests**
  * Added comprehensive test coverage for the test output summarization utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->