### PR TITLE
fix(mm-quoter): inventory_pnl como delta sumable (telescoping), no snapshot M2M

### DIFF
--- a/packages/mm-recorder/src/quoter/engine.test.ts
+++ b/packages/mm-recorder/src/quoter/engine.test.ts
@@ -219,3 +219,37 @@ describe('Fix 4: flushHourly PnL deltas', () => {
     // If no row was emitted (position/realized unchanged) that's also correct — no double-count
   });
 });
+
+// Fix 5 regression: inventory_pnl must be a per-flush DELTA (telescoping), not an
+// instantaneous M2M snapshot. Accounting identity: equity = realized + unrealized, so
+// SUM(spreadPnl) + SUM(inventoryPnl) over all flushes must equal the equity change
+// (from 0). With a snapshot the open M2M is double-counted across flushes and the sum
+// inflates — exactly the SUM(inventory_pnl) trap that bit the daily-review query.
+describe('Fix 5: inventory_pnl telescoping invariant', () => {
+  it('sum of spread+inventory deltas across flushes equals final equity', async () => {
+    const { engine, persistence, book } = setup({ MM_REQUOTE_MIN_MS: '0' });
+
+    // Buy 10@0.48 (bid at touch, queue 0 → at-level trade fills), mid 0.50.
+    book(0, 0.48, 0.52, 0, 0);
+    await engine.onTrade({ time: t(1), tokenId: 'T', marketId: 'M', price: 0.48, size: 10, side: 'SELL' });
+    await engine.flushHourly(new Date(Date.UTC(2026, 5, 12, 11, 0, 0)));
+
+    // Mid drifts up to 0.51 (open inventory M2M moves) — flush with no new fills.
+    book(2, 0.49, 0.53, 0, 0);
+    await engine.flushHourly(new Date(Date.UTC(2026, 5, 12, 12, 0, 0)));
+
+    // Sell 10@0.53 (ask at touch) → position flat, realized +0.50.
+    await engine.onTrade({ time: t(3), tokenId: 'T', marketId: 'M', price: 0.53, size: 10, side: 'BUY' });
+    await engine.flushHourly(new Date(Date.UTC(2026, 5, 12, 13, 0, 0)));
+
+    const rows = (persistence.insertPnl as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as { marketId: string; bound: string; spreadPnl: number; inventoryPnl: number })
+      .filter((r) => r.marketId === 'M' && r.bound === 'trades');
+    const sum = rows.reduce((a, r) => a + r.spreadPnl + r.inventoryPnl, 0);
+
+    // Telescoping identity — holds only when inventoryPnl is a delta, not a snapshot.
+    expect(sum).toBeCloseTo(engine.equity('trades'), 6);
+    // And the realized leg alone is the round-trip profit (10 × (0.53−0.48)).
+    expect(engine.equity('trades')).toBeCloseTo(0.5, 6);
+  });
+});

