### PR TITLE
fix(data-collector): trades misattribution — query by market, real dedup

### DIFF
--- a/docs/superpowers/plans/2026-06-06-trades-misattribution-fix.md
+++ b/docs/superpowers/plans/2026-06-06-trades-misattribution-fix.md
@@ -12,6 +12,14 @@
 
 **Branch:** `fix-trades-misattribution` (already created off `main`).
 
+**Post-review revision (applied):** the INSERT uses **bare** `ON CONFLICT DO NOTHING`
+(not an explicit column target, which would raise `42P10` and silently insert zero
+trades on the live DB where the index is absent). The index is delivered to
+already-initialised volumes by a startup `ensureRuntimeSchema()`
+(`database/runtimeSchema.ts`, wired in `index.ts`), in addition to `001_schema.sql`
+for fresh installs. Task 3's ops sequence is correspondingly: deploy → `TRUNCATE
+trades` → restart data-collector (startup ensure creates the index on the empty table).
+
 **Background the implementer needs:**
 - Root cause: `ClobCollector.fetchTrades(tokenId)` called `data-api/trades?asset_id=<tokenId>`, but the data-api IGNORES `asset_id` and returns a GLOBAL feed of recent trades across all markets; `syncTradesToDb` tagged every one with the queried token. Only `market=<conditionId>` filters correctly.
 - A data-api trade object has these relevant fields: `asset` (the CLOB token id the trade belongs to), `side` (`BUY`/`SELL`), `price` (string), `size` (string), `timestamp` (unix **seconds**), `transactionHash`, `proxyWallet`, `outcome`, `conditionId`.
@@ -330,7 +338,10 @@ Expected: the merge commit is present and `polymarket-data-collector` is `Up (he
 ```bash
 gcloud compute ssh polymarket-vm --zone=us-east1-b -- "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c 'TRUNCATE trades;' -c 'CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_dedup ON trades (time, tx_hash, token_id, side, price, size);'"
 ```
-Expected: `TRUNCATE TABLE` then `CREATE INDEX`.
+Expected: `TRUNCATE TABLE` then `CREATE INDEX`. (Creating the index manually here is
+equivalent to restarting the data-collector so its `ensureRuntimeSchema()` builds it
+on the now-empty table — do either. The index must be built *after* the truncate; on
+the contaminated table it would fail on the existing duplicates.)
 
 - [ ] **Step 3: Wait for repopulation, then verify reconciliation**
 

--- a/docs/superpowers/plans/2026-06-06-trades-misattribution-fix.md
+++ b/docs/superpowers/plans/2026-06-06-trades-misattribution-fix.md
@@ -1,0 +1,380 @@
+# Trades Misattribution Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the raw `trades` table reflect real per-token executions by querying the data-api with `market=<conditionId>` and storing each trade under its true `asset`, so the live OFI/Hawkes signals stop computing on a misattributed global feed.
+
+**Architecture:** Fix `ClobCollector` trade collection (query by market, store by asset, real dedup), add a unique dedup index, and purge the contaminated history on the VM. No signal-weight changes — OFI falls back to book-only/null and Hawkes clears its in-memory state on the deploy restart.
+
+**Tech Stack:** TypeScript (Node), vitest, PostgreSQL/TimescaleDB.
+
+**Spec:** `docs/superpowers/specs/2026-06-06-trades-misattribution-fix-design.md`. Read it for the root-cause evidence and blast-radius audit.
+
+**Branch:** `fix-trades-misattribution` (already created off `main`).
+
+**Background the implementer needs:**
+- Root cause: `ClobCollector.fetchTrades(tokenId)` called `data-api/trades?asset_id=<tokenId>`, but the data-api IGNORES `asset_id` and returns a GLOBAL feed of recent trades across all markets; `syncTradesToDb` tagged every one with the queried token. Only `market=<conditionId>` filters correctly.
+- A data-api trade object has these relevant fields: `asset` (the CLOB token id the trade belongs to), `side` (`BUY`/`SELL`), `price` (string), `size` (string), `timestamp` (unix **seconds**), `transactionHash`, `proxyWallet`, `outcome`, `conditionId`.
+- `markets` columns: `id`, `condition_id`, `clob_token_id_yes`, `clob_token_id_no`, `tracking_status`, `market_score`.
+- `trades` table: `id SERIAL`, PK `(time, id)`, columns `time, market_id, token_id, side, price, size, value_usd, fee, maker_address, taker_address, tx_hash, ...`. It is a TimescaleDB hypertable partitioned on `time` (so any unique index MUST include `time`).
+- Test infra: `vitest`. Mock `../database/connection.js` (`query`), `../services/RateLimiter.js` (`getRateLimiter`), and `axios`. Run tests from `packages/data-collector`.
+
+---
+
+## Task 1: Fix `ClobCollector` trade collection (query by market, store by asset, real dedup)
+
+The three trade methods are interdependent (changing `fetchTrades`'s parameter cascades), so they change together in one commit to keep the build green.
+
+**Files:**
+- Modify: `packages/data-collector/src/collectors/ClobCollector.ts` (`fetchTrades`, `syncTradesToDb`, `syncAllTrades`)
+- Create: `packages/data-collector/src/collectors/ClobCollector.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/data-collector/src/collectors/ClobCollector.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../database/connection.js', () => ({ query: vi.fn(), transaction: vi.fn() }));
+vi.mock('../services/RateLimiter.js', () => ({
+  getRateLimiter: () => ({ acquire: vi.fn().mockResolvedValue(undefined) }),
+}));
+vi.mock('axios', () => {
+  const get = vi.fn();
+  return { default: { get, create: () => ({ get }) } };
+});
+
+import axios from 'axios';
+import { query } from '../database/connection.js';
+import { ClobCollector } from './ClobCollector.js';
+
+const YES = '11111111111111111111111111111111111111111111111111111111111111111111111111111';
+const NO  = '22222222222222222222222222222222222222222222222222222222222222222222222222222';
+const OTHER = '99999999999999999999999999999999999999999999999999999999999999999999999999999';
+const COND = '0xcond';
+
+function trade(asset: string, side: string, price: string, ts: number, tx: string) {
+  return { asset, side, price, size: '10', timestamp: ts, transactionHash: tx, proxyWallet: '0xw' };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (query as any).mockResolvedValue({ rowCount: 0, rows: [] });
+});
+
+describe('ClobCollector.fetchTrades', () => {
+  it('queries the data-api by market (conditionId), not asset_id', async () => {
+    (axios.get as any).mockResolvedValue({ data: [] });
+    const c = new ClobCollector();
+    await c.fetchTrades(COND);
+    const [, opts] = (axios.get as any).mock.calls[0];
+    expect(opts.params.market).toBe(COND);
+    expect(opts.params).not.toHaveProperty('asset_id');
+  });
+});
+
+describe('ClobCollector.syncTradesToDb', () => {
+  const market = { id: 'mkt1', condition_id: COND, clob_token_id_yes: YES, clob_token_id_no: NO };
+
+  it('stores each trade under its real asset (token_id) with the market id', async () => {
+    (axios.get as any).mockResolvedValue({ data: [
+      trade(YES, 'BUY', '0.93', 1000, '0xa'),
+      trade(NO, 'SELL', '0.07', 1001, '0xb'),
+    ] });
+    const c = new ClobCollector();
+    await c.syncTradesToDb(market);
+    const insertCall = (query as any).mock.calls.find((c0: any[]) => /INSERT INTO trades/.test(c0[0]));
+    expect(insertCall).toBeTruthy();
+    const params = insertCall[1] as any[];
+    expect(params).toContain(YES);    // a row keyed by the YES asset
+    expect(params).toContain(NO);     // a row keyed by the NO asset
+    expect(params).toContain('mkt1'); // market id present
+  });
+
+  it('skips trades whose asset is neither of the market two tokens', async () => {
+    (axios.get as any).mockResolvedValue({ data: [ trade(OTHER, 'BUY', '0.5', 1000, '0xc') ] });
+    const c = new ClobCollector();
+    const res = await c.syncTradesToDb(market);
+    expect(res.inserted).toBe(0);
+    const insertCall = (query as any).mock.calls.find((c0: any[]) => /INSERT INTO trades/.test(c0[0]));
+    expect(insertCall).toBeFalsy(); // nothing to insert
+  });
+
+  it('inserts with ON CONFLICT on the dedup key', async () => {
+    (axios.get as any).mockResolvedValue({ data: [ trade(YES, 'BUY', '0.93', 1000, '0xa') ] });
+    const c = new ClobCollector();
+    await c.syncTradesToDb(market);
+    const insertCall = (query as any).mock.calls.find((c0: any[]) => /INSERT INTO trades/.test(c0[0]));
+    expect(insertCall[0]).toMatch(/ON CONFLICT \(time, tx_hash, token_id, side, price, size\) DO NOTHING/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd packages/data-collector && npx vitest run src/collectors/ClobCollector.test.ts`
+Expected: FAIL — `syncTradesToDb` currently takes `(marketId, tokenId)` not a market object, `fetchTrades` sends `asset_id`, and the INSERT lacks the new ON CONFLICT target.
+
+- [ ] **Step 3: Rewrite `fetchTrades`**
+
+In `packages/data-collector/src/collectors/ClobCollector.ts`, replace the `fetchTrades` method with:
+
+```typescript
+  /**
+   * Fetch recent trades for a MARKET from the Data API (public, no auth).
+   * NOTE: the data-api ignores `asset_id` (returns a global feed); only `market`
+   * (the conditionId) filters. Each returned trade carries its real `asset`.
+   */
+  async fetchTrades(conditionId: string): Promise<any[]> {
+    await this.rateLimiter.acquire('data_trades');
+
+    try {
+      const response = await axios.get('https://data-api.polymarket.com/trades', {
+        params: { market: conditionId, limit: '100' },
+        timeout: 15000,
+      });
+      return Array.isArray(response.data) ? response.data : [];
+    } catch (error: any) {
+      if (error.response?.status === 404) {
+        return [];
+      }
+      throw error;
+    }
+  }
+```
+
+- [ ] **Step 4: Rewrite `syncTradesToDb`**
+
+Replace the `syncTradesToDb` method with a version that takes a market row, stores each trade under its real `asset`, guards to the market's two tokens, and uses the real ON CONFLICT target:
+
+```typescript
+  /**
+   * Sync a market's trades to the DB. One `market=conditionId` query returns both
+   * outcomes' trades; each is stored under its real `asset` (token_id). Guards to
+   * the market's two known tokens. Dedupes via the unique (time, tx_hash, token_id,
+   * side, price, size) index.
+   */
+  async syncTradesToDb(market: {
+    id: string;
+    condition_id: string;
+    clob_token_id_yes: string;
+    clob_token_id_no: string | null;
+  }): Promise<{ inserted: number }> {
+    const cacheKey = `trades:${market.id}`;
+    const lastSync = this.lastSyncTimeCache.get(cacheKey);
+
+    const trades = await this.fetchTrades(market.condition_id);
+    if (trades.length === 0) {
+      this.lastSyncTimeCache.set(cacheKey, new Date());
+      return { inserted: 0 };
+    }
+
+    const validTokens = new Set(
+      [market.clob_token_id_yes, market.clob_token_id_no].filter(Boolean) as string[]
+    );
+
+    // Keep only trades for THIS market's tokens, newer than the last sync.
+    const newTrades = trades.filter((t: any) => {
+      if (!validTokens.has(String(t.asset))) return false;
+      if (lastSync) return new Date((t.timestamp || 0) * 1000) > lastSync;
+      return true;
+    });
+
+    if (newTrades.length === 0) {
+      this.lastSyncTimeCache.set(cacheKey, new Date());
+      return { inserted: 0 };
+    }
+
+    const values: any[] = [];
+    const placeholders: string[] = [];
+    newTrades.forEach((t: any, idx: number) => {
+      const baseIdx = idx * 8;
+      placeholders.push(
+        `($${baseIdx + 1}, $${baseIdx + 2}, $${baseIdx + 3}, $${baseIdx + 4}, $${baseIdx + 5}, $${baseIdx + 6}, $${baseIdx + 7}, $${baseIdx + 8})`
+      );
+      const tradeTime = new Date((t.timestamp || 0) * 1000);
+      const side = (t.side || 'BUY').toUpperCase() === 'BUY' ? 'buy' : 'sell';
+      values.push(
+        tradeTime,                       // time
+        market.id,                       // market_id
+        String(t.asset),                 // token_id (the trade's REAL asset)
+        side,                            // side
+        parseFloat(t.price) || 0,        // price
+        parseFloat(t.size) || 0,         // size
+        t.proxyWallet || null,           // maker_address
+        t.transactionHash || null,       // tx_hash
+      );
+    });
+
+    try {
+      const result = await query(
+        `INSERT INTO trades (time, market_id, token_id, side, price, size, maker_address, tx_hash)
+         VALUES ${placeholders.join(', ')}
+         ON CONFLICT (time, tx_hash, token_id, side, price, size) DO NOTHING`,
+        values
+      );
+      const inserted = result.rowCount || 0;
+      this.lastSyncTimeCache.set(cacheKey, new Date());
+      if (inserted > 0) {
+        logger.debug({ marketId: market.id, inserted, total: newTrades.length }, 'Synced trades');
+      }
+      return { inserted };
+    } catch (error) {
+      logger.error({ error, marketId: market.id }, 'Error inserting trades');
+      return { inserted: 0 };
+    }
+  }
+```
+
+- [ ] **Step 5: Rewrite `syncAllTrades`**
+
+Replace the `syncAllTrades` method body's market query and loop with a per-market call (one `market=` query covers both tokens):
+
+```typescript
+  async syncAllTrades(): Promise<{ markets: number; totalInserted: number; errors: number }> {
+    const marketsResult = await query(
+      `SELECT id, condition_id, clob_token_id_yes, clob_token_id_no
+       FROM markets
+       WHERE tracking_status IN ('warming', 'active', 'cooling')
+         AND condition_id IS NOT NULL
+       ORDER BY market_score DESC NULLS LAST`
+    );
+
+    const markets = marketsResult.rows;
+    let totalInserted = 0;
+    let errors = 0;
+
+    for (const market of markets) {
+      try {
+        const res = await this.syncTradesToDb(market);
+        totalInserted += res.inserted;
+      } catch (error) {
+        logger.error({ error, marketId: market.id }, 'Error syncing trades');
+        errors++;
+      }
+    }
+
+    logger.info({ markets: markets.length, totalInserted, errors }, 'Trades synced');
+    return { markets: markets.length, totalInserted, errors };
+  }
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cd packages/data-collector && npx vitest run src/collectors/ClobCollector.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 7: Typecheck the package**
+
+Run: `cd packages/data-collector && npx tsc --noEmit`
+Expected: no errors. (If any other caller referenced the old `syncTradesToDb(marketId, tokenId)` signature, fix it — grep `syncTradesToDb` first; only `syncAllTrades` and the test should call it.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/data-collector/src/collectors/ClobCollector.ts packages/data-collector/src/collectors/ClobCollector.test.ts
+git commit -m "fix(data-collector): query trades by market=conditionId, store under real asset
+
+The data-api ignores asset_id and returns a global feed; the collector was tagging
+every trade with the queried token, corrupting the trades table. Query by market
+(conditionId), store each trade under its real asset, guard to the market two tokens,
+and dedupe via ON CONFLICT (time, tx_hash, token_id, side, price, size)."
+```
+
+---
+
+## Task 2: Add the dedup unique index to the schema
+
+**Files:**
+- Modify: `packages/data-collector/src/database/init/001_schema.sql`
+
+- [ ] **Step 1: Add the unique index after the trades indexes**
+
+In `packages/data-collector/src/database/init/001_schema.sql`, immediately after the existing `idx_trades_taker` index (around line 174), add:
+
+```sql
+-- Dedup key for ON CONFLICT in ClobCollector.syncTradesToDb. Must include the
+-- hypertable partition column (time). Rows with a NULL tx_hash are not deduped.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_dedup
+  ON trades (time, tx_hash, token_id, side, price, size);
+```
+
+- [ ] **Step 2: Verify the SQL parses (no DB run needed here)**
+
+Run: `node -e "const fs=require('fs');const s=fs.readFileSync('packages/data-collector/src/database/init/001_schema.sql','utf8');if(!/idx_trades_dedup/.test(s))throw new Error('missing index');console.log('ok')"`
+Expected: prints `ok`. (Init SQL only runs on a fresh volume; the existing VM gets this index via the ops step in Task 3.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/data-collector/src/database/init/001_schema.sql
+git commit -m "fix(data-collector): add trades dedup unique index for fresh installs"
+```
+
+---
+
+## Task 3: Deploy and one-time VM remediation (ops)
+
+This task runs **after the PR merges and CI deploys the new data-collector image**. It is operational (no code). Order matters: deploy → truncate → index (the index must be built on the empty table; the contaminated table's duplicates would violate uniqueness).
+
+- [ ] **Step 1: Confirm the new image is deployed**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- "cd /home/Usuario/polymarket-trader && git log --oneline -1 && docker compose -f docker-compose.gcp.yml ps"
+```
+Expected: the merge commit is present and `polymarket-data-collector` is `Up (healthy)`.
+
+- [ ] **Step 2: Purge the contaminated history, then create the index**
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c 'TRUNCATE trades;' -c 'CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_dedup ON trades (time, tx_hash, token_id, side, price, size);'"
+```
+Expected: `TRUNCATE TABLE` then `CREATE INDEX`.
+
+- [ ] **Step 3: Wait for repopulation, then verify reconciliation**
+
+Wait ~10 minutes for the trade-sync cron to repopulate, then run the reconciliation check (sampled trade prices for a token must cluster near that token's book, not span 0–1):
+
+```bash
+gcloud compute ssh polymarket-vm --zone=us-east1-b -- "docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -c \"
+WITH tk AS (
+  SELECT t.token_id FROM trades t
+  WHERE t.time>NOW()-INTERVAL '30 minutes'
+    AND EXISTS (SELECT 1 FROM orderbook_snapshots o WHERE o.token_id=t.token_id AND o.time>NOW()-INTERVAL '30 minutes')
+  GROUP BY t.token_id ORDER BY COUNT(*) DESC LIMIT 1)
+SELECT t.price AS trade_price,
+  (SELECT o.best_bid FROM orderbook_snapshots o WHERE o.token_id=t.token_id AND o.time<=t.time ORDER BY o.time DESC LIMIT 1) AS bid,
+  (SELECT o.best_ask FROM orderbook_snapshots o WHERE o.token_id=t.token_id AND o.time<=t.time ORDER BY o.time DESC LIMIT 1) AS ask
+FROM trades t JOIN tk ON tk.token_id=t.token_id
+WHERE t.time>NOW()-INTERVAL '30 minutes' ORDER BY t.time DESC LIMIT 10;\""
+```
+Expected: every `trade_price` lies at or between `bid` and `ask` (within a few cents) for the token — NOT prices like 0.05 against a 0.93/0.94 book. If prices still span 0–1, the fix did not take — stop and investigate before declaring success.
+
+---
+
+## Task 4: Update memory
+
+**Files:**
+- Modify: `C:\Users\Usuario\.claude\projects\C--Users-Usuario-github-polymarket-trader\memory\MEMORY.md` (index line)
+- Create: `C:\Users\Usuario\.claude\projects\C--Users-Usuario-github-polymarket-trader\memory\project_trades_misattribution_2026-06-06.md`
+
+- [ ] **Step 1: Write the memory note**
+
+Create `project_trades_misattribution_2026-06-06.md` recording: the root cause (data-api ignores `asset_id`, returns a global feed; collector tagged every trade with the queried token), the fix (query `market=conditionId`, store under `trade.asset`, dedup index, TRUNCATE), the blast radius (OFI + Hawkes were live on noise; MultiLevelOFI/VolumeAnomaly/backtest/paper_trades unaffected), and the **follow-up**: re-measure OFI/Hawkes edge with `scripts/p2-tstat.js` after several days of clean data, and **resume the parked H-MM-1** (`mm-spread-h-mm-1` branch) now that trade prices reconcile with the book. Add the PR number once merged. Follow the memory frontmatter format and link `[[project_p2_results_2026-05-11]]` and `[[next-levers-market-making-informational-edge-harness-automation]]`.
+
+- [ ] **Step 2: Add the index pointer**
+
+Add a one-line pointer under "Latest verified work" in `MEMORY.md`.
+
+(No commit required — memory files persist as plain files.)
+
+---
+
+## Notes for the implementer
+
+- Keep the `lastSyncTimeCache` map; only the key changes (per market, `trades:${market.id}`).
+- Do NOT change OFI/Hawkes or any signal weights — the spec justifies why no gate is needed.
+- The data-api `timestamp` is unix **seconds** (multiply by 1000 for `Date`), as the old code did.
+- After Task 1, grep `syncTradesToDb` across the repo to confirm only `syncAllTrades` (and the test) call it; fix any other caller to the new single-argument signature.
+- Final check before finishing the branch: `cd packages/data-collector && npx vitest run && npx tsc --noEmit` green, then use superpowers:finishing-a-development-branch (Option 2: push + PR). Tasks 3 and 4 happen after merge/deploy.

--- a/docs/superpowers/specs/2026-06-06-trades-misattribution-fix-design.md
+++ b/docs/superpowers/specs/2026-06-06-trades-misattribution-fix-design.md
@@ -1,0 +1,147 @@
+# Trades Misattribution Fix (design)
+
+**Date:** 2026-06-06
+**Status:** approved (brainstorm), pending implementation plan
+
+## Problem
+
+The raw `trades` hypertable is fully misattributed. `ClobCollector.fetchTrades(tokenId)`
+(`packages/data-collector/src/collectors/ClobCollector.ts`) queries
+`data-api.polymarket.com/trades?asset_id=<tokenId>`, but **the data-api ignores
+`asset_id` and returns a GLOBAL feed of recent trades across all markets**.
+`syncTradesToDb` then stores every returned trade tagged with the queried
+`token_id` and `market_id`. So for any token/market, the `trades` rows are random
+trades from *other* markets — price/size/side do not correspond to that token.
+
+Confirmed empirically (2026-06-06):
+- For a token with a tight book (bid 0.961 / ask 0.967), its stored "trades" print
+  at 0.05, 0.18, 0.56, 0.79, 0.89 — impossible against that book.
+- Raw data-api response: every returned trade's `asset` field ≠ the queried
+  `asset_id` (0/15 match); outcomes are "Up"/"Down"/"No" from unrelated markets.
+- Parameter probe: `asset_id`, `asset`, `takerAssetId` are all ignored (global
+  feed). **Only `market=<conditionId>` filters correctly** (asset_match 10/10).
+
+Secondary defect: `trades` PK is `(time, id)` with `id SERIAL`, and the insert uses
+`ON CONFLICT DO NOTHING` — which **never fires** (a fresh `id` each time), so the
+table also accumulates duplicates of the global feed every poll.
+
+## Blast radius (audited)
+
+Two **live-trading** signals consume the raw `trades` table via
+`SignalEngine.computeSignals` (`packages/dashboard/src/services/SignalEngine.ts`,
+`SELECT ... FROM trades WHERE market_id = $1 AND time > NOW() - INTERVAL '30 minutes' LIMIT 200`
+→ `context.recentTrades`):
+
+- **OrderFlowImbalanceSignal** — buy/sell volume imbalance. Currently blends a
+  garbage trade-OFI with the (clean) book-OFI → corrupted strength/direction.
+- **HawkesSignal** — trade-arrival clustering. Currently models bursts from other
+  markets → spurious intensity/side.
+
+Both feed `AutoSignalExecutor` (live). **Not affected:** `MultiLevelOFISignal`
+(order book), `VolumeAnomalyGenerator` (OHLCV bars), all other generators
+(`recentTrades: []`), backtest, optimizer, `MarketScorer`, `CircuitBreakerService`,
+and the `paper_trades` / `shadow_trades` tables (separate). This likely explains the
+historical anti-edge of OFI/Hawkes in the P2 analysis.
+
+## Goal
+
+Make `trades` reflect real per-token executions, so the two live microstructure
+signals compute on truthful order flow (and so the parked H-MM-1 realized-spread
+measurement becomes computable). One focused PR + a one-time VM ops step.
+
+## Design
+
+### 1. Collection fix (`ClobCollector`)
+
+- **Query by market, not asset.** `fetchTrades(conditionId)` calls the data-api with
+  `params: { market: conditionId, limit: 100 }` (drop `asset_id`). The response is
+  the market's real trades (both YES and NO outcomes).
+- **Store under the real asset.** In `syncTradesToDb`, for each returned trade set
+  `token_id = trade.asset` (the CLOB asset/token the trade actually belongs to),
+  `market_id =` the market being synced, and `side`/`price`/`size` from the trade.
+  Map `side` exactly as today (`BUY`→`buy`, else `sell`).
+- **Defensive guard.** Accept a trade only if `trade.asset ∈ {clob_token_id_yes,
+  clob_token_id_no}` for that market; skip otherwise (guards against API surprises).
+- **Caller wiring.** `syncAllTrades` selects `condition_id` alongside
+  `id, clob_token_id_yes, clob_token_id_no` and passes `condition_id` to
+  `syncTradesToDb`; the per-market call replaces the current per-token (yes/no) calls
+  (one `market=` query returns both sides). Keep the `lastSyncTimeCache` newer-than
+  filter, keyed per market.
+
+### 2. Dedup (make `ON CONFLICT` real)
+
+Add a unique index that includes the hypertable partition column `time`:
+`UNIQUE (time, tx_hash, token_id, side, price, size)`, and change the insert to
+`ON CONFLICT (time, tx_hash, token_id, side, price, size) DO NOTHING`. This stops the
+re-insertion of overlapping recent trades each poll. (`tx_hash` from the data-api
+`transactionHash`; trades with a null `tx_hash` are not deduped — acceptable.) The
+index goes in `001_schema.sql` for fresh installs; on the existing VM volume it is
+applied manually (init SQL only runs on first volume init).
+
+### 3. Purge contaminated history (VM ops, one-time)
+
+Every existing `trades` row is contaminated, so after the fixed collector deploys,
+run once on the VM: `TRUNCATE trades;` (`paper_trades` / `shadow_trades` untouched).
+The collector repopulates correct, per-token trades within minutes. **Order matters:
+deploy fix → `TRUNCATE trades` → create the unique index.** The index must be created
+on the empty table — building it on the contaminated table would fail, since the
+existing duplicates violate the uniqueness constraint.
+
+### 4. No signal gate (justified by code)
+
+No weight/enable changes are needed:
+- **OFI** — `calculateTradeOFI` returns `null` when `trades.length < minTrades`, and
+  `compute` then falls back to **book-only OFI** (clean) or `null`. Empty/sparse
+  trades never produce a spurious trade-OFI.
+- **Hawkes** — skips ingestion when `recentTrades` is empty and returns `null` when
+  `events < minTrades`. Its in-memory event state is cleared by the **process
+  restart on deploy**, so it starts fresh on clean data.
+
+The corruption only occurs when contaminated rows are *present*; deploy + truncate
+removes them, and both signals degrade to neutral/book-only meanwhile.
+
+### 5. Verification (post-deploy)
+
+- Re-run the reconciliation check: sampled trade prices for a token must cluster near
+  that token's book (`best_bid`/`best_ask`), not span 0–1. This confirms the fix.
+- **Follow-up (separate session, not this PR):** once several days of clean trades
+  accumulate, re-measure OFI/Hawkes edge with `scripts/p2-tstat.js` to see whether
+  they regain edge now that they no longer consume noise. Record in memory.
+
+## Testing
+
+Unit tests for `ClobCollector` (`ClobCollector.test.ts`, create if absent) with
+`axios` and the `query` layer mocked:
+
+1. `fetchTrades` issues the request with `market=<conditionId>` and no `asset_id`.
+2. Given a mocked data-api response of trades for a market's two assets, each row is
+   inserted with `token_id = trade.asset`, the correct `market_id`, and mapped
+   `side`/`price`/`size`.
+3. A trade whose `asset` is neither of the market's two tokens is skipped.
+4. The INSERT statement targets `ON CONFLICT (time, tx_hash, token_id, side, price, size) DO NOTHING`.
+
+DB-level dedup is validated by the unique index plus the manual VM reconciliation
+check (CI also has a Postgres service if an integration test is wanted later).
+
+## File inventory
+
+- **Modify:** `packages/data-collector/src/collectors/ClobCollector.ts`
+  (`fetchTrades`, `syncTradesToDb`, `syncAllTrades`).
+- **Modify:** `packages/data-collector/src/database/init/001_schema.sql` (add the
+  unique index for fresh installs).
+- **Create:** `packages/data-collector/src/collectors/ClobCollector.test.ts` (if absent).
+- **VM ops (post-deploy):** `TRUNCATE trades`, then `CREATE UNIQUE INDEX` on the empty table.
+- **Memory:** record root cause, fix, and the OFI/Hawkes edge re-measurement follow-up.
+
+## Scope (anti-scope-creep)
+
+In scope: the collection fix, the dedup index, the purge ops step, the unit tests,
+the verification check. **Out of scope:** re-measuring OFI/Hawkes edge (follow-up);
+H-MM-1 (resumes after this lands); any change to the signals themselves; backfilling
+historical trades beyond what the live collector repopulates.
+
+## Success criteria
+
+After deploy + index + truncate, sampled `trades` for a token reconcile with that
+token's order book, duplicates stop accumulating, and OFI/Hawkes compute on truthful
+per-market order flow. A clean reconciliation check is the acceptance gate.

--- a/docs/superpowers/specs/2026-06-06-trades-misattribution-fix-design.md
+++ b/docs/superpowers/specs/2026-06-06-trades-misattribution-fix-design.md
@@ -68,24 +68,40 @@ measurement becomes computable). One focused PR + a one-time VM ops step.
   (one `market=` query returns both sides). Keep the `lastSyncTimeCache` newer-than
   filter, keyed per market.
 
-### 2. Dedup (make `ON CONFLICT` real)
+### 2. Dedup (make `ON CONFLICT` real, robustly)
 
 Add a unique index that includes the hypertable partition column `time`:
-`UNIQUE (time, tx_hash, token_id, side, price, size)`, and change the insert to
-`ON CONFLICT (time, tx_hash, token_id, side, price, size) DO NOTHING`. This stops the
-re-insertion of overlapping recent trades each poll. (`tx_hash` from the data-api
-`transactionHash`; trades with a null `tx_hash` are not deduped — acceptable.) The
-index goes in `001_schema.sql` for fresh installs; on the existing VM volume it is
-applied manually (init SQL only runs on first volume init).
+`UNIQUE (time, tx_hash, token_id, side, price, size)`, and use **bare**
+`ON CONFLICT DO NOTHING` (no explicit column target). This stops the re-insertion of
+overlapping recent trades each poll once the index exists. (`tx_hash` from the
+data-api `transactionHash`; trades with a null `tx_hash` are not deduped — acceptable.)
+
+**Index delivery (critical).** An explicit `ON CONFLICT (cols)` target would raise
+`42P10` on any DB lacking that exact index — and `001_schema.sql` only runs on a
+*fresh* volume, so the live DB would error on every insert and silently insert zero
+trades. Two safeguards:
+- The INSERT uses **bare** `ON CONFLICT DO NOTHING`, which never errors whether or not
+  the index exists (it just doesn't dedup until it does).
+- A startup `ensureRuntimeSchema()` (`database/runtimeSchema.ts`, called from
+  `index.ts` after the DB health check) runs `CREATE UNIQUE INDEX IF NOT EXISTS
+  idx_trades_dedup ...` in a try/catch — so the index lands on already-initialised
+  volumes, not just fresh installs. If pre-existing duplicates block creation it logs
+  and continues (the purge in §3 clears them; the index is then created on the next
+  start). The index also stays in `001_schema.sql` for fresh installs.
 
 ### 3. Purge contaminated history (VM ops, one-time)
 
 Every existing `trades` row is contaminated, so after the fixed collector deploys,
 run once on the VM: `TRUNCATE trades;` (`paper_trades` / `shadow_trades` untouched).
-The collector repopulates correct, per-token trades within minutes. **Order matters:
-deploy fix → `TRUNCATE trades` → create the unique index.** The index must be created
-on the empty table — building it on the contaminated table would fail, since the
-existing duplicates violate the uniqueness constraint.
+The collector repopulates correct, per-token trades within minutes.
+
+With bare `ON CONFLICT` (§2) there is **no silent-zero-insert window**: the deployed
+collector inserts correctly even before the index exists. The index is created by
+`ensureRuntimeSchema()` — but on a contaminated table that call fails (duplicates), so
+the sequence is: **deploy → `TRUNCATE trades` → restart the data-collector** (its
+startup `ensureRuntimeSchema()` then creates `idx_trades_dedup` on the now-empty
+table). Equivalently, create the index manually right after the truncate. Building the
+index on the still-contaminated table would fail on the existing duplicates.
 
 ### 4. No signal gate (justified by code)
 
@@ -129,6 +145,9 @@ check (CI also has a Postgres service if an integration test is wanted later).
   (`fetchTrades`, `syncTradesToDb`, `syncAllTrades`).
 - **Modify:** `packages/data-collector/src/database/init/001_schema.sql` (add the
   unique index for fresh installs).
+- **Create:** `packages/data-collector/src/database/runtimeSchema.ts` +
+  `runtimeSchema.test.ts` (startup `ensureRuntimeSchema()` that lands the index on
+  already-initialised volumes); wire the call into `packages/data-collector/src/index.ts`.
 - **Create:** `packages/data-collector/src/collectors/ClobCollector.test.ts` (if absent).
 - **VM ops (post-deploy):** `TRUNCATE trades`, then `CREATE UNIQUE INDEX` on the empty table.
 - **Memory:** record root cause, fix, and the OFI/Hawkes edge re-measurement follow-up.

--- a/packages/data-collector/src/collectors/ClobCollector.test.ts
+++ b/packages/data-collector/src/collectors/ClobCollector.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../database/connection.js', () => ({ query: vi.fn(), transaction: vi.fn() }));
+vi.mock('../services/RateLimiter.js', () => ({
+  getRateLimiter: () => ({ acquire: vi.fn().mockResolvedValue(undefined) }),
+}));
+vi.mock('axios', () => {
+  const get = vi.fn();
+  return { default: { get, create: () => ({ get }) } };
+});
+
+import axios from 'axios';
+import { query } from '../database/connection.js';
+import { ClobCollector } from './ClobCollector.js';
+
+const YES = '11111111111111111111111111111111111111111111111111111111111111111111111111111';
+const NO  = '22222222222222222222222222222222222222222222222222222222222222222222222222222';
+const OTHER = '99999999999999999999999999999999999999999999999999999999999999999999999999999';
+const COND = '0xcond';
+
+function trade(asset: string, side: string, price: string, ts: number, tx: string) {
+  return { asset, side, price, size: '10', timestamp: ts, transactionHash: tx, proxyWallet: '0xw' };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (query as any).mockResolvedValue({ rowCount: 0, rows: [] });
+});
+
+describe('ClobCollector.fetchTrades', () => {
+  it('queries the data-api by market (conditionId), not asset_id', async () => {
+    (axios.get as any).mockResolvedValue({ data: [] });
+    const c = new ClobCollector();
+    await c.fetchTrades(COND);
+    const [, opts] = (axios.get as any).mock.calls[0];
+    expect(opts.params.market).toBe(COND);
+    expect(opts.params).not.toHaveProperty('asset_id');
+  });
+});
+
+describe('ClobCollector.syncTradesToDb', () => {
+  const market = { id: 'mkt1', condition_id: COND, clob_token_id_yes: YES, clob_token_id_no: NO };
+
+  it('stores each trade under its real asset (token_id) with the market id', async () => {
+    (axios.get as any).mockResolvedValue({ data: [
+      trade(YES, 'BUY', '0.93', 1000, '0xa'),
+      trade(NO, 'SELL', '0.07', 1001, '0xb'),
+    ] });
+    const c = new ClobCollector();
+    await c.syncTradesToDb(market);
+    const insertCall = (query as any).mock.calls.find((c0: any[]) => /INSERT INTO trades/.test(c0[0]));
+    expect(insertCall).toBeTruthy();
+    const params = insertCall[1] as any[];
+    expect(params).toContain(YES);
+    expect(params).toContain(NO);
+    expect(params).toContain('mkt1');
+  });
+
+  it('skips trades whose asset is neither of the market two tokens', async () => {
+    (axios.get as any).mockResolvedValue({ data: [ trade(OTHER, 'BUY', '0.5', 1000, '0xc') ] });
+    const c = new ClobCollector();
+    const res = await c.syncTradesToDb(market);
+    expect(res.inserted).toBe(0);
+    const insertCall = (query as any).mock.calls.find((c0: any[]) => /INSERT INTO trades/.test(c0[0]));
+    expect(insertCall).toBeFalsy();
+  });
+
+  it('inserts with ON CONFLICT on the dedup key', async () => {
+    (axios.get as any).mockResolvedValue({ data: [ trade(YES, 'BUY', '0.93', 1000, '0xa') ] });
+    const c = new ClobCollector();
+    await c.syncTradesToDb(market);
+    const insertCall = (query as any).mock.calls.find((c0: any[]) => /INSERT INTO trades/.test(c0[0]));
+    expect(insertCall[0]).toMatch(/ON CONFLICT \(time, tx_hash, token_id, side, price, size\) DO NOTHING/);
+  });
+});

--- a/packages/data-collector/src/collectors/ClobCollector.test.ts
+++ b/packages/data-collector/src/collectors/ClobCollector.test.ts
@@ -70,6 +70,32 @@ describe('ClobCollector.syncTradesToDb', () => {
     const c = new ClobCollector();
     await c.syncTradesToDb(market);
     const insertCall = (query as any).mock.calls.find((c0: any[]) => /INSERT INTO trades/.test(c0[0]));
-    expect(insertCall[0]).toMatch(/ON CONFLICT \(time, tx_hash, token_id, side, price, size\) DO NOTHING/);
+    expect(insertCall[0]).toMatch(/ON CONFLICT DO NOTHING/);
+  });
+
+  it('skips trades older than the last sync (no insert on the second pass)', async () => {
+    const c = new ClobCollector();
+    const nowSec = Math.floor(Date.now() / 1000);
+    (axios.get as any).mockResolvedValue({ data: [ trade(YES, 'BUY', '0.93', nowSec, '0xa') ] });
+    await c.syncTradesToDb(market);            // first pass populates the cache
+    (query as any).mockClear();
+    (axios.get as any).mockResolvedValue({ data: [ trade(YES, 'BUY', '0.93', 1000, '0xold') ] }); // 1970
+    const res = await c.syncTradesToDb(market);
+    expect(res.inserted).toBe(0);
+    const insertCall = (query as any).mock.calls.find((c0: any[]) => /INSERT INTO trades/.test(c0[0]));
+    expect(insertCall).toBeFalsy();
+  });
+
+  it('maps trade side BUY->buy and SELL->sell', async () => {
+    (axios.get as any).mockResolvedValue({ data: [
+      trade(YES, 'BUY', '0.93', 1000, '0xa'),
+      trade(NO, 'SELL', '0.07', 1001, '0xb'),
+    ] });
+    const c = new ClobCollector();
+    await c.syncTradesToDb(market);
+    const insertCall = (query as any).mock.calls.find((c0: any[]) => /INSERT INTO trades/.test(c0[0]));
+    const params = insertCall[1] as any[];
+    expect(params).toContain('buy');
+    expect(params).toContain('sell');
   });
 });

--- a/packages/data-collector/src/collectors/ClobCollector.ts
+++ b/packages/data-collector/src/collectors/ClobCollector.ts
@@ -8,6 +8,13 @@ const logger = pino({ name: 'clob-collector' });
 
 const CLOB_API_URL = process.env.CLOB_API_URL || 'https://clob.polymarket.com';
 
+type TradeSyncMarket = {
+  id: string;
+  condition_id: string;
+  clob_token_id_yes: string;
+  clob_token_id_no: string | null;
+};
+
 interface PriceHistoryResponse {
   history: PriceHistory[];
 }
@@ -187,12 +194,7 @@ export class ClobCollector {
    * the market's two known tokens. Dedupes via the unique (time, tx_hash, token_id,
    * side, price, size) index.
    */
-  async syncTradesToDb(market: {
-    id: string;
-    condition_id: string;
-    clob_token_id_yes: string;
-    clob_token_id_no: string | null;
-  }): Promise<{ inserted: number }> {
+  async syncTradesToDb(market: TradeSyncMarket): Promise<{ inserted: number }> {
     const cacheKey = `trades:${market.id}`;
     const lastSync = this.lastSyncTimeCache.get(cacheKey);
 
@@ -242,7 +244,7 @@ export class ClobCollector {
       const result = await query(
         `INSERT INTO trades (time, market_id, token_id, side, price, size, maker_address, tx_hash)
          VALUES ${placeholders.join(', ')}
-         ON CONFLICT (time, tx_hash, token_id, side, price, size) DO NOTHING`,
+         ON CONFLICT DO NOTHING`,
         values
       );
       const inserted = result.rowCount || 0;
@@ -270,18 +272,13 @@ export class ClobCollector {
        ORDER BY market_score DESC NULLS LAST`
     );
 
-    const markets = marketsResult.rows;
+    const markets = marketsResult.rows as TradeSyncMarket[];
     let totalInserted = 0;
     let errors = 0;
 
     for (const market of markets) {
       try {
-        const res = await this.syncTradesToDb(market as {
-          id: string;
-          condition_id: string;
-          clob_token_id_yes: string;
-          clob_token_id_no: string | null;
-        });
+        const res = await this.syncTradesToDb(market);
         totalInserted += res.inserted;
       } catch (error) {
         logger.error({ error, marketId: market.id }, 'Error syncing trades');

--- a/packages/data-collector/src/collectors/ClobCollector.ts
+++ b/packages/data-collector/src/collectors/ClobCollector.ts
@@ -160,14 +160,16 @@ export class ClobCollector {
   }
 
   /**
-   * Fetch recent trades for a token from Data API (public, no auth required)
+   * Fetch recent trades for a MARKET from the Data API (public, no auth).
+   * NOTE: the data-api ignores `asset_id` (returns a global feed); only `market`
+   * (the conditionId) filters. Each returned trade carries its real `asset`.
    */
-  async fetchTrades(tokenId: string): Promise<any[]> {
+  async fetchTrades(conditionId: string): Promise<any[]> {
     await this.rateLimiter.acquire('data_trades');
 
     try {
       const response = await axios.get('https://data-api.polymarket.com/trades', {
-        params: { asset_id: tokenId, limit: '100' },
+        params: { market: conditionId, limit: '100' },
         timeout: 15000,
       });
       return Array.isArray(response.data) ? response.data : [];
@@ -180,83 +182,77 @@ export class ClobCollector {
   }
 
   /**
-   * Sync trades for a single token to database
-   * Uses in-memory cache to avoid re-fetching old trades
+   * Sync a market's trades to the DB. One `market=conditionId` query returns both
+   * outcomes' trades; each is stored under its real `asset` (token_id). Guards to
+   * the market's two known tokens. Dedupes via the unique (time, tx_hash, token_id,
+   * side, price, size) index.
    */
-  async syncTradesToDb(
-    marketId: string,
-    tokenId: string
-  ): Promise<{ inserted: number }> {
-    // Use cache to determine how far back to fetch
-    const lastSync = this.lastSyncTimeCache.get(`trades:${tokenId}`);
+  async syncTradesToDb(market: {
+    id: string;
+    condition_id: string;
+    clob_token_id_yes: string;
+    clob_token_id_no: string | null;
+  }): Promise<{ inserted: number }> {
+    const cacheKey = `trades:${market.id}`;
+    const lastSync = this.lastSyncTimeCache.get(cacheKey);
 
-    const trades = await this.fetchTrades(tokenId);
-
+    const trades = await this.fetchTrades(market.condition_id);
     if (trades.length === 0) {
-      this.lastSyncTimeCache.set(`trades:${tokenId}`, new Date());
+      this.lastSyncTimeCache.set(cacheKey, new Date());
       return { inserted: 0 };
     }
 
-    // Filter trades newer than last sync
-    // data-api returns timestamp as unix seconds
-    const newTrades = lastSync
-      ? trades.filter((t: any) => {
-          const tradeTime = new Date(t.timestamp * 1000);
-          return tradeTime > lastSync;
-        })
-      : trades;
+    const validTokens = new Set(
+      [market.clob_token_id_yes, market.clob_token_id_no].filter(Boolean) as string[]
+    );
+
+    const newTrades = trades.filter((t: any) => {
+      if (!validTokens.has(String(t.asset))) return false;
+      if (lastSync) return new Date((t.timestamp || 0) * 1000) > lastSync;
+      return true;
+    });
 
     if (newTrades.length === 0) {
-      this.lastSyncTimeCache.set(`trades:${tokenId}`, new Date());
+      this.lastSyncTimeCache.set(cacheKey, new Date());
       return { inserted: 0 };
     }
 
-    // Batch insert
     const values: any[] = [];
     const placeholders: string[] = [];
-
-    newTrades.forEach((trade: any, idx: number) => {
+    newTrades.forEach((t: any, idx: number) => {
       const baseIdx = idx * 8;
       placeholders.push(
         `($${baseIdx + 1}, $${baseIdx + 2}, $${baseIdx + 3}, $${baseIdx + 4}, $${baseIdx + 5}, $${baseIdx + 6}, $${baseIdx + 7}, $${baseIdx + 8})`
       );
-
-      // data-api fields: timestamp (unix s), side, price, size, proxyWallet, transactionHash
-      const tradeTime = new Date((trade.timestamp || 0) * 1000);
-      const side = (trade.side || 'BUY').toUpperCase() === 'BUY' ? 'buy' : 'sell';
-
+      const tradeTime = new Date((t.timestamp || 0) * 1000);
+      const side = (t.side || 'BUY').toUpperCase() === 'BUY' ? 'buy' : 'sell';
       values.push(
-        tradeTime,                                // time
-        marketId,                                 // market_id
-        tokenId,                                  // token_id
-        side,                                     // side
-        parseFloat(trade.price) || 0,             // price
-        parseFloat(trade.size) || 0,              // size
-        trade.proxyWallet || null,                // maker_address
-        trade.transactionHash || null,            // tx_hash
+        tradeTime,
+        market.id,
+        String(t.asset),
+        side,
+        parseFloat(t.price) || 0,
+        parseFloat(t.size) || 0,
+        t.proxyWallet || null,
+        t.transactionHash || null,
       );
     });
 
     try {
-      const insertResult = await query(
+      const result = await query(
         `INSERT INTO trades (time, market_id, token_id, side, price, size, maker_address, tx_hash)
          VALUES ${placeholders.join(', ')}
-         ON CONFLICT DO NOTHING`,
+         ON CONFLICT (time, tx_hash, token_id, side, price, size) DO NOTHING`,
         values
       );
-
-      const inserted = insertResult.rowCount || 0;
-
-      // Update cache
-      this.lastSyncTimeCache.set(`trades:${tokenId}`, new Date());
-
+      const inserted = result.rowCount || 0;
+      this.lastSyncTimeCache.set(cacheKey, new Date());
       if (inserted > 0) {
-        logger.debug({ tokenId, inserted, total: newTrades.length }, 'Synced trades');
+        logger.debug({ marketId: market.id, inserted, total: newTrades.length }, 'Synced trades');
       }
-
       return { inserted };
     } catch (error) {
-      logger.error({ error, tokenId }, 'Error inserting trades');
+      logger.error({ error, marketId: market.id }, 'Error inserting trades');
       return { inserted: 0 };
     }
   }
