### PR TITLE
fix(edge-research): H-MM-1 sample 100% + 7d window — unblocks PASS verdict post-#318

### DIFF
--- a/scripts/edge-research/mm_trade_spreads.sql
+++ b/scripts/edge-research/mm_trade_spreads.sql
@@ -1,21 +1,34 @@
--- H-MM-1 export: per sampled trade, the realized-spread decomposition vs the book
+-- H-MM-1 export: per trade, the realized-spread decomposition vs the book
 -- mid before (mid_t) and after (mid_after), sign via the quote test.
 --
 -- Designed to run on the e2-micro (1GB RAM, TimescaleDB 350MB): the naive per-trade
 -- correlated subquery over compressed chunks crashed the server, so this
 --   (1) materialises recent snapshots into an INDEXED session-temp table (no prod
 --       schema change, no compressed-chunk scan in the lateral lookups),
---   (2) hash-samples ~5% of trades cheaply (no global sort),
---   (3) FRESHNESS-FILTERS to trades within 120s of their preceding snapshot — at
+--   (2) FRESHNESS-FILTERS to trades within 120s of their preceding snapshot — at
 --       10-min book cadence a stale mid_t turns price drift into spurious "spread";
 --       keeping only near-snapshot trades makes eff_half ≈ the real quotable spread.
 -- gap_sec is exported for transparency; the harness validator ignores extra columns.
 -- Run: psql -f this_file  (streams CSV to stdout via server-side COPY).
+--
+-- WINDOW: defaults to 7 days; override with `psql -v win='30 days' -f ...`.
+-- 100% of trades (no hash-sample). Rationale: the original 5% hash-sample was
+-- calibrated for the pre-#318 INFLATED trades feed (a mis-attributed global feed,
+-- tens of thousands of rows/day). After the #318 fix (per-market query) the feed is
+-- correctly attributed and small (~2.5k trades/24h); at 5%×24h the cohorts landed at
+-- n≈42, far below the n>=200 validator floor, so H-MM-1 stayed perpetually
+-- inconclusive. 100%×7d brings the tradeable cohorts above the floor and is cheap on
+-- the e2-micro (snap ~70k rows, strades ~18k rows). See
+-- project_trades_collection_corrupt_2026-06-06 / project_market_making_idea.
+\if :{?win}
+\else
+  \set win '7 days'
+\endif
 
 CREATE TEMP TABLE snap AS
   SELECT token_id, time AS st, mid_price, best_bid, best_ask
   FROM orderbook_snapshots
-  WHERE time > NOW() - INTERVAL '24 hours'
+  WHERE time > NOW() - INTERVAL :'win'
     AND mid_price IS NOT NULL AND best_bid IS NOT NULL AND best_ask IS NOT NULL;
 CREATE INDEX ON snap (token_id, st);
 ANALYZE snap;
@@ -23,8 +36,7 @@ ANALYZE snap;
 CREATE TEMP TABLE strades AS
   SELECT market_id, token_id, time AS tt, price, size
   FROM trades
