### PR TITLE
feat(edge-research): H-INE-5 validator + offline --datasets-dir mode + weekly GHA scoreboard

### DIFF
--- a/.github/workflows/edge-research-weekly.yml
+++ b/.github/workflows/edge-research-weekly.yml
@@ -1,0 +1,122 @@
+name: Edge Research Weekly Scoreboard
+
+# Re-runs the edge-research harness against the live panel once a week (after the
+# market_panel forward snapshot accrues), commits the refreshed scoreboard, and
+# alerts only when a CLEAN pass appears (status=pass with NO caveat) — a new
+# tradeable edge. The harness itself runs offline from CSVs exported on the VM
+# (the dashboard container is Node/Alpine; no Python/psycopg2), via
+# `run.py --datasets-dir`.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'    # Mondays 09:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: edge-research-weekly
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  scoreboard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: 'projects/992492426638/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+          service_account: 'github-deploy@project-94e9f6f2-aba7-4cb6-afc.iam.gserviceaccount.com'
+
+      - name: Setup Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Cleanup stale SSH keys in project metadata
+        # Mirrors daily-review: each `gcloud compute ssh` uploads a key; without
+        # pruning, metadata grows unbounded and delays key propagation past the
+        # ConnectTimeout, causing `Permission denied (publickey)`.
+        run: |
+          set -euo pipefail
+          tmp=$(mktemp)
+          gcloud compute project-info describe --format=json \
+            | jq -r '.commonInstanceMetadata.items[]? | select(.key == "ssh-keys") | .value' \
+            | awk -F: '{ lines[$1]=$0 } END { for (k in lines) if (k != "") print lines[k] }' \
+            > "$tmp"
+          if [ -s "$tmp" ]; then
+            gcloud compute project-info add-metadata --metadata-from-file=ssh-keys="$tmp"
+          fi
+          rm -f "$tmp"
+
+      - name: Export datasets from VM as CSV
+        run: |
+          set -euo pipefail
+          mkdir -p datasets
+          PSQL="docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c"
+          gcloud compute ssh polymarket-vm --zone=us-east1-b --command="$PSQL \"\\copy (SELECT market_id, snapshot_at, end_date, yes_price, market_type, market_score, outcome_yes FROM market_panel WHERE outcome_yes IS NOT NULL) TO STDOUT WITH CSV HEADER\"" > datasets/market_panel.csv
+          gcloud compute ssh polymarket-vm --zone=us-east1-b --command="$PSQL \"\\copy (SELECT market_id, entry_yes_price, market_type, net_pnl, net_pnl_real, entry_cost_real, resolved_at FROM flb_shadow_signals WHERE net_pnl_real IS NOT NULL) TO STDOUT WITH CSV HEADER\"" > datasets/flb_shadow_signals.csv
+          echo "market_panel rows: $(($(wc -l < datasets/market_panel.csv) - 1))"
+          echo "flb rows: $(($(wc -l < datasets/flb_shadow_signals.csv) - 1))"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install deps
+        run: pip install pandas numpy
+
+      - name: Run harness
+        run: |
+          python scripts/edge-research/run.py \
+            --datasets-dir datasets \
+            --out scripts/edge-research/out \
+            --computed-at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+      - name: Detect clean passes (tradeable edge, no caveat)
+        id: passes
+        run: |
+          # A clean pass = status==pass AND caveats column empty. H-INE-5's
+          # flat-cost pass carries a caveat, so it does NOT trigger here.
+          CLEAN=$(python - <<'PY'
+          import csv
+          rows = list(csv.DictReader(open("scripts/edge-research/out/scoreboard.csv")))
+          clean = [r for r in rows if r["status"] == "pass" and not r["caveats"].strip()]
+          for r in clean:
+              print(f"{r['id']} ({r['class']}) edge_net={r['edge_net_pct']} n={r['n']}")
+          PY
+          )
+          if [ -n "$CLEAN" ]; then
+            echo "found=true" >> $GITHUB_OUTPUT
+            { echo 'detail<<EOF'; echo "$CLEAN"; echo 'EOF'; } >> $GITHUB_OUTPUT
+          else
+            echo "found=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Alert on clean pass
+        if: steps.passes.outputs.found == 'true' && env.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          MSG="🟢 Edge-research: a CLEAN pass (tradeable, no caveat) appeared on the scoreboard:\n${{ steps.passes.outputs.detail }}"
+          curl -fsS -X POST -H 'Content-type: application/json' \
+            --data "$(python -c "import json,sys; print(json.dumps({'text': sys.argv[1]}))" "$MSG")" \
+            "$SLACK_WEBHOOK_URL" || echo "Slack post failed (non-fatal)"
+
+      - name: Commit refreshed scoreboard
+        continue-on-error: true
+        run: |
+          git config user.name "Edge Research (weekly)"
+          git config user.email "noreply@anthropic.com"
+          git add scripts/edge-research/out/scoreboard.md   # .csv is gitignored by design
+          if git diff --cached --quiet; then
+            echo "Scoreboard unchanged."
+          else
+            git commit -m "chore(edge-research): weekly scoreboard refresh [skip ci]"
+            git push origin HEAD:main
+          fi

