### PR TITLE
fix(agent-trader): make the null-run detector immune to the agent self-committing

### DIFF
--- a/.github/workflows/agent-trader-weekly.yml
+++ b/.github/workflows/agent-trader-weekly.yml
@@ -82,6 +82,13 @@ jobs:
           fi
           # Evaluate resolved bets first (deterministic), so the agent sees fresh state.
           python agent_trader.py evaluate || true
+          # Fingerprint the track record BEFORE the agent runs. The null-run corroborator below
+          # compares content, not working-tree state: the agent has Bash and has been seen running
+          # `git commit` itself (2026-07-27), which leaves `git diff` clean on a perfectly healthy
+          # run and made the detector cry wolf. Content fingerprints are immune to that.
+          RUNS_BEFORE=$(grep -c '^## Run ' lessons.md 2>/dev/null || echo 0)
+          LESSONS_SUM_BEFORE=$(md5sum lessons.md 2>/dev/null | cut -d' ' -f1 || echo none)
+          BETS_BEFORE=$(wc -l < bets.jsonl 2>/dev/null || echo 0)
           # Hand the decision loop to Claude with web + bash access. The prompt file
           # drives the full research->bet->lessons routine. Capture the exit status:
           # `claude --print` can exit 0 on an API error (e.g. spend-cap reached), so a
@@ -99,12 +106,20 @@ jobs:
           if grep -qiE "API Error|usage limit|rate limit|Execute error|Overloaded|Not logged in" /tmp/agent-run.log; then
             AGENT_OK=0
           fi
-          if git diff --quiet -- lessons.md bets.jsonl; then
-            LESSONS_TOUCHED=0
-          else
+          RUNS_AFTER=$(grep -c '^## Run ' lessons.md 2>/dev/null || echo 0)
+          LESSONS_SUM_AFTER=$(md5sum lessons.md 2>/dev/null | cut -d' ' -f1 || echo none)
+          BETS_AFTER=$(wc -l < bets.jsonl 2>/dev/null || echo 0)
+          # A real run always appends a new `## Run N — <date>` section; accept a plain content
+          # change or a new bet line as corroboration too, so a formatting drift in the header
+          # can't downgrade a genuine run to a false alarm.
+          if [ "$RUNS_AFTER" -gt "$RUNS_BEFORE" ] \
+            || [ "$LESSONS_SUM_AFTER" != "$LESSONS_SUM_BEFORE" ] \
+            || [ "$BETS_AFTER" -gt "$BETS_BEFORE" ]; then
             LESSONS_TOUCHED=1
+          else
+            LESSONS_TOUCHED=0
           fi
-          echo "AGENT_OK=$AGENT_OK LESSONS_TOUCHED=$LESSONS_TOUCHED"
+          echo "AGENT_OK=$AGENT_OK LESSONS_TOUCHED=$LESSONS_TOUCHED (runs ${RUNS_BEFORE}->${RUNS_AFTER}, bets ${BETS_BEFORE}->${BETS_AFTER})"
           if [ "$AGENT_OK" = "0" ] || [ "$LESSONS_TOUCHED" = "0" ]; then
             AGENT_OK=0
             echo "::warning::Agent-Trader LLM run did NOT complete (API error / no lessons written). This week produced no research — see /tmp/agent-run.log above."

--- a/.github/workflows/agent-trader-weekly.yml
+++ b/.github/workflows/agent-trader-weekly.yml
@@ -127,7 +127,11 @@ jobs:
           # change or a new bet line as corroboration too, so a formatting drift in the header
           # can't downgrade a genuine run to a false alarm. The checksum branch requires the file
           # to exist on BOTH sides — a vanished lessons.md is a broken run, not a productive one.
-          if [ "$RUNS_AFTER" -gt "$RUNS_BEFORE" ] \
+          if [ "$LESSONS_HAD" = "1" ] && [ "$LESSONS_HAS" = "0" ]; then
+            # Fail closed: a run that destroyed the learning history is broken even if it also
+            # appended a bet — don't let the bet counter vouch for it.
+            LESSONS_TOUCHED=0
+          elif [ "$RUNS_AFTER" -gt "$RUNS_BEFORE" ] \
             || { [ "$LESSONS_HAD" = "1" ] && [ "$LESSONS_HAS" = "1" ] \
                  && [ "$LESSONS_SUM_AFTER" != "$LESSONS_SUM_BEFORE" ]; } \
             || [ "$BETS_AFTER" -gt "$BETS_BEFORE" ]; then