-  WHERE time > NOW() - INTERVAL '24 hours'
-    AND get_byte(decode(md5(token_id || time::text), 'hex'), 0) < 13;  -- ~5% sample
+  WHERE time > NOW() - INTERVAL :'win';
 
 COPY (
   WITH j AS (

--- a/scripts/edge-research/out/scoreboard.md
+++ b/scripts/edge-research/out/scoreboard.md
@@ -3,6 +3,9 @@
 | id | class | n | edge_net% | insample% | sig | status | caveats |
 |----|-------|---|-----------|-----------|-----|--------|---------|
 | H-INE-5 | inefficiency | 154 | 1.50 | 1.50 | 0.00 | pass | flat cost; real-cost refuted for this side by H-INE-1 (FLB) |
+| H-MM-1 | market_making | 510 | 0.37 | 0.37 | 0.00 | pass | Δ≈10min (coarse); passive-maker proxy, not simulated fills; excludes queue priority / inventory risk / rewards (H-MM-2) |
+| H-MM-1 | market_making | 498 | 0.37 | 0.37 | 0.00 | pass | Δ≈10min (coarse); passive-maker proxy, not simulated fills; excludes queue priority / inventory risk / rewards (H-MM-2) |
+| H-MM-1 | market_making | 1006 | 0.19 | 0.19 | 0.00 | pass | Δ≈10min (coarse); passive-maker proxy, not simulated fills; excludes queue priority / inventory risk / rewards (H-MM-2) |
 | H-INE-1 | inefficiency | 101 | -0.28 | -0.28 | 0.03 | fail |  |
 | H-SUP-1 | supervised | 434 | -1.30 | 5.19 | 0.02 | fail |  |
 | H-INE-1 | inefficiency | 54 | -1.35 | -1.35 | 0.07 | fail |  |
@@ -21,9 +24,7 @@
 | H-INE-1 | inefficiency | 0 |  |  |  | inconclusive | n=0 below floor 30 |
 | H-INE-1 | inefficiency | 5 |  |  |  | inconclusive | n=5 below floor 30 |
 | H-INE-5 | inefficiency | 10 |  |  |  | inconclusive | n=10 below floor 50 |
-| H-MM-1 | market_making | 15 |  |  |  | inconclusive | Δ≈10min (coarse); passive-maker proxy, not simulated fills; excludes queue priority / inventory risk / rewards (H-MM-2); n=15 below floor 200 |
-| H-MM-1 | market_making | 15 |  |  |  | inconclusive | Δ≈10min (coarse); passive-maker proxy, not simulated fills; excludes queue priority / inventory risk / rewards (H-MM-2); n=15 below floor 200 |
-| H-MM-1 | market_making | 10 |  |  |  | inconclusive | Δ≈10min (coarse); passive-maker proxy, not simulated fills; excludes queue priority / inventory risk / rewards (H-MM-2); n=10 below floor 200 |
+| H-MM-1 | market_making | 12 |  |  |  | inconclusive | Δ≈10min (coarse); passive-maker proxy, not simulated fills; excludes queue priority / inventory risk / rewards (H-MM-2); n=12 below floor 200 |
 | H-ENS-1 | ensemble | 0 |  |  |  | inconclusive | fewer than 2 passing components — nothing to combine |
 
 ## Blocked (data not available)


### PR DESCRIPTION
## Qué

El validador H-MM-1 (market-making) quedaba perpetuamente `inconclusive` tras el fix de trades #318. Este PR corrige el SQL de export para que alcance el floor `n≥200` y cierra el veredicto.

## Por qué

El `mm_trade_spreads.sql` usaba `hash-sample 5% + ventana 24h`, calibrados para el **feed global inflado pre-#318** (decenas de miles de trades/día mal atribuidos). Tras #318 (query por mercado) el feed está bien atribuido y es pequeño (~2.5k trades/24h); a 5%×24h los cohorts caían a `n≈42 << 200`.

El carry-over previo decía "esperar a que se acumulen más días limpios" — **incorrecto**: la query usa ventana **fija** de 24h, así que esperar nunca sube n. El blocker era el sample rate.

## Cambio

- `mm_trade_spreads.sql`: 100% de trades (sin hash-sample) + ventana parametrizable (`-v win='...'`, default `7 days`). Barato en el e2-micro (snap ~70k filas, strades ~18k).
- `out/scoreboard.md`: regenerado. Solo cambian las filas H-MM-1 (resto de datasets 06-05/06, sin cambio, siguen NO-edge).

## Veredicto (cost-aware, maker_fee=0, bootstrap lo>0, n≥200)

| cohort | n | edge | status |
|---|---|---|---|
| headline:tradeable | 510 | +0.37% | **pass** |
| event_financial | 498 | +0.37% | **pass** |
| event_long | 1006 | +0.19% | **pass** |
| event_short | 12 | — | inconclusive |

Primer edge estructural positivo del programa edge-research. El maker retiene ≈35bps/fill neto de selección adversa @10min.

**Caveat (del propio validador):** Δ≈10min coarse, passive-maker proxy (sin fills simulados), excluye queue priority / inventory / rewards (H-MM-2). No tradeable todavía — justifica el siguiente paso (recolector de cadencia fina + fill-sim).

## Tests

`pytest tests/test_mm.py tests/test_run.py` → 9/9 verdes (usan DataFrames sintéticos; el cambio de SQL no los afecta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved market-making research tools with flexible, configurable time window parameters (default 7 days) replacing fixed periods
  * Enhanced trade data analysis by processing complete datasets instead of sampled data
  * Updated market-making performance metrics and analysis scoreboard with consolidated research findings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->