--- a/scripts/edge-research/data.py
+++ b/scripts/edge-research/data.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import os, pandas as pd
+import os, pathlib, pandas as pd
 
 # --- market_panel: resolved, earliest snapshot per market (calibration, supervised) ---
 
@@ -78,4 +78,40 @@ def load_all_datasets(database_url: str | None = None) -> dict:
             out[token] = df if df is not None and len(df) else None
         except Exception:
             out[token] = None
+    return out
+
+
+# --- offline CSV mode (--datasets-dir): drive the harness without DB access ---
+#
+# The dashboard container is Node/Alpine (no Python, no psycopg2), so the weekly
+# GHA runner exports each raw query to CSV on the VM, then runs run.py against
+# the CSV dir. A CSV mirrors the RAW SQL output; the same shape_* transforms run
+# on it, so the resulting frames are identical to the DB path.
+
+def _read_raw_csv(path: pathlib.Path, date_cols: list[str]) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    for c in date_cols:
+        if c in df.columns:
+            df[c] = pd.to_datetime(df[c], utc=True)
+    return df
+
+def load_all_datasets_from_dir(datasets_dir: str) -> dict:
+    """Mirror of load_all_datasets, reading raw CSVs from `datasets_dir` instead
+    of the DB. Expected files: market_panel.csv (raw RESOLVED_SQL columns) and
+    flb_shadow_signals.csv (raw FLB_SQL columns). A missing/empty/invalid file
+    maps its token(s) to None, same contract as the DB path."""
+    d = pathlib.Path(datasets_dir)
+    out: dict = {}
+    try:
+        raw = _read_raw_csv(d / "market_panel.csv", ["snapshot_at", "end_date"])
+        out["market_panel_resolved"] = shape_panel(raw) if len(raw) else None
+        out["market_panel_full"] = shape_panel_full(raw) if len(raw) else None
+    except Exception:
+        out["market_panel_resolved"] = None
+        out["market_panel_full"] = None
+    try:
+        flb = _read_raw_csv(d / "flb_shadow_signals.csv", ["resolved_at"])
+        out["flb_shadow_signals"] = flb if len(flb) else None
+    except Exception:
+        out["flb_shadow_signals"] = None
     return out

--- a/scripts/edge-research/out/scoreboard.md
+++ b/scripts/edge-research/out/scoreboard.md
@@ -2,6 +2,7 @@
 
 | id | class | n | edge_net% | insample% | sig | status | caveats |
 |----|-------|---|-----------|-----------|-----|--------|---------|