@@ -267,10 +263,10 @@ export class ClobCollector {
    */
   async syncAllTrades(): Promise<{ markets: number; totalInserted: number; errors: number }> {
     const marketsResult = await query(
-      `SELECT id, clob_token_id_yes, clob_token_id_no
+      `SELECT id, condition_id, clob_token_id_yes, clob_token_id_no
        FROM markets
        WHERE tracking_status IN ('warming', 'active', 'cooling')
-         AND clob_token_id_yes IS NOT NULL
+         AND condition_id IS NOT NULL
        ORDER BY market_score DESC NULLS LAST`
     );
 
@@ -280,13 +276,13 @@ export class ClobCollector {
 
     for (const market of markets) {
       try {
-        const yesResult = await this.syncTradesToDb(market.id, market.clob_token_id_yes);
-        totalInserted += yesResult.inserted;
-
-        if (market.clob_token_id_no) {
-          const noResult = await this.syncTradesToDb(market.id, market.clob_token_id_no);
-          totalInserted += noResult.inserted;
-        }
+        const res = await this.syncTradesToDb(market as {
+          id: string;
+          condition_id: string;
+          clob_token_id_yes: string;
+          clob_token_id_no: string | null;
+        });
+        totalInserted += res.inserted;
       } catch (error) {
         logger.error({ error, marketId: market.id }, 'Error syncing trades');
         errors++;

--- a/packages/data-collector/src/database/init/001_schema.sql
+++ b/packages/data-collector/src/database/init/001_schema.sql
@@ -173,6 +173,11 @@ CREATE INDEX IF NOT EXISTS idx_trades_market ON trades (market_id, time DESC);
 CREATE INDEX IF NOT EXISTS idx_trades_maker ON trades (maker_address, time DESC) WHERE maker_address IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_trades_taker ON trades (taker_address, time DESC) WHERE taker_address IS NOT NULL;
 
+-- Dedup key for ON CONFLICT in ClobCollector.syncTradesToDb. Must include the
+-- hypertable partition column (time). Rows with a NULL tx_hash are not deduped.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_dedup
+  ON trades (time, tx_hash, token_id, side, price, size);
+
 -- ============================================
 -- WALLETS
 -- ============================================

--- a/packages/data-collector/src/database/runtimeSchema.test.ts
+++ b/packages/data-collector/src/database/runtimeSchema.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+vi.mock('./connection.js', () => ({ query: vi.fn() }));
+import { query } from './connection.js';
+import { ensureRuntimeSchema } from './runtimeSchema.js';
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+describe('ensureRuntimeSchema', () => {
+  it('creates the trades dedup unique index idempotently', async () => {
+    (query as any).mockResolvedValue({ rowCount: 0 });
+    await ensureRuntimeSchema();
+    expect((query as any).mock.calls[0][0]).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_dedup/);
+  });
+  it('swallows errors (e.g. duplicates blocking the index) without throwing', async () => {
+    (query as any).mockRejectedValue(new Error('duplicate key'));
+    await expect(ensureRuntimeSchema()).resolves.toBeUndefined();
+  });
+});

--- a/packages/data-collector/src/database/runtimeSchema.ts
+++ b/packages/data-collector/src/database/runtimeSchema.ts
@@ -1,0 +1,24 @@
+import { pino } from 'pino';
+import { query } from './connection.js';
+
+const logger = pino({ name: 'runtime-schema' });
+
+/**
+ * Idempotent runtime DDL that must exist on ALREADY-INITIALISED volumes — the SQL
+ * in database/init/ only runs on a fresh volume, so indexes added later never reach
+ * the live DB without this. Safe to run on every startup.
+ */
+export async function ensureRuntimeSchema(): Promise<void> {
+  try {
+    await query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_trades_dedup
+       ON trades (time, tx_hash, token_id, side, price, size)`
+    );
+    logger.info('Runtime schema ensured (idx_trades_dedup)');
+  } catch (error) {
+    // Most likely pre-existing duplicate rows block the unique index. Log and
+    // continue — bare ON CONFLICT DO NOTHING still inserts safely without it, and
+    // the index gets created once the table is purged/clean and the service restarts.
+    logger.warn({ error }, 'ensureRuntimeSchema: could not create idx_trades_dedup (will retry next start)');
+  }
+}