@@ -189,6 +193,16 @@ jobs:
           # never ran and the whole week's research died with the runner.
           if [ -n "$(git log --oneline "${GITHUB_SHA}..HEAD")" ]; then
             git log --oneline "${GITHUB_SHA}..HEAD"
+            # Pushing "whatever HEAD is ahead" means pushing whatever the agent committed, and the
+            # agent has Bash and write access to the checkout. Only the three track-record files may
+            # reach the branch; anything else is a bug or a hijacked run — refuse and fail loudly.
+            UNEXPECTED=$(git diff --name-only "${GITHUB_SHA}..HEAD" \
+              | grep -vE '^scripts/agent-trader/(bets\.jsonl|lessons\.md|metrics\.jsonl)$' || true)
+            if [ -n "$UNEXPECTED" ]; then
+              echo "::error::Refusing to push — commits touch files outside the track record:"
+              echo "$UNEXPECTED"
+              exit 1
+            fi
             git push origin HEAD:${GITHUB_REF_NAME}
           else
             echo "Nothing to push."

--- a/.github/workflows/agent-trader-weekly.yml
+++ b/.github/workflows/agent-trader-weekly.yml
@@ -86,8 +86,16 @@ jobs:
           # compares content, not working-tree state: the agent has Bash and has been seen running
           # `git commit` itself (2026-07-27), which leaves `git diff` clean on a perfectly healthy
           # run and made the detector cry wolf. Content fingerprints are immune to that.
-          RUNS_BEFORE=$(grep -c '^## Run ' lessons.md 2>/dev/null || echo 0)
-          LESSONS_SUM_BEFORE=$(md5sum lessons.md 2>/dev/null | cut -d' ' -f1 || echo none)
+          # awk, not `grep -c || echo 0`: grep exits 1 on zero matches *after* printing "0", so the
+          # fallback would concatenate a second 0 and the later `-gt` would abort on a non-integer.
+          RUNS_BEFORE=$(awk '/^## Run /{n++} END{print n+0}' lessons.md 2>/dev/null || echo 0)
+          if [ -f lessons.md ]; then
+            LESSONS_HAD=1
+            LESSONS_SUM_BEFORE=$(md5sum lessons.md | cut -d' ' -f1)
+          else
+            LESSONS_HAD=0
+            LESSONS_SUM_BEFORE=absent
+          fi
           BETS_BEFORE=$(wc -l < bets.jsonl 2>/dev/null || echo 0)
           # Hand the decision loop to Claude with web + bash access. The prompt file
           # drives the full research->bet->lessons routine. Capture the exit status:
@@ -106,14 +114,22 @@ jobs:
           if grep -qiE "API Error|usage limit|rate limit|Execute error|Overloaded|Not logged in" /tmp/agent-run.log; then
             AGENT_OK=0
           fi
-          RUNS_AFTER=$(grep -c '^## Run ' lessons.md 2>/dev/null || echo 0)
-          LESSONS_SUM_AFTER=$(md5sum lessons.md 2>/dev/null | cut -d' ' -f1 || echo none)
+          RUNS_AFTER=$(awk '/^## Run /{n++} END{print n+0}' lessons.md 2>/dev/null || echo 0)
+          if [ -f lessons.md ]; then
+            LESSONS_HAS=1
+            LESSONS_SUM_AFTER=$(md5sum lessons.md | cut -d' ' -f1)
+          else
+            LESSONS_HAS=0
+            LESSONS_SUM_AFTER=absent
+          fi
           BETS_AFTER=$(wc -l < bets.jsonl 2>/dev/null || echo 0)
           # A real run always appends a new `## Run N — <date>` section; accept a plain content
           # change or a new bet line as corroboration too, so a formatting drift in the header
-          # can't downgrade a genuine run to a false alarm.
+          # can't downgrade a genuine run to a false alarm. The checksum branch requires the file
+          # to exist on BOTH sides — a vanished lessons.md is a broken run, not a productive one.
           if [ "$RUNS_AFTER" -gt "$RUNS_BEFORE" ] \
-            || [ "$LESSONS_SUM_AFTER" != "$LESSONS_SUM_BEFORE" ] \
+            || { [ "$LESSONS_HAD" = "1" ] && [ "$LESSONS_HAS" = "1" ] \
+                 && [ "$LESSONS_SUM_AFTER" != "$LESSONS_SUM_BEFORE" ]; } \
             || [ "$BETS_AFTER" -gt "$BETS_BEFORE" ]; then
             LESSONS_TOUCHED=1
           else
