### PR TITLE
fix(ci): clave SSH fija en todos los workflows con gcloud compute ssh

### DIFF
--- a/.github/workflows/daily-trade-review-claude.yml
+++ b/.github/workflows/daily-trade-review-claude.yml
@@ -86,6 +86,19 @@ jobs:
       - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Install fixed deploy SSH key
+        # Reuse a STABLE key (secret GCP_SSH_PRIVATE_KEY; public half in the VM's
+        # ssh-keys metadata) so `gcloud compute ssh` does NOT regenerate an ephemeral
+        # key per run — regeneration churned the shared `Usuario` ssh-keys metadata and
+        # broke SSH with `Permission denied (publickey)` (2026-06-15). Writing to
+        # gcloud's DEFAULT key path makes it reuse this key without re-uploading.
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.GCP_SSH_PRIVATE_KEY }}" > ~/.ssh/google_compute_engine
+          chmod 600 ~/.ssh/google_compute_engine
+          ssh-keygen -y -f ~/.ssh/google_compute_engine > ~/.ssh/google_compute_engine.pub
+
       - name: Configure git
         run: |
           git config user.name "Claude (Daily Review)"

--- a/.github/workflows/daily-trade-review.yml
+++ b/.github/workflows/daily-trade-review.yml
@@ -36,6 +36,19 @@ jobs:
       - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Install fixed deploy SSH key
+        # Reuse a STABLE key (secret GCP_SSH_PRIVATE_KEY; public half in the VM's
+        # ssh-keys metadata) so `gcloud compute ssh` does NOT regenerate an ephemeral
+        # key per run — regeneration churned the shared `Usuario` ssh-keys metadata and
+        # broke SSH with `Permission denied (publickey)` (2026-06-15). Writing to
+        # gcloud's DEFAULT key path makes it reuse this key without re-uploading.
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.GCP_SSH_PRIVATE_KEY }}" > ~/.ssh/google_compute_engine
+          chmod 600 ~/.ssh/google_compute_engine
+          ssh-keygen -y -f ~/.ssh/google_compute_engine > ~/.ssh/google_compute_engine.pub
+
       - name: Gather data from VM
         id: gather
         run: |

--- a/.github/workflows/edge-research-weekly.yml
+++ b/.github/workflows/edge-research-weekly.yml
@@ -37,6 +37,19 @@ jobs:
       - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Install fixed deploy SSH key
+        # Reuse a STABLE key (secret GCP_SSH_PRIVATE_KEY; public half in the VM's
+        # ssh-keys metadata) so `gcloud compute ssh` does NOT regenerate an ephemeral
+        # key per run — regeneration churned the shared `Usuario` ssh-keys metadata and
+        # broke SSH with `Permission denied (publickey)` (2026-06-15). Writing to
+        # gcloud's DEFAULT key path makes it reuse this key without re-uploading.
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.GCP_SSH_PRIVATE_KEY }}" > ~/.ssh/google_compute_engine
+          chmod 600 ~/.ssh/google_compute_engine
+          ssh-keygen -y -f ~/.ssh/google_compute_engine > ~/.ssh/google_compute_engine.pub
+
       - name: Cleanup stale SSH keys in project metadata
         # Mirrors daily-review: each `gcloud compute ssh` uploads a key; without
         # pruning, metadata grows unbounded and delays key propagation past the

--- a/.github/workflows/flb-monitor.yml
+++ b/.github/workflows/flb-monitor.yml
@@ -46,6 +46,19 @@ jobs:
       - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Install fixed deploy SSH key
+        # Reuse a STABLE key (secret GCP_SSH_PRIVATE_KEY; public half in the VM's
+        # ssh-keys metadata) so `gcloud compute ssh` does NOT regenerate an ephemeral
+        # key per run — regeneration churned the shared `Usuario` ssh-keys metadata and
+        # broke SSH with `Permission denied (publickey)` (2026-06-15). Writing to
+        # gcloud's DEFAULT key path makes it reuse this key without re-uploading.
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.GCP_SSH_PRIVATE_KEY }}" > ~/.ssh/google_compute_engine
+          chmod 600 ~/.ssh/google_compute_engine
+          ssh-keygen -y -f ~/.ssh/google_compute_engine > ~/.ssh/google_compute_engine.pub
+
       - name: Cleanup stale SSH keys in project metadata
         run: |
           set -euo pipefail

--- a/.github/workflows/flb-shadow-snapshot.yml
+++ b/.github/workflows/flb-shadow-snapshot.yml
@@ -36,6 +36,19 @@ jobs:
       - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Install fixed deploy SSH key
+        # Reuse a STABLE key (secret GCP_SSH_PRIVATE_KEY; public half in the VM's
+        # ssh-keys metadata) so `gcloud compute ssh` does NOT regenerate an ephemeral
+        # key per run — regeneration churned the shared `Usuario` ssh-keys metadata and
+        # broke SSH with `Permission denied (publickey)` (2026-06-15). Writing to
+        # gcloud's DEFAULT key path makes it reuse this key without re-uploading.
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.GCP_SSH_PRIVATE_KEY }}" > ~/.ssh/google_compute_engine
+          chmod 600 ~/.ssh/google_compute_engine
+          ssh-keygen -y -f ~/.ssh/google_compute_engine > ~/.ssh/google_compute_engine.pub
+
       - name: Cleanup stale SSH keys in project metadata
         # Each `gcloud compute ssh` uploads a key; without cleanup the project
         # metadata grows unbounded and delays key propagation past the connect


### PR DESCRIPTION
Follow-up de #330. Replica el step Install fixed deploy SSH key a los 5 workflows que hacen gcloud compute ssh (daily-trade-review, daily-trade-review-claude, edge-research-weekly, flb-monitor, flb-shadow-snapshot). Cada uno regeneraba clave efimera por run bajo username compartido Usuario, alimentando el churn que rompio el deploy. Ahora todos reusan la clave estable (secret GCP_SSH_PRIVATE_KEY) en la ruta default de gcloud -> cero churn global. YAML de los 6 validado.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced SSH authentication setup in deployment workflows to eliminate intermittent connection issues and improve the reliability of automated processes across multiple pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->