--- a/packages/data-collector/src/index.ts
+++ b/packages/data-collector/src/index.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import http from 'node:http';
 import { pino } from 'pino';
 import { healthCheck, closePool } from './database/connection.js';
+import { ensureRuntimeSchema } from './database/runtimeSchema.js';
 import { getScheduler } from './services/Scheduler.js';
 import { getRateLimiter } from './services/RateLimiter.js';
 import { AdaptiveSyncManager } from './services/AdaptiveSyncManager.js';
@@ -33,6 +34,8 @@ async function main(): Promise<void> {
   }
 
   logger.info('Database connection successful');
+
+  await ensureRuntimeSchema();
 
   // Initialize rate limiter
   const rateLimiter = getRateLimiter();


### PR DESCRIPTION
## Problem

The raw `trades` table is fully **misattributed**. `ClobCollector.fetchTrades` queried `data-api/trades?asset_id=<token>`, but the **data-api ignores `asset_id` and returns a global feed** of recent trades across all markets; every returned trade was stored tagged with the queried token. For a token with a tight book (bid 0.961 / ask 0.967), its stored "trades" printed at 0.05–0.99 (other markets). Parameter probe confirmed only `market=<conditionId>` filters.

Secondary defect: PK `(time, id)` with `id SERIAL` made the old `ON CONFLICT DO NOTHING` a no-op → duplicates accumulated every poll.