--- a/packages/mm-recorder/src/quoter/engine.ts
+++ b/packages/mm-recorder/src/quoter/engine.ts
@@ -37,6 +37,8 @@ export class QuoteEngine {
   private fillsSinceFlush = new Map<string, number>();
   /** Per-(market:bound) realized snapshot as of the last flush — for delta computation. */
   private prevRealized = new Map<string, number>();
+  /** Per-(market:bound) unrealized-M2M snapshot as of the last flush — for delta computation. */
+  private prevUnrealized = new Map<string, number>();
 
   constructor(private deps: EngineDeps) {
     // MANDATORY: pass tick to ShadowLedger so price comparisons are grid-aligned.
@@ -46,6 +48,8 @@ export class QuoteEngine {
 
   activeQuote(tokenId: string, side: Side) { return this.ledger.active(tokenId, side) }
   inventory(bound: 'trades' | 'cancels'): InventoryBook { return this.inv[bound] }
+  /** Current mark-to-market equity (cash + open M2M) for a bound, at last-known mids. */
+  equity(bound: 'trades' | 'cancels'): number { return this.inv[bound].equity(this.mids) }
 
   onBook(input: BookInput, row: BookEvent | null): void {
     const tokenId = input.tokenId;
@@ -253,10 +257,16 @@ export class QuoteEngine {
         const mbKey = `${marketId}:${bound}`;
         const prev = this.prevRealized.get(mbKey) ?? 0;
         const spreadPnlDelta = realizedNow - prev;
-        // inventoryPnl is the instantaneous M2M snapshot (not a delta — reflects open exposure now).
+        // inventoryPnl is the DELTA of unrealized open-position M2M since the last flush
+        // (NOT an instantaneous snapshot). This makes the column summable: with the
+        // accounting identity equity = realized + unrealized, SUM(spreadPnl)+SUM(inventoryPnl)
+        // over any window telescopes to the equity change in that window. A snapshot would
+        // double-count open M2M across flushes (the SUM(inventory_pnl) trap).
         const mid = this.mids.get(marketId);
-        const inventoryPnl = book.position(marketId) *
+        const unrealizedNow = book.position(marketId) *
           ((mid ?? book.avgPrice(marketId)) - book.avgPrice(marketId));
+        const prevUnrealized = this.prevUnrealized.get(mbKey) ?? 0;
+        const inventoryPnl = unrealizedNow - prevUnrealized;
         const fillsDelta = this.fillsSinceFlush.get(mbKey) ?? 0;
 
         if (book.position(marketId) === 0 && realizedNow === 0 && fillsDelta === 0) continue;
@@ -273,6 +283,7 @@ export class QuoteEngine {
 
         // Advance snapshots so the next flush emits deltas, not cumulative totals.
         this.prevRealized.set(mbKey, realizedNow);
+        this.prevUnrealized.set(mbKey, unrealizedNow);
       }
     }
     // Reset per-flush fill counters after writing.


### PR DESCRIPTION
@
## Problema

`mm_shadow_pnl.inventory_pnl` era un **snapshot instantáneo de M2M abierto**, mientras que `spread_pnl`, `fills` y `replaces` en la misma fila son **deltas del periodo**. Conviven sin distinción visible → invita a `SUM()` sobre todas las columnas, que **doble-cuenta la exposición abierta** repetidamente en cada flush horario. Surgió leyendo el shadow quoter en la VM: `SUM(inventory_pnl)` daba ≈−2700 cuando el M2M abierto real era ~−100.

## Fix

`inventory_pnl` pasa a ser el **delta del M2M no realizado** entre flushes. Con la identidad contable `equity = realized + unrealized`, la suma telescopa:

```
SUM(spread_pnl) + SUM(inventory_pnl)  ==  Δequity en la ventana
```

- Campo `prevUnrealized` análogo a `prevRealized`.
- Getter `equity(bound)` (expone cash + M2M a mids actuales).
- Test `Fix 5: inventory_pnl telescoping invariant` — secuencia compra→sube mid→venta con flushes intercalados; verifica `SUM(spread)+SUM(inventory) == equity(trades)`. Falla con snapshot (sum=1.0), pasa con delta (sum=0.5=equity).

## Alcance / no-afecta

- **Gate H-MM-4 NO afectado**: mide `retained = side·(price − mid_after)` por fill desde `mm_shadow_fills`, no usa `mm_shadow_pnl`.
- Filas `mm_shadow_pnl` escritas pre-deploy (shadow arrancó 2026-06-14) son snapshots con la semántica vieja; no mezclar épocas al sumar `inventory_pnl`.

## Tests

68/68 tests del quoter verdes (incluido el nuevo invariante), `tsc --noEmit` limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed inventory profit/loss reporting to show per-flush changes instead of cumulative values.

* **New Features**
  * Added equity calculation capability for portfolio performance tracking.

* **Tests**
  * Added regression test to validate inventory profit/loss calculation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->