@@ -163,8 +179,17 @@ jobs:
           set -euo pipefail
           git add scripts/agent-trader/bets.jsonl scripts/agent-trader/lessons.md scripts/agent-trader/metrics.jsonl
           if git diff --cached --quiet; then
-            echo "No changes to commit (no bets placed / no resolutions)."
+            echo "No staged changes of our own (no bets placed / no resolutions)."
           else
             git commit -m "chore(agent-trader): weekly run $(date -u +%Y-%m-%d) [skip ci]"
+          fi
+          # Push whatever HEAD is ahead of the checked-out SHA, not just our own commit. The agent
+          # has Bash and has committed the track record itself (2026-07-27); if it does that AND we
+          # stage nothing (e.g. the metrics snapshot failed), the old `push` inside the else branch
+          # never ran and the whole week's research died with the runner.
+          if [ -n "$(git log --oneline "${GITHUB_SHA}..HEAD")" ]; then
+            git log --oneline "${GITHUB_SHA}..HEAD"
             git push origin HEAD:${GITHUB_REF_NAME}
+          else
+            echo "Nothing to push."
           fi

--- a/scripts/agent-trader/agent-trader-prompt.md
+++ b/scripts/agent-trader/agent-trader-prompt.md
@@ -50,7 +50,9 @@ Working dir: `scripts/agent-trader/`. The harness is `agent_trader.py`. Bets log
    refined selection rules. This is the learning loop — be concrete.
 
 6. **Print a short summary** of bets placed/declined and the running record. (The
-   workflow commits `bets.jsonl` + `lessons.md`.)
+   workflow commits `bets.jsonl` + `lessons.md`. **Never run `git commit`, `git add` or
+   `git push` yourself** — leave the files dirty in the working tree; committing them
+   yourself breaks the run-integrity check downstream.)
 
 ## Guardrails
 - Paper only. Never claim real trading. Realistic costs always (entry net of spread).


### PR DESCRIPTION
## Problem

The 2026-07-27 weekly run was **healthy** — the LLM researched, appended `## Run 9` to `lessons.md` and placed 2 bets — yet the run log shows:

```
AGENT_OK=1 LESSONS_TOUCHED=0
::warning::Agent-Trader LLM run did NOT complete (API error / no lessons written)
```

and the weekly email went out with the subject **"⚠️ Agent-Trader weekly — AGENT DID NOT RUN"**.

## Root cause

The corroborating check was a **working-tree** test:

```bash
if git diff --quiet -- lessons.md bets.jsonl; then LESSONS_TOUCHED=0; ...
```

The agent has `Bash` and committed the two files **itself** (`80cb6c4`, 15:58:41) 15 seconds before the workflow's own "Commit track record" step (`6781b8b`, which consequently only had `metrics.jsonl` left). The tree was clean, so the detector concluded no research had happened.

This is the exact inverse of the 2026-06-29 failure the guard was built for: instead of hiding a real null run it now cries wolf on every healthy run — which retires the signal just as effectively.

## Fix

Fingerprint the track record **by content** before and after the agent block and compare:

- count of `^## Run ` headers in `lessons.md` (a real run always appends one),
- md5 of `lessons.md`,
- line count of `bets.jsonl`.

Content survives a self-commit. The before→after counts are also echoed into the run log so a future regression is diagnosable without re-deriving anything.

Belt and braces: `agent-trader-prompt.md` already told the agent the workflow does the committing; that is now an explicit prohibition on invoking git.

## Verification

The new block was extracted and exercised locally against four cases:

| case | expected | result |
|---|---|---|
| nothing changed (true null run) | 0 | 0 |
| healthy run **followed by a self-commit** (`git diff` reports clean) | 1 | 1 |
| bet appended, no new lessons header | 1 | 1 |
| files missing | 1 (no regression — old check also flagged a deletion) | 1 |

`yaml.safe_load` parses the workflow (8 steps).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weekly trading-run verification by using multiple progress signals (lesson updates and bet activity growth), reducing false alerts when output formatting drifts.
  * Updated logic to better confirm that the run actually made forward progress.
* **Chores**
  * Added workflow safeguards to prevent automated steps from committing or pushing changes during the lessons step, keeping run validation reliable.
  * Refined when the workflow pushes updated track records to avoid missing updates in edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->