## Blast radius (audited)

Two **live** signals consume the raw table via `SignalEngine` (`SELECT ... FROM trades WHERE market_id=$1 ... LIMIT 200` → `context.recentTrades`):
- **OrderFlowImbalanceSignal** — buy/sell imbalance blended a garbage trade-OFI with the clean book-OFI.
- **HawkesSignal** — trade-arrival clustering modelled bursts from other markets.

Both feed `AutoSignalExecutor` (live). Unaffected: `MultiLevelOFISignal` (order book), `VolumeAnomalyGenerator` (OHLCV), all other generators, backtest, optimizer, `paper_trades`/`shadow_trades`. This likely explains the historical anti-edge of OFI/Hawkes.

## Fix

- Query `data-api/trades?market=<conditionId>`; store each trade under its **real `asset`** (token_id), guarded to the market's two tokens; one call per market.
- **Bare `ON CONFLICT DO NOTHING`** (an explicit target would raise `42P10` and silently insert zero trades where the index is absent) + a unique dedup index `(time, tx_hash, token_id, side, price, size)`.
- Index delivery: `001_schema.sql` (fresh installs) **and** a startup `ensureRuntimeSchema()` (already-initialised volumes) — the init SQL only runs on a fresh volume.
- **No signal-weight changes** (justified): OFI falls back to book-only/null and Hawkes clears its in-memory state on the deploy restart; corruption only occurs with contaminated rows *present*.

## Post-merge ops (manual, see plan)

deploy → `TRUNCATE trades` → restart data-collector (startup ensure builds the index on the empty table) → reconciliation check (sampled trade prices must cluster at the token's book).

## Test Plan

- [x] 8 new unit tests (ClobCollector: market-query, store-by-asset, guard, bare ON CONFLICT, lastSync filter, side mapping; runtimeSchema: idempotent create + error-swallow).
- [x] Full data-collector suite green (322 tests). `tsc --noEmit` clean.
- [ ] Post-deploy reconciliation check (Task 3, after merge).

Spec: `docs/superpowers/specs/2026-06-06-trades-misattribution-fix-design.md` · Plan: `docs/superpowers/plans/2026-06-06-trades-misattribution-fix.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected trades misattribution; trades now properly attributed to their correct markets and token assets.
  * Implemented enhanced deduplication to prevent duplicate trade records.

* **Documentation**
  * Added comprehensive design specification and implementation plan for trades correction.

* **Tests**
  * Added extensive test coverage for trade data collection and synchronization.

* **Chores**
  * Added database schema initialization during system startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->