+| H-INE-5 | inefficiency | 154 | 1.50 | 1.50 | 0.00 | pass | flat cost; real-cost refuted for this side by H-INE-1 (FLB) |
 | H-INE-1 | inefficiency | 101 | -0.28 | -0.28 | 0.03 | fail |  |
 | H-SUP-1 | supervised | 434 | -1.30 | 5.19 | 0.02 | fail |  |
 | H-INE-1 | inefficiency | 54 | -1.35 | -1.35 | 0.07 | fail |  |
@@ -19,11 +20,8 @@
 | H-CAL-4 | calibration | 295 |  |  |  | fail |  |
 | H-INE-1 | inefficiency | 0 |  |  |  | inconclusive | n=0 below floor 30 |
 | H-INE-1 | inefficiency | 5 |  |  |  | inconclusive | n=5 below floor 30 |
+| H-INE-5 | inefficiency | 10 |  |  |  | inconclusive | n=10 below floor 50 |
 | H-ENS-1 | ensemble | 0 |  |  |  | inconclusive | fewer than 2 passing components — nothing to combine |
-
-## Pending (data available, validator not implemented yet)
-
-- H-INE-5 — Time-decay extreme band (pending)
 
 ## Blocked (data not available)
 

--- a/scripts/edge-research/run.py
+++ b/scripts/edge-research/run.py
@@ -5,6 +5,7 @@ from validators.calibration import CalibrationValidator
 from validators.flb import FLBValidator
 from validators.supervised import SupervisedValidator
 from validators.ensemble import EnsembleValidator
+from validators.ine5 import TimeDecayExtremeBandValidator
 from scoreboard import render_markdown, render_csv
 
 # Primary hypothesis_id → validator factory. A validator may emit several slices
@@ -13,7 +14,8 @@ from scoreboard import render_markdown, render_csv
 # hypotheses without a validator yet (reported as `pending`, never dropped).
 # Extended as sub-projects B/C land validators.
 VALIDATORS = {"H-CAL-1": CalibrationValidator, "H-INE-1": FLBValidator,
-              "H-SUP-1": SupervisedValidator, "H-ENS-1": EnsembleValidator}
+              "H-SUP-1": SupervisedValidator, "H-ENS-1": EnsembleValidator,
+              "H-INE-5": TimeDecayExtremeBandValidator}
 
 
 def _ctx(datasets, computed_at):
@@ -49,14 +51,24 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--out", default="scripts/edge-research/out")
     ap.add_argument("--computed-at", required=True, help="ISO timestamp (pass explicitly for determinism)")
+    ap.add_argument("--datasets-dir", default=None,
+                    help="Load datasets from raw CSVs in this dir instead of the DB "
+                         "(offline runner mode; no DATABASE_URL / psycopg2 needed).")
     args = ap.parse_args()
-    from data import load_all_datasets
-    datasets = load_all_datasets()
+    if args.datasets_dir:
+        from data import load_all_datasets_from_dir
+        datasets = load_all_datasets_from_dir(args.datasets_dir)
+    else:
+        from data import load_all_datasets
+        datasets = load_all_datasets()
     res = run_validators(datasets, args.computed_at)
     outdir = pathlib.Path(args.out); outdir.mkdir(parents=True, exist_ok=True)
+    # encoding pinned: the scoreboard contains em-dashes; the default write_text
+    # encoding is the platform locale (cp1252 on Windows) which mangles them.
     (outdir / "scoreboard.md").write_text(
-        render_markdown(res["verdicts"], res["blocked"], res.get("pending", [])))
-    (outdir / "scoreboard.csv").write_text(render_csv(res["verdicts"]))
+        render_markdown(res["verdicts"], res["blocked"], res.get("pending", [])),
+        encoding="utf-8")
+    (outdir / "scoreboard.csv").write_text(render_csv(res["verdicts"]), encoding="utf-8")
     print(f"Wrote {outdir}/scoreboard.md ({len(res['verdicts'])} verdicts, "
           f"{len(res['blocked'])} blocked, {len(res.get('pending', []))} pending)")
 

