### PR TITLE
feat(mm-recorder): GCP deploy (Dockerfile + CI + on-demand capture service)

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -15,6 +15,7 @@ env:
   REGISTRY: ghcr.io
   DASHBOARD_IMAGE: ghcr.io/javimaligno/polymarket-trader/dashboard-api
   DATA_COLLECTOR_IMAGE: ghcr.io/javimaligno/polymarket-trader/data-collector
+  MM_RECORDER_IMAGE: ghcr.io/javimaligno/polymarket-trader/mm-recorder
 
 jobs:
   changes:
@@ -24,6 +25,7 @@ jobs:
     outputs:
       dashboard: ${{ steps.detect.outputs.dashboard }}
       data-collector: ${{ steps.detect.outputs.data-collector }}
+      mm-recorder: ${{ steps.detect.outputs.mm-recorder }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -48,6 +50,7 @@ jobs:
 
           dashboard=false
           data_collector=false
+          mm_recorder=false
 
           while IFS= read -r file; do
             [ -n "$file" ] || continue
@@ -63,10 +66,17 @@ jobs:
                 data_collector=true
                 ;;
             esac
+
+            case "$file" in
+              packages/mm-recorder/*)
+                mm_recorder=true
+                ;;
+            esac
           done <<< "$changed_files"
 
           echo "dashboard=$dashboard" >> "$GITHUB_OUTPUT"
           echo "data-collector=$data_collector" >> "$GITHUB_OUTPUT"
+          echo "mm-recorder=$mm_recorder" >> "$GITHUB_OUTPUT"
 
   build-dashboard:
     needs: changes
@@ -134,8 +144,41 @@ jobs:
           cache-from: type=gha,scope=data-collector
           cache-to: type=gha,mode=max,scope=data-collector
 
+  build-mm-recorder:
+    needs: changes
+    if: needs.changes.outputs.mm-recorder == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push mm-recorder
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: packages/mm-recorder/Dockerfile.gcp
+          push: true
+          tags: |
+            ${{ env.MM_RECORDER_IMAGE }}:latest
+            ${{ env.MM_RECORDER_IMAGE }}:${{ github.sha }}
+          cache-from: type=gha,scope=mm-recorder
+          cache-to: type=gha,mode=max,scope=mm-recorder
+
   deploy:
-    needs: [changes, build-dashboard, build-data-collector]
+    needs: [changes, build-dashboard, build-data-collector, build-mm-recorder]
     if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     permissions:

--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -355,6 +355,43 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # ============================================
+  # mm-recorder (fine-cadence orderbook capture) — ON-DEMAND
+  # ============================================
+  # Lever B (market-making H-MM-3): captures the Polymarket CLOB market-channel
+  # top-of-book + trade stream for the most liquid event_financial markets into
+  # mm_book_events / mm_trade_events / mm_capture_gaps, for offline maker fill-sim.
+  # NOT part of the always-on stack — guarded by the `capture` profile so a plain
+  # `docker compose up -d` never starts it. Start a campaign with:
+  #   docker compose -f docker-compose.gcp.yml --profile capture up -d mm-recorder
+  # Stop it with:
+  #   docker compose -f docker-compose.gcp.yml --profile capture stop mm-recorder
+  # Hard 120M cap: the recorder is SACRIFICIAL — if it exceeds the limit the
+  # kernel OOM-kills it, NOT the live services (TimescaleDB/data-collector/dashboard).
+  mm-recorder:
+    image: ghcr.io/javimaligno/polymarket-trader/mm-recorder:latest
+    container_name: polymarket-mm-recorder
+    profiles: ["capture"]
+    restart: unless-stopped
+    environment:
+      NODE_ENV: production
+      DATABASE_URL: ${DATABASE_URL}
+      NODE_TLS_REJECT_UNAUTHORIZED: "0"
+      MM_UNIVERSE_N: "15"
+      MM_BATCH: "200"
+      DB_POOL_MAX: "2"
+    deploy:
+      resources:
+        limits:
+          memory: 120M
+        reservations:
+          memory: 40M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
 volumes:
   timescaledb_data:
     driver: local

--- a/packages/mm-recorder/Dockerfile.gcp
+++ b/packages/mm-recorder/Dockerfile.gcp
@@ -1,0 +1,33 @@
+# mm-recorder — fine-cadence orderbook capture (GCP, standalone)
+# On-demand capture service; runs only under the `capture` compose profile.
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Install deps (incl. dev for the tsc build)
+COPY packages/mm-recorder/package.json ./
+RUN npm install
+
+# Build TypeScript
+COPY packages/mm-recorder/src ./src
+COPY packages/mm-recorder/tsconfig.json ./
+RUN npm run build
+
+# Production stage — minimal image
+FROM node:20-alpine AS production
+
+WORKDIR /app
+
+# Production deps only
+COPY packages/mm-recorder/package.json ./
+RUN npm install --omit=dev
+
+# Built JS
+COPY --from=builder /app/dist ./dist
+# The runtime reads schema.sql / selectUniverse.sql with readFileSync relative to
+# dist/ (import.meta.url dir). tsc does not copy non-TS files, so copy them in.
+COPY packages/mm-recorder/src/schema.sql packages/mm-recorder/src/selectUniverse.sql ./dist/
+
+ENV NODE_ENV=production
+
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
Despliega el recolector de cadencia fina (Lever B / H-MM-3, PR #321) al e2-micro para la campaña de captura.

- **Dockerfile.gcp**: build standalone multi-stage; copia `schema.sql`/`selectUniverse.sql` a `dist/` (se leen en runtime).
- **CI** (`deploy-gcp.yml`): detecta cambios en `packages/mm-recorder/*` + job `build-mm-recorder` → `ghcr.io/.../mm-recorder`. NO se añade al pull/up automático — es on-demand.
- **compose**: servicio `mm-recorder` bajo el profile `capture` (un `up -d` normal nunca lo arranca) con cap duro de 120M. **Sacrificable**: si excede el límite lo mata el OOM killer, no los servicios live.

Arranque de campaña en la VM:
```
docker compose -f docker-compose.gcp.yml --profile capture up -d mm-recorder
```

Tras merge: CI construye la imagen. Luego aplico el schema en la VM DB, arranco una cata de validación de ~30min midiendo RAM real, y si aguanta lo dejo en campaña 1-2 semanas. El veredicto H-MM-3 se corre al final.

🤖 Generated with [Claude Code](https://claude.com/claude-code)