### PR TITLE
feat(mm-quoter): activar shadow quoting en el mm-recorder

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -380,6 +380,16 @@ services:
       MM_UNIVERSE_N: "45"
       MM_BATCH: "200"
       DB_POOL_MAX: "2"
+      # Shadow quoting (H-MM Nivel 3, fase shadow). MODE=shadow postea quotes
+      # maker VIRTUALES contra el libro real (sin órdenes), persiste fills a
+      # mm_shadow_fills con cola inicial exacta + dual drain bounds para el
+      # validator H-MM-4. Arranca el reloj de los ≥7 días del gate shadow→real.
+      # minSpread/volPause se dejan en default permisivo (sin definir) para que
+      # el shadow APRENDA los umbrales de la curva retained-vs-spread/vol; live
+      # los endurecerá con esos datos. NO poner mode=live (index.ts lanza error).
+      MM_QUOTER_MODE: "shadow"
+      MM_QUOTE_SIZE: "20"
+      MM_ORDER_TTL_MS: "1800000"
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Resumen
Activa la **fase shadow** del quoter de market-making (H-MM Nivel 3) poniendo `MM_QUOTER_MODE=shadow` en el servicio `mm-recorder` (perfil `capture`).

- Quotes maker **virtuales** (sin órdenes reales) contra el libro real, con **cola inicial exacta** + **dual drain bounds** (trades/cancels).
- Persiste fills a `mm_shadow_fills` (creada en runtime) para el validator **H-MM-4** del harness edge-research.
- `MM_QUOTE_SIZE=20` y `MM_ORDER_TTL_MS=1800000` explícitos; `minSpread`/`volPause` en **default permisivo** para que el shadow aprenda los umbrales; live los endurecerá con esos datos.
- **NO** activa modo live (`index.ts` lanza error en `mode=live`).

El código del quoter ya está en main (mergeado, gated off). Este PR solo cambia un env var del compose.

## Implicaciones
- **Arranca el reloj de los ≥7 días del gate shadow→real.** Tras ~1 semana se lee H-MM-4 (cron lunes o corrida manual).
- Recorder sacrificial (cap 120M, OOM-kill aislado de los servicios live). Estado del quoter en memoria acotado por el universo (45 mercados / 80 tokens) — holgura amplia sobre los ~21M actuales.

## Test Plan
- [ ] Deploy llega a la VM; recrear el recorder (`docker compose --profile capture up -d mm-recorder`).
- [ ] Log muestra `shadow quoter started`.
- [ ] Tablas `mm_shadow_fills`/`mm_quoter_state`/`mm_quote_eligibility`/`mm_shadow_pnl` creadas en runtime.
- [ ] Tras ~1h: fills sombra en ambos bounds; RAM < 120M.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated recorder service configuration settings to optimize quoting behavior and system performance management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->