--- a/scripts/edge-research/tests/test_data.py
+++ b/scripts/edge-research/tests/test_data.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from data import shape_panel
+from data import shape_panel, load_all_datasets_from_dir
 
 def test_shape_panel_takes_earliest_snapshot_and_computes_ttr():
     raw = pd.DataFrame({
@@ -17,3 +17,57 @@ def test_shape_panel_takes_earliest_snapshot_and_computes_ttr():
     assert m1.yes_price == 0.10               # earliest snapshot kept
     assert abs(m1.ttr_days - 10.0) < 1e-6     # 05-29 minus 05-19
     assert set(["yes_price","outcome_yes","market_type","ttr_days","market_score"]).issubset(df.columns)
+
+
+# --- CSV / --datasets-dir mode (offline runner, no DB) ---
+
+def _write_csvs(d):
+    # Raw market_panel rows (mirror of RESOLVED_SQL output) — two markets, m1
+    # with two snapshots so the earliest-snapshot shaping is exercised.
+    pd.DataFrame({
+        "market_id": ["m1", "m1", "m2"],
+        "snapshot_at": ["2026-05-19", "2026-05-26", "2026-05-19"],
+        "end_date": ["2026-05-29", "2026-05-29", "2026-06-08"],
+        "yes_price": [0.10, 0.40, 0.80],
+        "market_type": ["event_long", "event_long", "event_short"],
+        "market_score": [0.5, 0.5, 0.6],
+        "outcome_yes": [1, 1, 0],
+    }).to_csv(d / "market_panel.csv", index=False)
+    pd.DataFrame({
+        "market_id": ["a", "b"],
+        "entry_yes_price": [0.05, 0.07],
+        "market_type": ["event_long", "crypto_daily"],
+        "net_pnl": [0.02, -0.01],
+        "net_pnl_real": [0.015, -0.02],
+        "entry_cost_real": [0.004, 0.012],
+        "resolved_at": ["2026-05-20", "2026-05-21"],
+    }).to_csv(d / "flb_shadow_signals.csv", index=False)
+
+
+def test_load_from_dir_matches_db_shaping(tmp_path):
+    _write_csvs(tmp_path)
+    out = load_all_datasets_from_dir(str(tmp_path))
+    # Same three tokens the DB path produces.
+    assert set(out) == {"market_panel_resolved", "market_panel_full", "flb_shadow_signals"}
+    res = out["market_panel_resolved"]
+    assert len(res) == 2                                  # one row per market (earliest)
+    m1 = res[res.market_id == "m1"].iloc[0]
+    assert m1.yes_price == 0.10                           # earliest snapshot kept
+    assert abs(m1.ttr_days - 10.0) < 1e-6                 # dates parsed → TTR computed
+    assert out["market_panel_full"].shape[0] == 3        # all snapshots retained
+    flb = out["flb_shadow_signals"]
+    assert len(flb) == 2
+    assert "net_pnl_real" in flb.columns
+
+
+def test_load_from_dir_missing_file_maps_to_none(tmp_path):
+    # Only the flb file present → market_panel tokens are None, flb still loads.
+    pd.DataFrame({
+        "market_id": ["a"], "entry_yes_price": [0.05], "market_type": ["event_long"],
+        "net_pnl": [0.02], "net_pnl_real": [0.015], "entry_cost_real": [0.004],
+        "resolved_at": ["2026-05-20"],
+    }).to_csv(tmp_path / "flb_shadow_signals.csv", index=False)
+    out = load_all_datasets_from_dir(str(tmp_path))
+    assert out["market_panel_resolved"] is None
+    assert out["market_panel_full"] is None
+    assert out["flb_shadow_signals"] is not None

--- a/scripts/edge-research/tests/test_ine5.py
+++ b/scripts/edge-research/tests/test_ine5.py
@@ -1,0 +1,70 @@
+import numpy as np, pandas as pd, types
+from validators.ine5 import TimeDecayExtremeBandValidator
+
+
+def _ctx(df, ine5_min_n=40, cost=0.005):
+    return types.SimpleNamespace(datasets={"market_panel_resolved": df},
+                                 cost=cost, computed_at="t", seed=7,
+                                 ine5_min_n=ine5_min_n, ine5_band=0.10,
+                                 ine5_ttr_max_days=7.0)
+
+
+def _rows(n, price, ttr, p_yes, seed):
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame({
+        "market_id": [f"m{seed}_{i}" for i in range(n)],
+        "yes_price": np.full(n, price),
+        "outcome_yes": (rng.uniform(size=n) < p_yes).astype(int),
+        "market_type": ["event_short"] * n, "ttr_days": np.full(n, ttr),
+        "market_score": [0.5] * n,
+    })
+
+
+def _band(verdicts, name):
+    return [v for v in verdicts if v.class_metric.get("band") == name][0]
+
+
+def test_overpriced_longshot_near_expiry_short_passes():
+    # priced 0.10 but only 2% resolve YES near expiry → SHORT captures the gap
+    df = _rows(200, 0.10, 3.0, 0.02, seed=1)
+    v = TimeDecayExtremeBandValidator().run(_ctx(df))
+    ls = _band(v, "longshot")
+    assert ls.hypothesis_id == "H-INE-5"
+    assert ls.n == 200
+    assert ls.status == "pass"
+    assert ls.edge_net_pct > 0
+
+
+def test_fairly_priced_longshot_fails():
+    # priced 0.10 and 10% resolve YES → SHORT edge ≈ -cost → fail
+    df = _rows(200, 0.10, 3.0, 0.10, seed=2)
+    v = TimeDecayExtremeBandValidator().run(_ctx(df))
+    ls = _band(v, "longshot")
+    assert ls.status == "fail"
+    assert ls.edge_net_pct < 0
+
+
+def test_high_ttr_markets_excluded():
+    # all markets far from expiry (ttr 30d > 7d cap) → no enterable rows
+    df = _rows(200, 0.10, 30.0, 0.02, seed=3)
+    v = TimeDecayExtremeBandValidator().run(_ctx(df))
+    ls = _band(v, "longshot")
+    assert ls.n == 0
+    assert ls.status == "inconclusive"
+
+
+def test_longshot_verdict_carries_flat_cost_caveat():
+    # The panel only has flat cost; the real-cost answer lives in H-INE-1.
+    df = _rows(200, 0.10, 3.0, 0.02, seed=4)
+    v = TimeDecayExtremeBandValidator().run(_ctx(df))
+    ls = _band(v, "longshot")
+    assert any("H-INE-1" in c for c in ls.n_caveats)
+
+
+def test_favorite_band_emitted_and_uses_long_direction():
+    # favorites priced 0.90 that mostly resolve YES (0.97) → LONG positive
+    df = _rows(200, 0.90, 3.0, 0.97, seed=5)
+    v = TimeDecayExtremeBandValidator().run(_ctx(df))
+    fav = _band(v, "favorite")
+    assert fav.class_metric["direction"] == 1
+    assert fav.edge_net_pct > 0

--- a/scripts/edge-research/tests/test_run.py
+++ b/scripts/edge-research/tests/test_run.py
@@ -1,3 +1,4 @@
+import subprocess, sys, pathlib
 import numpy as np, pandas as pd
 from run import run_validators
 
@@ -19,12 +20,36 @@ def test_run_dispatches_calibration_and_is_deterministic():
     r2 = run_validators(datasets, computed_at="t")
     assert [v.to_json() for v in r1["verdicts"]] == [v.to_json() for v in r2["verdicts"]]
     assert any(v.hypothesis_id == "H-CAL-1" for v in r1["verdicts"])
-    # H-MM-1 needs gamma_rewards → blocked when only the panel is available
+    # H-INE-5 (time-decay extreme band) now has a validator → it emits a verdict
+    assert any(v.hypothesis_id == "H-INE-5" for v in r1["verdicts"])
+    # H-MM-1 needs price_history_bidask → blocked when only the panel is available
     assert any(b["id"] == "H-MM-1" for b in r1["blocked"])
 
 def test_run_reports_pending_for_runnable_hypothesis_without_validator():
-    # H-INE-5 needs market_panel_resolved (available) but has no validator yet →
-    # it must be reported as pending, never silently dropped.
-    datasets = {"market_panel_resolved": _panel()}
+    # H-INE-2 needs market_panel_resolved + price_history_resolved (both supplied)
+    # but has no validator yet → it must be reported as pending, never dropped.
+    datasets = {"market_panel_resolved": _panel(),
+                "price_history_resolved": _panel()}
     res = run_validators(datasets, computed_at="t")
-    assert any(p["id"] == "H-INE-5" for p in res["pending"])
+    assert any(p["id"] == "H-INE-2" for p in res["pending"])
+
+def test_main_datasets_dir_mode_writes_scoreboard(tmp_path):
+    # Offline CSV mode end-to-end: a tiny market_panel.csv drives run.py without
+    # a DB, and a scoreboard is produced.
+    pd.DataFrame({
+        "market_id": [f"m{i}" for i in range(300)],
+        "snapshot_at": ["2026-05-19"] * 300,
+        "end_date": ["2026-05-22"] * 300,
+        "yes_price": [0.10] * 300,
+        "market_type": ["event_short"] * 300,
+        "market_score": [0.5] * 300,
+        "outcome_yes": ([0] * 294) + ([1] * 6),   # 2% YES → longshot SHORT edge
+    }).to_csv(tmp_path / "market_panel.csv", index=False)
+    root = pathlib.Path(__file__).resolve().parents[1]
+    res = subprocess.run(
+        [sys.executable, str(root / "run.py"), "--datasets-dir", str(tmp_path),
+         "--out", str(tmp_path / "out"), "--computed-at", "t"],
+        capture_output=True, text=True, cwd=str(root))
+    assert res.returncode == 0, res.stderr
+    assert (tmp_path / "out" / "scoreboard.md").exists()
+    assert "H-INE-5" in (tmp_path / "out" / "scoreboard.md").read_text()

--- a/scripts/edge-research/validators/ine5.py
+++ b/scripts/edge-research/validators/ine5.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+import numpy as np
+from verdict import Verdict
+from validators.base import bootstrap_ci
+
+
+class TimeDecayExtremeBandValidator:
+    """H-INE-5 — time-decay extreme-band mispricing on the resolved panel.
+
+    Near expiry (ttr_days <= cap), do the extreme price bands drift to
+    resolution enough to beat cost? Two cohorts, each with a FIXED structural
+    direction from the favorite-longshot prior (so the direction is a hypothesis,
+    not fit to the data):
+      - longshot (yes_price <= band): SHORT YES (-1) — longshots are overpriced,
+        bet they resolve NO.
+      - favorite (yes_price >= 1-band): LONG YES (+1) — favorites are underpriced.
+    Per-market entry-only return: direction*(outcome - price) - cost, held to
+    resolution. `pass` only on a positive, bootstrap-significant mean.
+
+    Cost is FLAT (ctx.cost): the panel has no per-market spread. The real-cost
+    answer for the longshot side lives in H-INE-1 (FLB), which refuted it; this
+    flat-cost verdict is observability, not a promotion signal — carried as a
+    caveat on the longshot cohort.
+    """
+
+    hypothesis_id = "H-INE-5"
+    hclass = "inefficiency"
+
+    def required_inputs(self) -> list[str]:
+        return ["market_panel_resolved"]
+
+    def run(self, ctx) -> list[Verdict]:
+        df = ctx.datasets["market_panel_resolved"]
+        band = getattr(ctx, "ine5_band", 0.10)
+        ttr_max = getattr(ctx, "ine5_ttr_max_days", 7.0)
+        near = df[df["ttr_days"] <= ttr_max]
+        return [
+            self._cohort(ctx, near[near["yes_price"] <= band], "longshot", -1,
+                         ["flat cost; real-cost refuted for this side by H-INE-1 (FLB)"]),
+            self._cohort(ctx, near[near["yes_price"] >= 1.0 - band], "favorite", 1, []),
+        ]
+
+    def _cohort(self, ctx, sub, label, direction, caveats) -> Verdict:
+        floor = getattr(ctx, "ine5_min_n", 50)
+        n = len(sub)
+        meta = {"band": label, "direction": direction,
+                "ttr_max_days": getattr(ctx, "ine5_ttr_max_days", 7.0)}
+        cost_model = f"entry_only_{ctx.cost}"
+        if n < floor:
+            return Verdict(self.hypothesis_id, self.hclass, n, None, None, None,
+                           "full", meta, cost_model, "inconclusive",
+                           caveats + [f"n={n} below floor {floor}"], ctx.computed_at)
+        price = sub["yes_price"].to_numpy(float)
+        outcome = sub["outcome_yes"].to_numpy(float)
+        r = direction * (outcome - price) - ctx.cost
+        edge = float(r.mean())
+        lo, hi = bootstrap_ci(r, seed=ctx.seed)
+        status = "pass" if (edge > 0 and lo > 0) else "fail"
+        meta["avg_price"] = float(price.mean())
+        return Verdict(self.hypothesis_id, self.hclass, n, edge, edge,
+                       float((hi - lo) / 2), "full", meta, cost_model,
+                       status, caveats, ctx.computed_at)


### PR DESCRIPTION
## Summary

Advances the two remaining edge-research items that were actionable now:

- **H-INE-5 validator** (time-decay extreme-band) — the only "pending lever" hypothesis runnable without new data collection (needs only `market_panel_resolved`, already loaded). Structural favorite-longshot direction per cohort (longshot near-expiry → SHORT, favorite near-expiry → LONG), entry-only return net of flat cost, bootstrap significance gate.
- **Offline `--datasets-dir` mode** — `run.py` loads raw CSVs (exported on the VM via `psql \copy`) instead of the DB, so a runner without `psycopg2` can drive the harness. The CSV mirrors raw SQL output; the existing `shape_*` transforms apply unchanged.
- **Weekly GHA workflow** (`edge-research-weekly.yml`) — exports panel + flb CSVs from the VM, runs the harness, commits the refreshed scoreboard, and alerts only on a **clean pass** (status=pass with no caveat = genuinely tradeable edge).
- **utf-8 pin** on scoreboard writes (em-dashes were mangled under the Windows cp1252 locale).

## Real-data result (regenerated scoreboard)

H-INE-5 longshot cohort **passes at FLAT cost (1.50%, n=154)** but carries an explicit caveat that the real-cost answer (H-INE-1 / FLB) refuted this side. The scoreboard now shows the flat-vs-real gap side by side — exactly the honest framing: the flat-cost panel reproduces the FLB in-sample longshot edge that dies at real cost. Favorite cohort inconclusive (n=10; panel is 96% event_long longshots).

The remaining levers stay **blocked on data that is not collected**: H-MM-1 (no bid/ask in `price_history` — 616k rows, all NULL), H-MM-2 (no rewards fields), H-INE-3 (news pipeline), H-INE-4 (manual mapping).

## Test Plan

- [x] 38/38 harness tests green (`pytest scripts/edge-research`)
- [x] `--datasets-dir` exercised end-to-end against live VM CSV exports (2,165 panel rows, 160 flb rows)
- [ ] Weekly workflow validated on first scheduled/dispatch run (gcloud SSH + export path is untested in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated weekly scoreboard refresh with Slack notifications
  * New hypothesis detecting extreme band trading inefficiencies near market expiry

* **Tests**
  * Added comprehensive test coverage for new hypothesis and offline data loading modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->