### PR TITLE
fix(mm-quoter): mm_shadow_pnl acumulativo por hora (flush sub-horario)

### DIFF
--- a/packages/mm-recorder/src/quoter/engine.test.ts
+++ b/packages/mm-recorder/src/quoter/engine.test.ts
@@ -159,6 +159,135 @@ describe('Fix 3: post-fill requote gap', () => {
   });
 });
 
+// Fix 6 regression (bug 2026-06-16): flushHourly is invoked every 5 min (sub-hourly),
+// so several flushes land in the SAME wall-clock hour. The engine must attribute each
+// per-flush delta to the CURRENT hour (floor(now/1h)), and persistence accumulates on
+// conflict (verified in persistence.test.ts). The OLD code wrote to prevHour and the SQL
+// overwrote → each hour kept only the last ~5-min slice → ~12x undercount + 1-hour offset.
+describe('Fix 6: sub-hourly flushes accumulate into the current hour', () => {
+  // Fake persistence modelling the real ON CONFLICT (hour,market_id,bound) accumulation.
+  function accumulatingPersistence() {
+    const table = new Map<string, { hour: string; marketId: string; bound: string; spreadPnl: number; inventoryPnl: number; fills: number; replaces: number }>();
+    const insertPnl = vi.fn(async (r: { hour: Date; marketId: string; bound: string; spreadPnl: number; inventoryPnl: number; fills: number; replaces: number }) => {
+      const k = `${r.hour.toISOString()}|${r.marketId}|${r.bound}`;
+      const cur = table.get(k);
+      if (cur) {
+        cur.spreadPnl += r.spreadPnl; cur.inventoryPnl += r.inventoryPnl;
+        cur.fills += r.fills; cur.replaces += r.replaces;
+      } else {
+        table.set(k, { hour: r.hour.toISOString(), marketId: r.marketId, bound: r.bound,
+          spreadPnl: r.spreadPnl, inventoryPnl: r.inventoryPnl, fills: r.fills, replaces: r.replaces });
+      }
+    });
+    const persistence = {
+      ensureSchema: vi.fn().mockResolvedValue(undefined),
+      insertFill: vi.fn().mockResolvedValue(undefined),
+      upsertState: vi.fn().mockResolvedValue(undefined),
+      insertEligibility: vi.fn().mockResolvedValue(undefined),
+      insertPnl,
+    };
+    return { table, persistence };
+  }
+
+  it('three 5-min flushes in one hour sum fills into that hour, not prevHour', async () => {
+    const cfg = loadConfig({ MM_QUOTER_MODE: 'shadow' });
+    const state = new BookState();
+    const { table, persistence } = accumulatingPersistence();
+    const engine = new QuoteEngine({
+      cfg, state, persistence: persistence as never,
+      marketByToken: new Map([['T', 'M']]),
+      endDateByMarket: new Map([['M', new Date('2026-12-31T00:00:00Z')]]),
+      rewardsByMarket: new Map(),
+    });
+    // Bid at touch, queue 0 → at-level trades fill immediately.
+    const bk = { time: t(0), tokenId: 'T', marketId: 'M', eventType: 'book' as const,
+      bids: [{ price: 0.48, size: 0 }], asks: [{ price: 0.52, size: 100 }] };
+    engine.onBook(bk, state.apply(bk));
+
+    const at = (m: number) => new Date(Date.UTC(2026, 5, 12, 10, m, 0)); // 10:mm within hour 10:00
+
+    await engine.onTrade({ time: t(1), tokenId: 'T', marketId: 'M', price: 0.48, size: 5, side: 'SELL' });
+    await engine.flushHourly(at(5));
+    await engine.onTrade({ time: t(2), tokenId: 'T', marketId: 'M', price: 0.48, size: 5, side: 'SELL' });
+    await engine.flushHourly(at(10));
+    await engine.onTrade({ time: t(3), tokenId: 'T', marketId: 'M', price: 0.48, size: 5, side: 'SELL' });
+    await engine.flushHourly(at(15));
+
+    const hour10 = new Date(Date.UTC(2026, 5, 12, 10, 0, 0)).toISOString();
+    const row = table.get(`${hour10}|M|trades`);
+    expect(row).toBeDefined();
+    expect(row!.fills).toBe(3); // 3 fills total this hour, NOT 1 (last slice only)
+  });
+
+  it('a market with two tokens (Yes/No) is not double-counted under accumulation', async () => {
+    // marketByToken maps BOTH tokens of a market to the same market id, so .values()
+    // repeats it. With the accumulating ON CONFLICT, iterating raw values would write the
+    // (hour,market,bound) row twice and double the fills. Dedupe → exactly one fill counted.
+    const cfg = loadConfig({ MM_QUOTER_MODE: 'shadow' });
+    const state = new BookState();
+    const { table, persistence } = accumulatingPersistence();
+    const engine = new QuoteEngine({
+      cfg, state, persistence: persistence as never,
+      marketByToken: new Map([['Y', 'M'], ['N', 'M']]), // two tokens, one market
+      endDateByMarket: new Map([['M', new Date('2026-12-31T00:00:00Z')]]),
+      rewardsByMarket: new Map(),
+    });
+    const bk = { time: t(0), tokenId: 'Y', marketId: 'M', eventType: 'book' as const,
+      bids: [{ price: 0.48, size: 0 }], asks: [{ price: 0.52, size: 100 }] };
+    engine.onBook(bk, state.apply(bk));
+    await engine.onTrade({ time: t(1), tokenId: 'Y', marketId: 'M', price: 0.48, size: 5, side: 'SELL' });
+    await engine.flushHourly(new Date(Date.UTC(2026, 5, 12, 10, 30, 0)));
+
+    const hour10 = new Date(Date.UTC(2026, 5, 12, 10, 0, 0)).toISOString();
+    const row = table.get(`${hour10}|M|trades`);
+    expect(row).toBeDefined();
+    expect(row!.fills).toBe(1); // one fill, not two (no double-count from duplicate values)
+  });
+
+  it('replaces are attributed per-market, not as a global counter shared across markets', async () => {
+    // Two markets. Market A re-quotes several times (churn); market B only fills, never
+    // re-quotes. B's row must show replaces=0 — with the old global counter it inherited
+    // A's churn (and under accumulation that mis-attribution compounds).
+    const cfg = loadConfig({ MM_QUOTER_MODE: 'shadow', MM_REQUOTE_MIN_MS: '0' });
+    const state = new BookState();
+    const insertPnl = vi.fn().mockResolvedValue(undefined);
+    const persistence = {
+      ensureSchema: vi.fn().mockResolvedValue(undefined),
+      insertFill: vi.fn().mockResolvedValue(undefined),
+      upsertState: vi.fn().mockResolvedValue(undefined),
+      insertEligibility: vi.fn().mockResolvedValue(undefined),
+      insertPnl,
+    };
+    const engine = new QuoteEngine({
+      cfg, state, persistence: persistence as never,
+      marketByToken: new Map([['A', 'MA'], ['B', 'MB']]),
+      endDateByMarket: new Map([['MA', new Date('2026-12-31T00:00:00Z')], ['MB', new Date('2026-12-31T00:00:00Z')]]),
+      rewardsByMarket: new Map(),
+    });
+    const bookFor = (tok: string, mkt: string, s: number, bid: number, ask: number) => {
+      const input = { time: t(s), tokenId: tok, marketId: mkt, eventType: 'book' as const,
+        bids: [{ price: bid, size: 0 }], asks: [{ price: ask, size: 100 }] };
+      engine.onBook(input, state.apply(input));
+    };
+    // Market A: place, then 3 price-outs → 3 replaces.
+    bookFor('A', 'MA', 0, 0.40, 0.60);
+    bookFor('A', 'MA', 1, 0.41, 0.60);
+    bookFor('A', 'MA', 2, 0.42, 0.60);
+    bookFor('A', 'MA', 3, 0.43, 0.60);
+    // Market B: place once (no replace), then a fill so its row is emitted.
+    bookFor('B', 'MB', 4, 0.48, 0.52);
+    await engine.onTrade({ time: t(5), tokenId: 'B', marketId: 'MB', price: 0.48, size: 5, side: 'SELL' });
+
+    await engine.flushHourly(new Date(Date.UTC(2026, 5, 12, 11, 0, 0)));
+
+    const rowB = insertPnl.mock.calls
+      .map((c: unknown[]) => c[0] as { marketId: string; bound: string; replaces: number })
+      .find((r) => r.marketId === 'MB' && r.bound === 'trades');
+    expect(rowB).toBeDefined();
+    expect(rowB!.replaces).toBe(0); // B never re-quoted; must not inherit A's churn
+  });
+});
+
 // Fix 4 regression: flushHourly PnL uses deltas not cumulative
 describe('Fix 4: flushHourly PnL deltas', () => {
   it('two fills then flush → pnl row has fills=2 and spreadPnl=delta; second flush with no activity → zeros', async () => {

--- a/packages/mm-recorder/src/quoter/engine.ts
+++ b/packages/mm-recorder/src/quoter/engine.ts
@@ -24,7 +24,9 @@ export class QuoteEngine {
   private eligibility = new EligibilityTracker();
   private inv = { trades: new InventoryBook(), cancels: new InventoryBook() };
   private lastRequote = new Map<string, number>(); // `${tokenId}:${side}` -> ms
-  private replaces = 0;
+  /** Per-market re-quote count since last flush (churn). Per-market (not a global counter)
+   *  so the hourly PnL rows attribute churn to the market that produced it. */
+  private replacesByMarket = new Map<string, number>();
   private droppedFills = 0;
   private mids = new Map<string, number>();
   /**
@@ -44,6 +46,10 @@ export class QuoteEngine {
     // MANDATORY: pass tick to ShadowLedger so price comparisons are grid-aligned.
     this.ledger = new ShadowLedger(deps.cfg.tick);
     this.vol = new VolTracker(deps.cfg.volWindowMs);
+  }
+
+  private bumpReplace(marketId: string): void {
+    this.replacesByMarket.set(marketId, (this.replacesByMarket.get(marketId) ?? 0) + 1);
   }
 
   activeQuote(tokenId: string, side: Side) { return this.ledger.active(tokenId, side) }
@@ -118,7 +124,7 @@ export class QuoteEngine {
       }
 
       if (!want) {
-        if (have) { this.ledger.cancel(tokenId, side); this.replaces += 1; }
+        if (have) { this.ledger.cancel(tokenId, side); this.bumpReplace(marketId); }
         continue;
       }
 
@@ -174,10 +180,10 @@ export class QuoteEngine {
     want: { price: number; size: number; flags: string[] } | null,
     bookRow: BookEvent, eventTime: Date, _why: string,
   ): void {
+    const marketId = this.deps.marketByToken.get(tokenId) ?? bookRow.marketId;
     this.ledger.cancel(tokenId, side);
-    this.replaces += 1;
+    this.bumpReplace(marketId);
     if (want) {
-      const marketId = this.deps.marketByToken.get(tokenId) ?? bookRow.marketId;
       this.placeNew(tokenId, marketId, side, want.price, want.size, want.flags, bookRow, eventTime);
     }
   }
@@ -244,15 +250,23 @@ export class QuoteEngine {
       await this.deps.persistence.insertEligibility(row, est);
     }
 
-    // Snapshot replaces delta for this flush (global counter — same value on every row
-    // in this flush, not per-market; consumers should SUM one row per flush period).
-    const replacesDelta = this.replaces;
-    this.replaces = 0;
+    // Total churn this flush for the state snapshot (per-market detail goes on the PnL rows).
+    let totalReplaces = 0;
+    for (const v of this.replacesByMarket.values()) totalReplaces += v;
 
-    const prevHour = new Date(Math.floor(now.getTime() / 3_600_000) * 3_600_000 - 3_600_000);
+    // Attribute deltas to the CURRENT wall-clock hour. flushHourly runs sub-hourly
+    // (every 5 min), so the ~12 flushes within an hour all land on this same bucket and
+    // persistence accumulates them (ON CONFLICT … + EXCLUDED). Using prevHour here would
+    // mis-attribute the whole hour to the previous one (1-hour offset).
+    const curHour = new Date(Math.floor(now.getTime() / 3_600_000) * 3_600_000);
+    // Unique market ids: marketByToken maps BOTH tokens (Yes/No) of a market to the same
+    // market id, so .values() repeats each market. Iterating the raw values would call
+    // insertPnl twice per (hour,market,bound) and — under the accumulating ON CONFLICT —
+    // double-count fills/replaces. Dedupe to one row per market.
+    const marketIds = new Set(this.deps.marketByToken.values());
     for (const bound of ['trades', 'cancels'] as const) {
       const book = this.inv[bound];
-      for (const marketId of this.deps.marketByToken.values()) {
+      for (const marketId of marketIds) {
         const realizedNow = book.realized(marketId);
         const mbKey = `${marketId}:${bound}`;
         const prev = this.prevRealized.get(mbKey) ?? 0;
@@ -268,11 +282,14 @@ export class QuoteEngine {
         const prevUnrealized = this.prevUnrealized.get(mbKey) ?? 0;
         const inventoryPnl = unrealizedNow - prevUnrealized;
         const fillsDelta = this.fillsSinceFlush.get(mbKey) ?? 0;
+        // replaces is per-market churn (no bound dimension); written identically on both
+        // bound rows of a market — sum over a single bound to total it.
+        const replacesDelta = this.replacesByMarket.get(marketId) ?? 0;
 
-        if (book.position(marketId) === 0 && realizedNow === 0 && fillsDelta === 0) continue;
+        if (book.position(marketId) === 0 && realizedNow === 0 && fillsDelta === 0 && replacesDelta === 0) continue;
 
         await this.deps.persistence.insertPnl({
-          hour: prevHour,
+          hour: curHour,
           marketId, bound,
           spreadPnl: spreadPnlDelta,
           inventoryPnl,
@@ -286,11 +303,12 @@ export class QuoteEngine {
         this.prevUnrealized.set(mbKey, unrealizedNow);
       }
     }
-    // Reset per-flush fill counters after writing.
+    // Reset per-flush counters after writing.
     this.fillsSinceFlush.clear();
+    this.replacesByMarket.clear();
 
     await this.deps.persistence.upsertState('engine', {
-      mode: this.deps.cfg.mode, replaces: replacesDelta,
+      mode: this.deps.cfg.mode, replaces: totalReplaces,
       droppedFills: this.droppedFills,
       equityTrades: this.inv.trades.equity(this.mids),
       equityCancels: this.inv.cancels.equity(this.mids),

--- a/packages/mm-recorder/src/quoter/persistence.test.ts
+++ b/packages/mm-recorder/src/quoter/persistence.test.ts
@@ -46,4 +46,23 @@ describe('QuoterPersistence', () => {
     expect(exec.mock.calls[0][0]).toContain('INSERT INTO mm_quote_eligibility');
     expect(exec.mock.calls[1][0]).toContain('INSERT INTO mm_shadow_pnl');
   });
+
+  // Bug 2026-06-16: flushHourly runs every 5 min (sub-hourly), so several flushes hit
+  // the SAME (hour,market,bound) key within one hour. insertPnl persists per-flush DELTAS,
+  // so the ON CONFLICT clause MUST accumulate (add EXCLUDED), not overwrite — otherwise
+  // each hour keeps only the last ~5-min slice and fills/PnL undercount ~12x.
+  it('insertPnl accumulates the additive columns on conflict (must not overwrite)', async () => {
+    const exec = vi.fn().mockResolvedValue({ rows: [] });
+    await new QuoterPersistence(exec).insertPnl({
+      hour: fill.time, marketId: 'M', bound: 'trades',
+      spreadPnl: 0.4, inventoryPnl: -0.1, estRewards: 1.25, fills: 3, replaces: 7,
+    });
+    const sql = exec.mock.calls[0][0] as string;
+    expect(sql).toContain('ON CONFLICT (hour,market_id,bound)');
+    expect(sql).toContain('spread_pnl = mm_shadow_pnl.spread_pnl + EXCLUDED.spread_pnl');
+    expect(sql).toContain('inventory_pnl = mm_shadow_pnl.inventory_pnl + EXCLUDED.inventory_pnl');
+    expect(sql).toContain('fills = mm_shadow_pnl.fills + EXCLUDED.fills');
+    expect(sql).toContain('replaces = mm_shadow_pnl.replaces + EXCLUDED.replaces');
+    expect(sql).toContain('est_rewards = EXCLUDED.est_rewards');
+  });
 });

--- a/packages/mm-recorder/src/quoter/persistence.ts
+++ b/packages/mm-recorder/src/quoter/persistence.ts
@@ -81,11 +81,20 @@ export class QuoterPersistence {
   }
 
   async insertPnl(r: PnlRow): Promise<void> {
+    // flushHourly runs sub-hourly (every 5 min) and persists per-flush DELTAS, so several
+    // rows hit the same (hour,market_id,bound) key within one hour. The additive columns
+    // MUST accumulate (add EXCLUDED) so the hour holds the full sum; an overwrite would keep
+    // only the last ~5-min slice (~12x undercount) and break the telescoping invariant
+    // SUM(spread_pnl)+SUM(inventory_pnl)=Δequity. est_rewards is an absolute estimate, not a
+    // delta → it overwrites.
     await this.exec(
       `INSERT INTO mm_shadow_pnl(hour,market_id,bound,spread_pnl,inventory_pnl,est_rewards,fills,replaces)
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8) ON CONFLICT (hour,market_id,bound) DO UPDATE
-       SET spread_pnl = EXCLUDED.spread_pnl, inventory_pnl = EXCLUDED.inventory_pnl,
-           est_rewards = EXCLUDED.est_rewards, fills = EXCLUDED.fills, replaces = EXCLUDED.replaces`,
+       SET spread_pnl = mm_shadow_pnl.spread_pnl + EXCLUDED.spread_pnl,
+           inventory_pnl = mm_shadow_pnl.inventory_pnl + EXCLUDED.inventory_pnl,
+           est_rewards = EXCLUDED.est_rewards,
+           fills = mm_shadow_pnl.fills + EXCLUDED.fills,
+           replaces = mm_shadow_pnl.replaces + EXCLUDED.replaces`,
       [r.hour, r.marketId, r.bound, r.spreadPnl, r.inventoryPnl, r.estRewards, r.fills, r.replaces]);
   }
 }


### PR DESCRIPTION
## Problema

`mm_shadow_pnl` (observabilidad del shadow quoter) subcontaba fills/PnL ~12x. Evidencia en prod (06-16): **401 fills reales** en `mm_shadow_fills` desde el restart del recorder vs **50 contados** en `mm_shadow_pnl`; filas con `spread_pnl=0`, `replaces` errático (24/4327/180) y un offset temporal de 1h.

## Causa raíz

`engine.flushHourly()` está diseñado para correr 1×/hora, pero el timer lo invoca **cada 5 min** (`index.ts:100-102`). El método (a) escribía a `prevHour`, (b) reseteaba los acumuladores delta cada llamada y (c) persistía con `ON CONFLICT … DO UPDATE SET fills = EXCLUDED.fills` (**overwrite**). Combinado: los ~12 flushes de una hora se sobreescribían entre sí en la fila `hour=HH-1`, dejando solo el último slice de ~5 min, mal atribuido a la hora previa. El invariante telescópico `SUM(spread)+SUM(inventory)=Δequity` de #327 no se cumplía en producción.

## Fix

- **`persistence.insertPnl`**: `ON CONFLICT` **acumulativo** (suma `spread_pnl`/`inventory_pnl`/`fills`/`replaces`); `est_rewards` es estimación absoluta → overwrite.
- **`engine.flushHourly`**: atribuye los deltas a la **hora actual** (`floor(now/1h)`), no `prevHour`.
- **`replaces` per-market**: era un contador global replicado en cada fila → bajo acumulación heredaba churn de otros markets. Ahora se cuenta por market.
- **Dedup de markets**: `marketByToken` mapea los 2 tokens (Yes/No) de un market al mismo id, así que `.values()` lo repite; bajo el `ON CONFLICT` acumulativo eso **doblaba** fills. Se itera un `Set`.

## Tests (TDD, RED→GREEN)

- `persistence`: el SQL debe acumular, no sobreescribir.
- `engine`: 3 flushes sub-horarios en una hora suman fills en esa hora (no el último slice).
- `engine`: `replaces` per-market (2 markets, uno con churn).
- `engine`: market con 2 tokens no se doble-cuenta.

106 tests verdes + `tsc` limpio.

## Notas de despliegue

- El `mm-recorder` corre en el perfil `capture` (el deploy-gcp no lo recrea) → recreación manual.
- Conviene `TRUNCATE mm_shadow_pnl` tras desplegar: las filas actuales son de semántica vieja y el restart reinicia los acumuladores en memoria (no mezclar épocas). La tabla es observabilidad pura, sin FK, el gate H-MM-4 no la usa.

## Sin impacto en el gate

El gate shadow→real (H-MM-4, 06-22) lee retained spread de `mm_shadow_fills`, intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quote replacements now tracked per-market, preventing cross-market attribution errors.
  * Sub-hourly PnL flush data now correctly accumulates within the same hour instead of overwriting previous records.
  * Improved accuracy of PnL metrics for multi-token markets by eliminating double-counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->