### PR TITLE
fix(dashboard): tipar dbHealth con latency opcional — arregla build roto por #326

### DIFF
--- a/packages/dashboard/src/api/routes.ts
+++ b/packages/dashboard/src/api/routes.ts
@@ -582,14 +582,17 @@ export async function registerRoutes(
     // 7s timeout keeps us safely inside Docker's 10s health check timeout.
     // Without this, connectionTimeoutMillis=30000 causes wget to be killed by Docker before
     // we return any HTTP response, permanently marking the container unhealthy on DB slowness.
-    const dbHealthWithTimeout = isDatabaseConfigured()
+    // Shared shape so the race/resolve branches unify with dbHealthCheck()'s return type
+    // (which carries an optional `latency`) — otherwise `dbHealth.latency` below fails tsc.
+    type DbHealth = { connected: boolean; latency?: number; error?: string };
+    const dbHealthWithTimeout: Promise<DbHealth> = isDatabaseConfigured()
       ? Promise.race([
           dbHealthCheck(),
-          new Promise<{ connected: false; error: string }>(resolve =>
+          new Promise<DbHealth>(resolve =>
             setTimeout(() => resolve({ connected: false, error: 'DB health check timed out (>7s)' }), 7000)
           ),
         ])
-      : Promise.resolve({ connected: false, error: 'Not configured' } as const);
+      : Promise.resolve({ connected: false, error: 'Not configured' });
     const dbHealth = await dbHealthWithTimeout;
 
     // Check optimization scheduler


### PR DESCRIPTION
@
## Problema

El merge de #326 rompió `Deploy to GCP` (run 951c72b) en `build-dashboard`:

```
src/api/routes.ts(629): error TS2339: Property "latency" does not exist on type
"{ connected: false; error: string }"
```

#326 envolvió `dbHealthCheck()` en `Promise.race` con ramas `{connected:false;error}` que no llevan `latency`, pero `routes.ts` accede a `dbHealth.latency`. **No se detectó en el PR porque los PRs solo corren GitGuardian — no hay CI de build/tsc.**

## Fix

Tipo `DbHealth = { connected: boolean; latency?: number; error?: string }` compartido en ambas ramas del race/resolve → la unión colapsa al retorno de `dbHealthCheck()`. `pnpm --filter dashboard build` (tsc) verde.

## Seguimiento sugerido

Añadir un job de `tsc`/build a los PRs evitaría esta clase de regresión (el daily-review afirmó "1320 tests pass" pero el build de producción no se compiló).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@