### PR TITLE
feat(edge-research): H-MM-1 market-making spread measurement (realized-spread decomposition)

### DIFF
--- a/docs/superpowers/plans/2026-06-05-mm-spread-measurement-h-mm-1.md
+++ b/docs/superpowers/plans/2026-06-05-mm-spread-measurement-h-mm-1.md
@@ -1,0 +1,491 @@
+# H-MM-1 Market-Making Spread Measurement — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land an H-MM-1 verdict per `market_type` on the edge-research scoreboard, measuring whether a passive market-maker retains positive spread after adverse selection — from already-collected `trades` + `orderbook_snapshots`, no new collection.
+
+**Architecture:** A heavy asof-join (trades → book mid before/after) runs in SQL on the VM, exports a sampled CSV; a Python validator consumes it via the harness's offline `--datasets-dir` mode and emits a `Verdict` under the same bootstrap-significant, cost-aware bar as the other vías. The realized-spread decomposition (Lee-Ready quote test) splits each trade's half-spread into `eff_half` (gross), `real_half` (maker-retained ≈ revenue), `impact_half` (adverse selection).
+
+**Tech Stack:** Python 3.13 + pandas/numpy (harness), PostgreSQL/TimescaleDB (VM, SQL export), pytest.
+
+**Base branch:** This builds on the harness state from PR #315 (the `--datasets-dir` offline mode, `load_all_datasets_from_dir`, and the `VALIDATORS` dict in `run.py`). Base this work on `edge-research-automation-ine5` (or on `main` after #315 merges). The spec lives at `docs/superpowers/specs/2026-06-05-mm-spread-measurement-h-mm-1-design.md`.
+
+**Reference — the `Verdict` contract** (`scripts/edge-research/verdict.py`), positional order used throughout:
+`Verdict(hypothesis_id, hclass, n, edge_net_pct, edge_insample_pct, significance, split, class_metric, cost_model, status, n_caveats, computed_at)`. `bootstrap_ci(x, n_boot=1000, seed=0, alpha=0.05)` lives in `scripts/edge-research/validators/base.py` and returns `(lo, hi)`.
+
+All `pytest` commands run from `scripts/edge-research/` (where `tests/conftest.py` adds the package dir to `sys.path`). Ignore the harmless `RequestsDependencyWarning` urllib3 line in output.
+
+---
+
+## Task 1: Offline CSV loader for `mm_trade_spreads`
+
+The harness loads datasets from raw CSVs in `--datasets-dir` mode. Add the
+`mm_trade_spreads` token. It is a **CSV-mode-only** dataset (the asof-join is too
+heavy to run in the DB-mode `load_all_datasets`, and the dashboard container has no
+Python), so it is added to `load_all_datasets_from_dir` only, NOT to `_LOADERS`.
+
+**Files:**
+- Modify: `scripts/edge-research/data.py` (inside `load_all_datasets_from_dir`)
+- Test: `scripts/edge-research/tests/test_data.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `scripts/edge-research/tests/test_data.py`:
+
+```python
+def test_load_from_dir_reads_mm_trade_spreads(tmp_path):
+    pd.DataFrame({
+        "market_id": ["a", "b"],
+        "market_type": ["crypto_intraday", "event_long"],
+        "token_id": ["t1", "t2"],
+        "time": ["2026-06-04T10:00:00Z", "2026-06-04T10:05:00Z"],
+        "size": [100.0, 50.0],
+        "eff_half": [0.012, 0.020],
+        "real_half": [0.004, -0.001],
+        "impact_half": [0.008, 0.021],
+    }).to_csv(tmp_path / "mm_trade_spreads.csv", index=False)
+    out = load_all_datasets_from_dir(str(tmp_path))
+    mm = out["mm_trade_spreads"]
+    assert mm is not None
+    assert len(mm) == 2
+    assert set(["market_type", "real_half", "eff_half", "impact_half", "size"]).issubset(mm.columns)
+    assert abs(float(mm.iloc[0]["real_half"]) - 0.004) < 1e-9
+
+
+def test_load_from_dir_mm_missing_maps_to_none(tmp_path):
+    # market_panel present, mm file absent → mm token is None, others unaffected
+    pd.DataFrame({
+        "market_id": ["m1"], "snapshot_at": ["2026-05-19"], "end_date": ["2026-05-29"],
+        "yes_price": [0.10], "market_type": ["event_long"], "market_score": [0.5],
+        "outcome_yes": [1],
+    }).to_csv(tmp_path / "market_panel.csv", index=False)
+    out = load_all_datasets_from_dir(str(tmp_path))
+    assert out["mm_trade_spreads"] is None
+    assert out["market_panel_resolved"] is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_data.py -q`
+Expected: FAIL — `KeyError: 'mm_trade_spreads'` (key not produced by the loader).
+
+- [ ] **Step 3: Add the loader branch**
+
+In `scripts/edge-research/data.py`, inside `load_all_datasets_from_dir`, after the
+existing `flb_shadow_signals` try/except block and before `return out`, add:
+
+```python
+    try:
+        mm = _read_raw_csv(d / "mm_trade_spreads.csv", ["time"])
+        out["mm_trade_spreads"] = mm if len(mm) else None
+    except Exception:
+        out["mm_trade_spreads"] = None
+```
+
+(The existing `_read_raw_csv(path, date_cols)` helper parses the listed date
+columns and returns the frame; numeric columns load as floats from the CSV. No
+`_LOADERS` entry is added — `mm_trade_spreads` is CSV-mode only.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_data.py -q`
+Expected: PASS (all tests in the file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/edge-research/data.py scripts/edge-research/tests/test_data.py
+git commit -m "feat(edge-research): mm_trade_spreads offline CSV loader"
+```
+
+---
+
+## Task 2: `MMSpreadValidator` (H-MM-1)
+
+**Files:**
+- Create: `scripts/edge-research/validators/mm.py`
+- Test: `scripts/edge-research/tests/test_mm.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/edge-research/tests/test_mm.py`:
+
+```python
+import numpy as np, pandas as pd, types
+from validators.mm import MMSpreadValidator
+
+
+def _ctx(df, mm_min_n=200, mm_maker_fee=0.0):
+    return types.SimpleNamespace(datasets={"mm_trade_spreads": df},
+                                 cost=0.005, computed_at="t", seed=7,
+                                 mm_min_n=mm_min_n, mm_maker_fee=mm_maker_fee)
+
+
+def _rows(n, market_type, real_half, eff_half, seed):
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame({
+        "market_id": [f"m{seed}_{i}" for i in range(n)],
+        "market_type": [market_type] * n,
+        "token_id": [f"tk{seed}"] * n,
+        "time": ["2026-06-04T10:00:00Z"] * n,
+        "size": np.full(n, 100.0),
+        "eff_half": np.full(n, eff_half),
+        "real_half": real_half + rng.normal(0, 0.001, n),
+        "impact_half": np.full(n, eff_half) - real_half,
+    })
+
+
+def _cohort(verdicts, name):
+    return [v for v in verdicts if v.class_metric.get("cohort") == name][0]
+
+
+def test_positive_retained_spread_passes_and_exposes_decomposition():
+    df = _rows(300, "crypto_intraday", real_half=0.004, eff_half=0.012, seed=1)
+    v = MMSpreadValidator().run(_ctx(df))
+    head = _cohort(v, "headline:tradeable")
+    assert head.hypothesis_id == "H-MM-1"
+    assert head.hclass == "market_making"
+    assert head.status == "pass"
+    assert head.edge_net_pct > 0
+    assert abs(head.class_metric["eff_half"] - 0.012) < 1e-3
+    assert abs(head.class_metric["impact_half"] - 0.008) < 1e-3
+
+
+def test_adverse_selection_eats_spread_fails():
+    # eff_half 0.010 but real_half negative (impact 0.012 > eff) → fail
+    df = _rows(300, "crypto_intraday", real_half=-0.002, eff_half=0.010, seed=2)
+    v = MMSpreadValidator().run(_ctx(df))
+    head = _cohort(v, "headline:tradeable")
+    assert head.status == "fail"
+    assert head.edge_net_pct < 0
+
+
+def test_below_floor_inconclusive():
+    df = _rows(50, "crypto_intraday", real_half=0.004, eff_half=0.012, seed=3)
+    v = MMSpreadValidator().run(_ctx(df))
+    head = _cohort(v, "headline:tradeable")
+    assert head.status == "inconclusive"
+    assert head.n == 50
+
+
+def test_event_long_emitted_as_own_cohort_not_in_headline():
+    df = pd.concat([
+        _rows(300, "crypto_intraday", real_half=0.004, eff_half=0.012, seed=4),
+        _rows(300, "event_long", real_half=0.004, eff_half=0.012, seed=5),
+    ], ignore_index=True)
+    v = MMSpreadValidator().run(_ctx(df))
+    head = _cohort(v, "headline:tradeable")
+    el = _cohort(v, "event_long")
+    assert head.n == 300                      # headline excludes event_long
+    assert el.n == 300
+    assert el.class_metric["cohort"] == "event_long"
+
+
+def test_caveats_present_on_every_verdict():
+    df = _rows(300, "crypto_intraday", real_half=0.004, eff_half=0.012, seed=6)
+    v = MMSpreadValidator().run(_ctx(df))
+    for verdict in v:
+        assert any("passive-maker proxy" in c for c in verdict.n_caveats)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_mm.py -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'validators.mm'`.
+
+- [ ] **Step 3: Implement the validator**
+
+Create `scripts/edge-research/validators/mm.py`:
+
+```python
+from __future__ import annotations
+from verdict import Verdict
+from validators.base import bootstrap_ci
+
+_CAVEAT = ("Δ≈10min (coarse); passive-maker proxy, not simulated fills; "
+           "excludes queue priority / inventory risk / rewards (H-MM-2)")
+
+
+class MMSpreadValidator:
+    """H-MM-1 — passive market-maker retained spread net of adverse selection.
+
+    From sampled trades joined to the book mid before/after (mm_trade_spreads):
+    real_half is the half-spread a maker keeps after the mid moves (≈ revenue per
+    share). Per market_type cohort, edge = mean(real_half) − maker_fee; the eff_half
+    (gross) and impact_half (adverse selection) decomposition is exposed in
+    class_metric. Headline = tradeable types pooled (market_type != event_long).
+    `pass` only on a positive, bootstrap-significant mean with n >= floor.
+    """
+
+    hypothesis_id = "H-MM-1"
+    hclass = "market_making"
+
+    def required_inputs(self) -> list[str]:
+        return ["mm_trade_spreads"]
+
+    def run(self, ctx) -> list[Verdict]:
+        df = ctx.datasets["mm_trade_spreads"].copy()
+        df["tradeable"] = df["market_type"] != "event_long"
+        cohorts = [("headline:tradeable", df[df["tradeable"]])]
+        for mt in sorted(df["market_type"].unique()):
+            cohorts.append((mt, df[df["market_type"] == mt]))
+        return [self._cohort(ctx, label, sub) for label, sub in cohorts]
+
+    def _cohort(self, ctx, label, sub) -> Verdict:
+        floor = getattr(ctx, "mm_min_n", 200)
+        fee = getattr(ctx, "mm_maker_fee", 0.0)
+        cost_model = f"maker_fee_{fee}"
+        n = len(sub)
+        if n < floor:
+            return Verdict(self.hypothesis_id, self.hclass, n, None, None, None,
+                           "full", {"cohort": label}, cost_model, "inconclusive",
+                           [_CAVEAT, f"n={n} below floor {floor}"], ctx.computed_at)
+        real = sub["real_half"].to_numpy(float)
+        edge = float(real.mean()) - fee
+        lo, hi = bootstrap_ci(real - fee, seed=ctx.seed)
+        status = "pass" if (edge > 0 and lo > 0) else "fail"
+        meta = {"cohort": label,
+                "eff_half": float(sub["eff_half"].to_numpy(float).mean()),
+                "impact_half": float(sub["impact_half"].to_numpy(float).mean()),
+                "avg_size": float(sub["size"].to_numpy(float).mean())}
+        return Verdict(self.hypothesis_id, self.hclass, n, edge, edge,
+                       float((hi - lo) / 2), "full", meta, cost_model,
+                       status, [_CAVEAT], ctx.computed_at)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_mm.py -q`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/edge-research/validators/mm.py scripts/edge-research/tests/test_mm.py
+git commit -m "feat(edge-research): H-MM-1 market-making spread validator"
+```
+
+---
+
+## Task 3: Wire H-MM-1 into the runner + registry
+
+**Files:**
+- Modify: `scripts/edge-research/run.py` (import + `VALIDATORS`)
+- Modify: `scripts/edge-research/registry.yaml` (H-MM-1 `required_data`)
+- Test: `scripts/edge-research/tests/test_run.py`
+
+- [ ] **Step 1: Write the failing test**
+
+In `scripts/edge-research/tests/test_run.py`, update the H-MM-1 blocked comment and
+add a dispatch test. Change the existing line in
+`test_run_dispatches_calibration_and_is_deterministic`:
+
+```python
+    # H-MM-1 needs mm_trade_spreads → blocked when only the panel is available
+    assert any(b["id"] == "H-MM-1" for b in r1["blocked"])
+```
+
+Then append a new test:
+
+```python
+def test_run_dispatches_mm_when_trade_spreads_available():
+    mm = pd.DataFrame({
+        "market_id": [f"m{i}" for i in range(300)],
+        "market_type": ["crypto_intraday"] * 300,
+        "token_id": ["tk"] * 300,
+        "time": ["2026-06-04T10:00:00Z"] * 300,
+        "size": [100.0] * 300,
+        "eff_half": [0.012] * 300,
+        "real_half": [0.004] * 300,
+        "impact_half": [0.008] * 300,
+    })
+    res = run_validators({"mm_trade_spreads": mm}, computed_at="t")
+    assert any(v.hypothesis_id == "H-MM-1" for v in res["verdicts"])
+    assert not any(b["id"] == "H-MM-1" for b in res["blocked"])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_run.py -q`
+Expected: FAIL — `test_run_dispatches_mm_when_trade_spreads_available` fails because
+H-MM-1 is in `blocked` / not in `verdicts` (no validator registered, and registry
+still requires `price_history_bidask`).
+
+- [ ] **Step 3: Register the validator and rename the registry token**
+
+In `scripts/edge-research/run.py`, add the import next to the other validator imports:
+
+```python
+from validators.mm import MMSpreadValidator
+```
+
+and add the entry to `VALIDATORS`:
+
+```python
+VALIDATORS = {"H-CAL-1": CalibrationValidator, "H-INE-1": FLBValidator,
+              "H-SUP-1": SupervisedValidator, "H-ENS-1": EnsembleValidator,
+              "H-INE-5": TimeDecayExtremeBandValidator,
+              "H-MM-1": MMSpreadValidator}
+```
+
+In `scripts/edge-research/registry.yaml`, change the H-MM-1 line's `required_data`
+from `[price_history_bidask]` to `[mm_trade_spreads]`:
+
+```yaml
+- {id: H-MM-1, class: market_making, name: Spread capture net of adverse selection, required_data: [mm_trade_spreads], status: planned, priority: 2, depends_on: []}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest -q`  (full suite)
+Expected: PASS (all tests, including the existing `test_run_dispatches_calibration_and_is_deterministic` whose blocked assertion still holds — `mm_trade_spreads` is absent when only the panel is supplied).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/edge-research/run.py scripts/edge-research/registry.yaml scripts/edge-research/tests/test_run.py
+git commit -m "feat(edge-research): register H-MM-1 + retarget registry to mm_trade_spreads"
+```
+
+---
+
+## Task 4: SQL export + first real verdict
+
+This task is integration against the VM (no Python unit test). It produces the
+export query, validates the asof-join arithmetic on real data, generates the
+scoreboard verdict, and commits both the SQL and the refreshed scoreboard.
+
+**Files:**
+- Create: `scripts/edge-research/mm_trade_spreads.sql`
+- Modify: `scripts/edge-research/out/scoreboard.md` (regenerated)
+
+- [ ] **Step 1: Write the export SQL**
+
+Create `scripts/edge-research/mm_trade_spreads.sql`. Server-side `COPY (...) TO
+STDOUT` (NOT the `\copy` meta-command) so the multi-line query is allowed and
+streams CSV to the client:
+
+```sql
+-- H-MM-1 export: per sampled trade, the realized-spread decomposition vs the book
+-- mid before (mid_t) and after (mid_after). Sign via the quote test. 300 trades
+-- per token, deterministic md5 sampling. Both join legs must exist.
+COPY (
+  WITH sampled AS (
+    SELECT market_id, token_id, time, price, size,
+           row_number() OVER (PARTITION BY token_id
+                              ORDER BY md5(token_id || time::text)) AS rn
+    FROM trades
+    WHERE time > NOW() - INTERVAL '7 days'
+  ),
+  s AS (SELECT * FROM sampled WHERE rn <= 300),
+  joined AS (
+    SELECT s.market_id, s.token_id, s.time, s.size, s.price,
+      (SELECT ob.mid_price FROM orderbook_snapshots ob
+         WHERE ob.token_id = s.token_id AND ob.time <= s.time
+           AND ob.mid_price IS NOT NULL
+         ORDER BY ob.time DESC LIMIT 1) AS mid_t,
+      (SELECT ob.mid_price FROM orderbook_snapshots ob
+         WHERE ob.token_id = s.token_id AND ob.time > s.time
+           AND ob.mid_price IS NOT NULL
+         ORDER BY ob.time ASC LIMIT 1) AS mid_after
+    FROM s
+  )
+  SELECT j.market_id, m.market_type, j.token_id, j.time, j.size,
+         sign(j.price - j.mid_t) * (j.price - j.mid_t)     AS eff_half,
+         sign(j.price - j.mid_t) * (j.price - j.mid_after) AS real_half,
+         sign(j.price - j.mid_t) * (j.mid_after - j.mid_t) AS impact_half
+  FROM joined j
+  JOIN markets m ON m.id = j.market_id
+  WHERE j.mid_t IS NOT NULL AND j.mid_after IS NOT NULL
+    AND j.price <> j.mid_t
+) TO STDOUT WITH CSV HEADER;
+```
+
+- [ ] **Step 2: Export the real CSV from the VM**
+
+Run (produces `C:/Users/Usuario/edge-datasets/mm_trade_spreads.csv` alongside the
+existing panel/flb exports):
+
+```bash
+gcloud compute scp scripts/edge-research/mm_trade_spreads.sql polymarket-vm:/tmp/mm.sql --zone=us-east1-b
+gcloud compute ssh polymarket-vm --zone=us-east1-b --command="docker cp /tmp/mm.sql polymarket-timescaledb:/tmp/mm.sql && docker exec polymarket-timescaledb psql -U polymarket -d polymarket_trading -f /tmp/mm.sql" > "C:/Users/Usuario/edge-datasets/mm_trade_spreads.csv"
+wc -l "C:/Users/Usuario/edge-datasets/mm_trade_spreads.csv"
+head -3 "C:/Users/Usuario/edge-datasets/mm_trade_spreads.csv"
+```
+
+Expected: a header + up to ~155×300 ≈ 46k data rows; each row has numeric
+`eff_half, real_half, impact_half`.
+
+- [ ] **Step 3: Sanity-check the asof arithmetic**
+
+Run a Python sanity check on the export (the identity must hold by construction and
+signs must be classified):
+
+```bash
+python -c "import pandas as pd; d=pd.read_csv('C:/Users/Usuario/edge-datasets/mm_trade_spreads.csv'); import numpy as np; print('rows', len(d), 'tokens', d.token_id.nunique()); print('identity max err', float((d.eff_half - d.real_half - d.impact_half).abs().max())); print('mean real_half', round(d.real_half.mean(),5), 'mean eff_half', round(d.eff_half.mean(),5), 'mean impact_half', round(d.impact_half.mean(),5))"
+```
+
+Expected: `identity max err` ≈ 0 (≤ 1e-9); means printed. If `identity max err` is
+not ~0, the SQL signs are inconsistent — fix the SQL before proceeding.
+
+- [ ] **Step 4: Regenerate the scoreboard with the real verdict**
+
+Run (uses the offline `--datasets-dir` mode added in PR #315; the dir now contains
+all four CSVs):
+
+```bash
+python scripts/edge-research/run.py --datasets-dir "C:/Users/Usuario/edge-datasets" --out scripts/edge-research/out --computed-at "2026-06-05T00:00:00Z"
+grep -n "H-MM-1" scripts/edge-research/out/scoreboard.md
+```
+
+Expected: `Wrote ...scoreboard.md` with one or more H-MM-1 rows visible (headline +
+per-type cohorts), each carrying the passive-maker caveat.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/edge-research/mm_trade_spreads.sql scripts/edge-research/out/scoreboard.md
+git commit -m "feat(edge-research): H-MM-1 SQL export + first real-data scoreboard verdict"
+```
+
+---
+
+## Task 5: Update memory with the verdict
+
+**Files:**
+- Modify: `C:\Users\Usuario\.claude\projects\C--Users-Usuario-github-polymarket-trader\memory\project_market_making_idea.md`
+- Modify: `C:\Users\Usuario\.claude\projects\C--Users-Usuario-github-polymarket-trader\memory\project_next_levers_and_automation.md`
+
+- [ ] **Step 1: Record the measurement outcome**
+
+In `project_market_making_idea.md`, under Status, append a dated line stating: the
+bid/ask recorder already exists (`orderbook_snapshots`, 10-min, 7-day); H-MM-1 was
+measured via realized-spread decomposition; and the verdict (PASS on some cohort →
+next step is a quoting-engine spike / H-MM-2 rewards; or FAIL → market-making closed
+at this cadence, revisit only with finer Δ). Fill in the actual numbers from Task 4's
+scoreboard (headline `edge_net_pct`, `eff_half`, `impact_half`, n).
+
+In `project_next_levers_and_automation.md`, update the market-making section: replace
+"data-blocked, build a recorder" with the corrected finding (recorder exists; H-MM-1
+measured) and the verdict, linking the spec/plan.
+
+- [ ] **Step 2: Commit (if the memory dir is a tracked repo; otherwise files persist as-is)**
+
+Memory files persist as plain files; no commit required unless the directory is a git
+repo you are tracking.
+
+---
+
+## Notes for the implementer
+
+- **Numbers in caveats/memory are placeholders only in Task 5** — fill them from the
+  real scoreboard produced in Task 4. Every code step has complete, runnable content.
+- **Do not** add `mm_trade_spreads` to `_LOADERS` in `data.py` — it is CSV-mode only
+  by design (the asof-join cannot run cheaply in DB mode).
+- **Do not** size-weight or shorten Δ in v1 — both are explicitly deferred in the spec.
+- After Task 4, the offline run also re-emits H-INE-5 / H-INE-1 / calibration rows;
+  that is expected (the scoreboard is regenerated wholesale).
+- Final step before finishing the branch: run `python -m pytest -q` from
+  `scripts/edge-research/` and confirm the full suite is green, then use
+  superpowers:finishing-a-development-branch.
+```

--- a/docs/superpowers/specs/2026-06-05-mm-spread-measurement-h-mm-1-design.md
+++ b/docs/superpowers/specs/2026-06-05-mm-spread-measurement-h-mm-1-design.md
@@ -1,0 +1,143 @@
+# H-MM-1 — Market-Making Spread Measurement (design)
+
+**Date:** 2026-06-05
+**Status:** approved (brainstorm), pending implementation plan
+**Hypothesis:** H-MM-1 — *Spread capture net of adverse selection* (registry, class `market_making`)
+
+## Goal
+
+Measure, from data already collected, whether a passive market-maker on Polymarket
+would retain positive edge after adverse selection — per `market_type` — and land
+the verdict on the edge-research scoreboard. **Measure-first:** no new data
+collection. If a cohort shows positive, significant retained spread, that is the
+trigger to invest in a quoting engine / finer collection; if adverse selection
+eats the spread, market-making is closed the same way the other four vías were.
+
+## Context: the recorder already exists
+
+The premise "build a bid/ask recorder" was wrong. `ClobCollector.syncAllOrderBooks()`
+runs every 10 min (Scheduler job `sync-orderbooks`) and writes
+`orderbook_snapshots` (top-of-book + top-10 depth + `mid_price`), 7-day retention.
+`trades` is likewise populated (~15.7M rows, ~7-day retention). Only
+`price_history.bid/ask/spread` is NULL — a separate, unused column set. So the raw
+inputs for a market-making measurement are present; what is missing is the
+**measurement** (the H-MM-1 validator), which this sub-project builds.
+
+Verified on VM 2026-06-05:
+- `orderbook_snapshots` 48h: 26,200 rows, 60 markets, 120 tokens, 100% with both
+  bid and ask; `spread` mean 1.54%, median 1.00%.
+- `trades` 48h: 4.08M rows, 87 markets, 155 tokens; all-time 15.66M since 05-29.
+
+## Measurement method (Lee-Ready realized-spread decomposition)
+
+No own quotes/fills exist, so maker economics are estimated from trades + book.
+Per trade, as a fraction of price, **per share**:
+
+- **Taker sign** (quote test): `sign = +1 if price > mid_t else −1` (price below mid
+  → taker hit the bid). The recorded `side` field is NOT trusted — the quote test
+  is the standard, robust classifier.
+- **Effective half-spread** (gross the maker captures at fill): `eff_half = sign·(price − mid_t)`.
+- **Realized half-spread** (what the maker keeps after the mid moves; ≈ maker
+  revenue): `real_half = sign·(price − mid_after)`.
+- **Price impact / adverse selection**: `impact_half = eff_half − real_half = sign·(mid_after − mid_t)`.
+
+where `mid_t` is the last book snapshot at or before the trade and `mid_after` is the
+next snapshot for the same token (~5–10 min later).
+
+**Maker edge per share ≈ `mean(real_half) − maker_fee`.** Adverse selection is already
+inside `real_half`; if it is positive and significant, the maker retains spread; if
+`impact_half` consumes `eff_half`, there is no edge.
+
+**Rejected alternative — simulate a passive maker** (post own quotes at best
+bid/ask, fill against trades, carry inventory): more realistic in principle but
+assumption-heavy (quote size, queue priority, inventory policy). Inappropriate for a
+*first* go/no-go. The realized-spread measure assumes none of that and is the
+standard microstructure decomposition.
+
+**Δ caveat:** the book is sampled every 10 min, so `mid_after` is ~5–10 min out
+(classic realized spread uses ~5 min). Coarse but valid for a first read; recorded
+as a caveat on every verdict.
+
+## Architecture & data flow
+
+The heavy asof-join of ~15M trades to snapshots runs **in SQL on the VM** (where both
+tables live); Python only consumes a small sampled export.
+
+1. **`scripts/edge-research/mm_trade_spreads.sql`** (versioned): asof-join each trade
+   to its token's `mid_t` and `mid_after`, compute `eff_half / real_half / impact_half`,
+   join `market_type`, and **sample N trades per token** (default 300) so the export is
+   bounded (~155 tokens × 300 ≈ 46k rows). Output columns:
+   `market_id, market_type, token_id, time, size, eff_half, real_half, impact_half`.
+   Sampling is deterministic (e.g. `ORDER BY md5(token_id || time::text) LIMIT N` per
+   token via a window function) so re-runs are stable. Trades with no `mid_t` (before
+   the token's first snapshot) or no `mid_after` (within the last ~10 min, snapshot not
+   yet taken) are **excluded** — both legs of the join must exist.
+2. **Export** via `psql \copy (…) TO STDOUT WITH CSV HEADER` → `mm_trade_spreads.csv`,
+   same pattern as the market_panel / flb exports. The weekly GHA workflow adds this
+   export later (out of scope here; this sub-project produces a one-off export to get
+   the first verdict).
+3. **`data.py`**: new loader `load_mm_trade_spreads` + token `mm_trade_spreads` in
+   `_LOADERS`, and a `mm_trade_spreads.csv` branch in `load_all_datasets_from_dir`
+   (offline mode). The loader is a near-passthrough (numeric coercion only).
+
+## Validator and verdict (`H-MM-1`)
+
+`MMSpreadValidator` in `scripts/edge-research/validators/mm.py`, `hclass = "market_making"`,
+`required_inputs() == ["mm_trade_spreads"]`. Reuses `bootstrap_ci` and the `Verdict`
+contract exactly like `FLBValidator` / `TimeDecayExtremeBandValidator`.
+
+For each cohort (one per `market_type`, plus a headline = tradeable types pooled —
+tradeable = `market_type != "event_long"`, which is shadow-only for taker flow but
+in-scope for making):
+
+- `n = len(cohort)`; if `n < floor` (`getattr(ctx, "mm_min_n", 200)`) → `inconclusive`.
+- `edge = mean(real_half) − maker_fee`, `maker_fee = getattr(ctx, "mm_maker_fee", 0.0)`.
+- `lo, hi = bootstrap_ci(real_half − maker_fee, seed=ctx.seed)`.
+- `status = "pass" if (edge > 0 and lo > 0) else "fail"`.
+- `class_metric = {"cohort": label, "eff_half": mean(eff_half), "impact_half": mean(impact_half), "avg_size": mean(size)}` — exposes the spread→revenue decomposition.
+- `cost_model = f"maker_fee_{maker_fee}"`; `split = "full"`; `edge_insample_pct = edge`.
+- **Caveats on every verdict**: `"Δ≈10min (coarse); passive-maker proxy, not simulated fills; excludes queue priority / inventory risk / rewards (H-MM-2)"`.
+
+`edge_net_pct` (and CI) use the per-share `real_half` (price fraction). Equal-weighted
+across trades for the headline number; `avg_size` is surfaced so a future revision can
+size-weight without re-exporting.
+
+Registry: change H-MM-1 `required_data` from `[price_history_bidask]` to
+`[mm_trade_spreads]` so `runnable()` dispatches it once the export exists; H-MM-2
+(rewards) stays blocked.
+
+## Testing
+
+Synthetic fixtures, no DB (mirrors `test_flb.py` / `test_ine5.py`):
+
+1. **Positive retained spread passes**: cohort with `real_half ≈ +0.01`, tight variance
+   → headline `pass`, `edge_net_pct > 0`, and `class_metric` carries `eff_half`/`impact_half`.
+2. **Adverse selection eats the spread → fail**: `eff_half ≈ +0.01` but `impact_half ≈ +0.012`
+   so `real_half ≤ 0` → `fail`.
+3. **Below floor → inconclusive**: `n < mm_min_n`.
+4. **Cohort split**: `event_long` emitted as its own verdict, not folded into the headline.
+5. **`data.py` loader**: synthetic `mm_trade_spreads.csv` in a tmp dir →
+   `load_all_datasets_from_dir` returns the token with numeric columns.
+6. **`run.py` dispatch**: with `mm_trade_spreads` available, `run_validators` emits an
+   H-MM-1 verdict (extends `test_run.py`).
+
+The **SQL** is not unit-tested in Python; it is validated against the VM during
+implementation with a sanity check: `real_half = eff_half − impact_half` by
+construction, sign distribution matches the quote test, and row count ≈ N×tokens. The
+first real export produces the initial scoreboard verdict.
+
+## Scope (anti-scope-creep)
+
+In scope: the SQL export, the loader, the validator, its tests, registry token rename,
+scoreboard regen — one PR. **Out of scope**: wiring the export into the weekly GHA
+workflow (a follow-up once the first verdict justifies it); H-MM-2 rewards; any quoting
+engine; finer-cadence or longer-retention collection (only if the measurement clears
+the bar). Size-weighting and shorter Δ are explicit future revisions, not v1.
+
+## Success criteria
+
+A reproducible H-MM-1 verdict per `market_type` on the scoreboard, showing the
+`eff_half → real_half` (spread minus adverse selection) decomposition, with an honest
+pass/fail under the same bootstrap-significant, cost-aware bar as the other vías. The
+outcome — edge or no edge — is the deliverable; a `fail` closes market-making as
+cleanly as a `pass` opens it.

--- a/scripts/edge-research/data.py
+++ b/scripts/edge-research/data.py
@@ -115,6 +115,10 @@ def load_all_datasets_from_dir(datasets_dir: str) -> dict:
     except Exception:
         out["flb_shadow_signals"] = None
     try:
+        # CSV-mode only: the asof-join that builds mm_trade_spreads runs in SQL on
+        # the VM (see mm_trade_spreads.sql) and is too heavy for the DB-mode
+        # load_all_datasets, so there is deliberately no _LOADERS entry. H-MM-1
+        # is therefore blocked in DB mode and runs only from this CSV export.
         mm = _read_raw_csv(d / "mm_trade_spreads.csv", ["time"])
         out["mm_trade_spreads"] = mm if len(mm) else None
     except Exception:

--- a/scripts/edge-research/data.py
+++ b/scripts/edge-research/data.py
@@ -114,4 +114,9 @@ def load_all_datasets_from_dir(datasets_dir: str) -> dict:
         out["flb_shadow_signals"] = flb if len(flb) else None
     except Exception:
         out["flb_shadow_signals"] = None
+    try:
+        mm = _read_raw_csv(d / "mm_trade_spreads.csv", ["time"])
+        out["mm_trade_spreads"] = mm if len(mm) else None
+    except Exception:
+        out["mm_trade_spreads"] = None
     return out

--- a/scripts/edge-research/mm_trade_spreads.sql
+++ b/scripts/edge-research/mm_trade_spreads.sql
@@ -1,0 +1,55 @@
+-- H-MM-1 export: per sampled trade, the realized-spread decomposition vs the book
+-- mid before (mid_t) and after (mid_after), sign via the quote test.
+--
+-- Designed to run on the e2-micro (1GB RAM, TimescaleDB 350MB): the naive per-trade
+-- correlated subquery over compressed chunks crashed the server, so this
+--   (1) materialises recent snapshots into an INDEXED session-temp table (no prod
+--       schema change, no compressed-chunk scan in the lateral lookups),
+--   (2) hash-samples ~5% of trades cheaply (no global sort),
+--   (3) FRESHNESS-FILTERS to trades within 120s of their preceding snapshot — at
+--       10-min book cadence a stale mid_t turns price drift into spurious "spread";
+--       keeping only near-snapshot trades makes eff_half ≈ the real quotable spread.
+-- gap_sec is exported for transparency; the harness validator ignores extra columns.
+-- Run: psql -f this_file  (streams CSV to stdout via server-side COPY).
+
+CREATE TEMP TABLE snap AS
+  SELECT token_id, time AS st, mid_price, best_bid, best_ask
+  FROM orderbook_snapshots
+  WHERE time > NOW() - INTERVAL '24 hours'
+    AND mid_price IS NOT NULL AND best_bid IS NOT NULL AND best_ask IS NOT NULL;
+CREATE INDEX ON snap (token_id, st);
+ANALYZE snap;
+
+CREATE TEMP TABLE strades AS
+  SELECT market_id, token_id, time AS tt, price, size
+  FROM trades
+  WHERE time > NOW() - INTERVAL '24 hours'
+    AND get_byte(decode(md5(token_id || time::text), 'hex'), 0) < 13;  -- ~5% sample
+
+COPY (
+  WITH j AS (
+    SELECT t.market_id, t.token_id, t.tt, t.size, t.price,
+           mt.st AS mt_time, mt.mid_price AS mid_t,
+           mt.best_bid, mt.best_ask, ma.mid_price AS mid_after
+    FROM strades t
+    LEFT JOIN LATERAL (
+      SELECT st, mid_price, best_bid, best_ask FROM snap
+      WHERE snap.token_id = t.token_id AND snap.st <= t.tt
+      ORDER BY snap.st DESC LIMIT 1) mt ON true
+    LEFT JOIN LATERAL (
+      SELECT mid_price FROM snap
+      WHERE snap.token_id = t.token_id AND snap.st > t.tt
+      ORDER BY snap.st ASC LIMIT 1) ma ON true
+  )
+  SELECT j.market_id, m.market_type, j.token_id, j.tt AS time, j.size,
+         EXTRACT(EPOCH FROM (j.tt - j.mt_time))            AS gap_sec,
+         (j.best_ask - j.best_bid) / 2.0                   AS book_half,
+         sign(j.price - j.mid_t) * (j.price - j.mid_t)     AS eff_half,
+         sign(j.price - j.mid_t) * (j.price - j.mid_after) AS real_half,
+         sign(j.price - j.mid_t) * (j.mid_after - j.mid_t) AS impact_half
+  FROM j JOIN markets m ON m.id = j.market_id
+  WHERE j.mid_t IS NOT NULL AND j.mid_after IS NOT NULL
+    AND j.price <> j.mid_t
+    AND EXTRACT(EPOCH FROM (j.tt - j.mt_time)) <= 120
+    AND (j.best_ask - j.best_bid) <= 0.05   -- tight book: a real quotable two-sided market
+) TO STDOUT WITH CSV HEADER;

--- a/scripts/edge-research/out/scoreboard.md
+++ b/scripts/edge-research/out/scoreboard.md
@@ -21,6 +21,9 @@
 | H-INE-1 | inefficiency | 0 |  |  |  | inconclusive | n=0 below floor 30 |
 | H-INE-1 | inefficiency | 5 |  |  |  | inconclusive | n=5 below floor 30 |
 | H-INE-5 | inefficiency | 10 |  |  |  | inconclusive | n=10 below floor 50 |
+| H-MM-1 | market_making | 15 |  |  |  | inconclusive | Δ≈10min (coarse); passive-maker proxy, not simulated fills; excludes queue priority / inventory risk / rewards (H-MM-2); n=15 below floor 200 |
+| H-MM-1 | market_making | 15 |  |  |  | inconclusive | Δ≈10min (coarse); passive-maker proxy, not simulated fills; excludes queue priority / inventory risk / rewards (H-MM-2); n=15 below floor 200 |
+| H-MM-1 | market_making | 10 |  |  |  | inconclusive | Δ≈10min (coarse); passive-maker proxy, not simulated fills; excludes queue priority / inventory risk / rewards (H-MM-2); n=10 below floor 200 |
 | H-ENS-1 | ensemble | 0 |  |  |  | inconclusive | fewer than 2 passing components — nothing to combine |
 
 ## Blocked (data not available)
@@ -29,5 +32,4 @@
 - H-INE-2 — Resolution-day discovery gap (blocked)
 - H-INE-3 — News-event price lag (blocked)
 - H-INE-4 — Conditional markets not updating (blocked)
-- H-MM-1 — Spread capture net of adverse selection (blocked)
 - H-MM-2 — Liquidity-rewards subsidy (blocked)

--- a/scripts/edge-research/registry.yaml
+++ b/scripts/edge-research/registry.yaml
@@ -9,7 +9,7 @@
 - {id: H-INE-3, class: inefficiency, name: News-event price lag, required_data: [price_history_resolved, news], status: planned, priority: 3, depends_on: []}
 - {id: H-INE-4, class: inefficiency, name: Conditional markets not updating, required_data: [markets, manual_mapping], status: planned, priority: 4, depends_on: []}
 - {id: H-INE-5, class: inefficiency, name: Time-decay extreme band, required_data: [market_panel_resolved], status: planned, priority: 3, depends_on: []}
-- {id: H-MM-1, class: market_making, name: Spread capture net of adverse selection, required_data: [price_history_bidask], status: planned, priority: 2, depends_on: []}
+- {id: H-MM-1, class: market_making, name: Spread capture net of adverse selection, required_data: [mm_trade_spreads], status: planned, priority: 2, depends_on: []}
 - {id: H-MM-2, class: market_making, name: Liquidity-rewards subsidy, required_data: [gamma_rewards], status: planned, priority: 3, depends_on: []}
 - {id: H-ENS-1, class: ensemble, name: Combination of validated signals, required_data: [], status: planned, priority: 2, depends_on: []}
 - {id: H-ARB-1, class: arbitrage, name: Cross-venue, required_data: [], status: closed, priority: 9, depends_on: []}

--- a/scripts/edge-research/run.py
+++ b/scripts/edge-research/run.py
@@ -6,6 +6,7 @@ from validators.flb import FLBValidator
 from validators.supervised import SupervisedValidator
 from validators.ensemble import EnsembleValidator
 from validators.ine5 import TimeDecayExtremeBandValidator
+from validators.mm import MMSpreadValidator
 from scoreboard import render_markdown, render_csv
 
 # Primary hypothesis_id → validator factory. A validator may emit several slices
@@ -15,7 +16,8 @@ from scoreboard import render_markdown, render_csv
 # Extended as sub-projects B/C land validators.
 VALIDATORS = {"H-CAL-1": CalibrationValidator, "H-INE-1": FLBValidator,
               "H-SUP-1": SupervisedValidator, "H-ENS-1": EnsembleValidator,
-              "H-INE-5": TimeDecayExtremeBandValidator}
+              "H-INE-5": TimeDecayExtremeBandValidator,
+              "H-MM-1": MMSpreadValidator}
 
 
 def _ctx(datasets, computed_at):

--- a/scripts/edge-research/tests/test_data.py
+++ b/scripts/edge-research/tests/test_data.py
@@ -47,8 +47,11 @@ def _write_csvs(d):
 def test_load_from_dir_matches_db_shaping(tmp_path):
     _write_csvs(tmp_path)
     out = load_all_datasets_from_dir(str(tmp_path))
-    # Same three tokens the DB path produces.
-    assert set(out) == {"market_panel_resolved", "market_panel_full", "flb_shadow_signals"}
+    # The CSV path produces the DB-path tokens plus the CSV-only mm_trade_spreads
+    # token (None here, since no mm_trade_spreads.csv was written).
+    assert set(out) == {"market_panel_resolved", "market_panel_full",
+                        "flb_shadow_signals", "mm_trade_spreads"}
+    assert out["mm_trade_spreads"] is None
     res = out["market_panel_resolved"]
     assert len(res) == 2                                  # one row per market (earliest)
     m1 = res[res.market_id == "m1"].iloc[0]
@@ -71,3 +74,33 @@ def test_load_from_dir_missing_file_maps_to_none(tmp_path):
     assert out["market_panel_resolved"] is None
     assert out["market_panel_full"] is None
     assert out["flb_shadow_signals"] is not None
+
+
+def test_load_from_dir_reads_mm_trade_spreads(tmp_path):
+    pd.DataFrame({
+        "market_id": ["a", "b"],
+        "market_type": ["crypto_intraday", "event_long"],
+        "token_id": ["t1", "t2"],
+        "time": ["2026-06-04T10:00:00Z", "2026-06-04T10:05:00Z"],
+        "size": [100.0, 50.0],
+        "eff_half": [0.012, 0.020],
+        "real_half": [0.004, -0.001],
+        "impact_half": [0.008, 0.021],
+    }).to_csv(tmp_path / "mm_trade_spreads.csv", index=False)
+    out = load_all_datasets_from_dir(str(tmp_path))
+    mm = out["mm_trade_spreads"]
+    assert mm is not None
+    assert len(mm) == 2
+    assert set(["market_type", "real_half", "eff_half", "impact_half", "size"]).issubset(mm.columns)
+    assert abs(float(mm.iloc[0]["real_half"]) - 0.004) < 1e-9
+
+
+def test_load_from_dir_mm_missing_maps_to_none(tmp_path):
+    pd.DataFrame({
+        "market_id": ["m1"], "snapshot_at": ["2026-05-19"], "end_date": ["2026-05-29"],
+        "yes_price": [0.10], "market_type": ["event_long"], "market_score": [0.5],
+        "outcome_yes": [1],
+    }).to_csv(tmp_path / "market_panel.csv", index=False)
+    out = load_all_datasets_from_dir(str(tmp_path))
+    assert out["mm_trade_spreads"] is None
+    assert out["market_panel_resolved"] is not None

--- a/scripts/edge-research/tests/test_mm.py
+++ b/scripts/edge-research/tests/test_mm.py
@@ -1,0 +1,74 @@
+import numpy as np, pandas as pd, types
+from validators.mm import MMSpreadValidator
+
+
+def _ctx(df, mm_min_n=200, mm_maker_fee=0.0):
+    return types.SimpleNamespace(datasets={"mm_trade_spreads": df},
+                                 cost=0.005, computed_at="t", seed=7,
+                                 mm_min_n=mm_min_n, mm_maker_fee=mm_maker_fee)
+
+
+def _rows(n, market_type, real_half, eff_half, seed):
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame({
+        "market_id": [f"m{seed}_{i}" for i in range(n)],
+        "market_type": [market_type] * n,
+        "token_id": [f"tk{seed}"] * n,
+        "time": ["2026-06-04T10:00:00Z"] * n,
+        "size": np.full(n, 100.0),
+        "eff_half": np.full(n, eff_half),
+        "real_half": real_half + rng.normal(0, 0.001, n),
+        "impact_half": np.full(n, eff_half) - real_half,
+    })
+
+
+def _cohort(verdicts, name):
+    return [v for v in verdicts if v.class_metric.get("cohort") == name][0]
+
+
+def test_positive_retained_spread_passes_and_exposes_decomposition():
+    df = _rows(300, "crypto_intraday", real_half=0.004, eff_half=0.012, seed=1)
+    v = MMSpreadValidator().run(_ctx(df))
+    head = _cohort(v, "headline:tradeable")
+    assert head.hypothesis_id == "H-MM-1"
+    assert head.hclass == "market_making"
+    assert head.status == "pass"
+    assert head.edge_net_pct > 0
+    assert abs(head.class_metric["eff_half"] - 0.012) < 1e-3
+    assert abs(head.class_metric["impact_half"] - 0.008) < 1e-3
+
+
+def test_adverse_selection_eats_spread_fails():
+    df = _rows(300, "crypto_intraday", real_half=-0.002, eff_half=0.010, seed=2)
+    v = MMSpreadValidator().run(_ctx(df))
+    head = _cohort(v, "headline:tradeable")
+    assert head.status == "fail"
+    assert head.edge_net_pct < 0
+
+
+def test_below_floor_inconclusive():
+    df = _rows(50, "crypto_intraday", real_half=0.004, eff_half=0.012, seed=3)
+    v = MMSpreadValidator().run(_ctx(df))
+    head = _cohort(v, "headline:tradeable")
+    assert head.status == "inconclusive"
+    assert head.n == 50
+
+
+def test_event_long_emitted_as_own_cohort_not_in_headline():
+    df = pd.concat([
+        _rows(300, "crypto_intraday", real_half=0.004, eff_half=0.012, seed=4),
+        _rows(300, "event_long", real_half=0.004, eff_half=0.012, seed=5),
+    ], ignore_index=True)
+    v = MMSpreadValidator().run(_ctx(df))
+    head = _cohort(v, "headline:tradeable")
+    el = _cohort(v, "event_long")
+    assert head.n == 300
+    assert el.n == 300
+    assert el.class_metric["cohort"] == "event_long"
+
+
+def test_caveats_present_on_every_verdict():
+    df = _rows(300, "crypto_intraday", real_half=0.004, eff_half=0.012, seed=6)
+    v = MMSpreadValidator().run(_ctx(df))
+    for verdict in v:
+        assert any("passive-maker proxy" in c for c in verdict.n_caveats)

--- a/scripts/edge-research/tests/test_run.py
+++ b/scripts/edge-research/tests/test_run.py
@@ -22,7 +22,7 @@ def test_run_dispatches_calibration_and_is_deterministic():
     assert any(v.hypothesis_id == "H-CAL-1" for v in r1["verdicts"])
     # H-INE-5 (time-decay extreme band) now has a validator → it emits a verdict
     assert any(v.hypothesis_id == "H-INE-5" for v in r1["verdicts"])
-    # H-MM-1 needs price_history_bidask → blocked when only the panel is available
+    # H-MM-1 needs mm_trade_spreads → blocked when only the panel is available
     assert any(b["id"] == "H-MM-1" for b in r1["blocked"])
 
 def test_run_reports_pending_for_runnable_hypothesis_without_validator():
@@ -32,6 +32,21 @@ def test_run_reports_pending_for_runnable_hypothesis_without_validator():
                 "price_history_resolved": _panel()}
     res = run_validators(datasets, computed_at="t")
     assert any(p["id"] == "H-INE-2" for p in res["pending"])
+
+def test_run_dispatches_mm_when_trade_spreads_available():
+    mm = pd.DataFrame({
+        "market_id": [f"m{i}" for i in range(300)],
+        "market_type": ["crypto_intraday"] * 300,
+        "token_id": ["tk"] * 300,
+        "time": ["2026-06-04T10:00:00Z"] * 300,
+        "size": [100.0] * 300,
+        "eff_half": [0.012] * 300,
+        "real_half": [0.004] * 300,
+        "impact_half": [0.008] * 300,
+    })
+    res = run_validators({"mm_trade_spreads": mm}, computed_at="t")
+    assert any(v.hypothesis_id == "H-MM-1" for v in res["verdicts"])
+    assert not any(b["id"] == "H-MM-1" for b in res["blocked"])
 
 def test_main_datasets_dir_mode_writes_scoreboard(tmp_path):
     # Offline CSV mode end-to-end: a tiny market_panel.csv drives run.py without

--- a/scripts/edge-research/validators/mm.py
+++ b/scripts/edge-research/validators/mm.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+from verdict import Verdict
+from validators.base import bootstrap_ci
+
+_CAVEAT = ("Δ≈10min (coarse); passive-maker proxy, not simulated fills; "
+           "excludes queue priority / inventory risk / rewards (H-MM-2)")
+
+
+class MMSpreadValidator:
+    """H-MM-1 — passive market-maker retained spread net of adverse selection.
+
+    From sampled trades joined to the book mid before/after (mm_trade_spreads):
+    real_half is the half-spread a maker keeps after the mid moves (≈ revenue per
+    share). Per market_type cohort, edge = mean(real_half) − maker_fee; the eff_half
+    (gross) and impact_half (adverse selection) decomposition is exposed in
+    class_metric. Headline = tradeable types pooled (market_type != event_long).
+    `pass` only on a positive, bootstrap-significant mean with n >= floor.
+    """
+
+    hypothesis_id = "H-MM-1"
+    hclass = "market_making"
+
+    def required_inputs(self) -> list[str]:
+        return ["mm_trade_spreads"]
+
+    def run(self, ctx) -> list[Verdict]:
+        df = ctx.datasets["mm_trade_spreads"].copy()
+        df["tradeable"] = df["market_type"] != "event_long"
+        cohorts = [("headline:tradeable", df[df["tradeable"]])]
+        for mt in sorted(df["market_type"].unique()):
+            cohorts.append((mt, df[df["market_type"] == mt]))
+        return [self._cohort(ctx, label, sub) for label, sub in cohorts]
+
+    def _cohort(self, ctx, label, sub) -> Verdict:
+        floor = getattr(ctx, "mm_min_n", 200)
+        fee = getattr(ctx, "mm_maker_fee", 0.0)
+        cost_model = f"maker_fee_{fee}"
+        n = len(sub)
+        if n < floor:
+            return Verdict(self.hypothesis_id, self.hclass, n, None, None, None,
+                           "full", {"cohort": label}, cost_model, "inconclusive",
+                           [_CAVEAT, f"n={n} below floor {floor}"], ctx.computed_at)
+        real = sub["real_half"].to_numpy(float)
+        edge = float(real.mean()) - fee
+        lo, hi = bootstrap_ci(real - fee, seed=ctx.seed)
+        status = "pass" if (edge > 0 and lo > 0) else "fail"
+        meta = {"cohort": label,
+                "eff_half": float(sub["eff_half"].to_numpy(float).mean()),
+                "impact_half": float(sub["impact_half"].to_numpy(float).mean()),
+                "avg_size": float(sub["size"].to_numpy(float).mean())}
+        return Verdict(self.hypothesis_id, self.hclass, n, edge, edge,
+                       float((hi - lo) / 2), "full", meta, cost_model,
+                       status, [_CAVEAT], ctx.computed_at)


### PR DESCRIPTION
## Summary

Measures whether a passive market-maker retains positive spread after adverse selection, per `market_type`, on the edge-research scoreboard — from already-collected `orderbook_snapshots` + `trades`, no new collection.

**Method:** Lee-Ready realized-spread decomposition. Per sampled trade, asof-joined to the book mid before/after: `eff_half` (gross), `real_half` (kept after the mid moves ≈ revenue), `impact_half` (adverse selection). `edge = mean(real_half) − maker_fee`, bootstrap-gated, cohort by market_type. e2-micro-safe export (temp tables, ~5% hash sample, ≤120s freshness, tight-book ≤0.05).

## Depends on #318 (trades fix)

Blocked until #318: `trades` was misattributed so prices didn't reconcile with the book. Now sane: `eff_half` mean **0.00423 ≈ book_half 0.00422** (was **0.37**), impact 0.00196, real_half +0.00227.

## Verdict: preliminary / inconclusive

Scoreboard shows H-MM-1 inconclusive (n=15/15/10 < floor 200): only ~1h of clean trades post-`TRUNCATE`. Firms up as data accumulates. Floor stays 200 — no verdict on thin samples.

## Out of scope (deferred)

Weekly-GHA mm export wiring; fill simulation; H-MM-2 rewards; finer Δ / size-weighting.

## Test Plan
- [x] Harness suite green (46 tests incl. test_mm.py).
- [x] Method validated on clean data (eff_half ≈ book_half).
- [ ] Robust verdict — re-export after days of clean trades.

Spec: `docs/superpowers/specs/2026-06-05-mm-spread-measurement-h-mm-1-design.md` · Plan: `docs/superpowers/plans/2026-06-05-mm-spread-measurement-h-mm-1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)