### PR TITLE
fix(agent-trader): raise the catch-up staleness threshold 5d -> 7d

### DIFF
--- a/.github/workflows/agent-trader-weekly.yml
+++ b/.github/workflows/agent-trader-weekly.yml
@@ -64,20 +64,26 @@ jobs:
           # monthly budget can exhaust before the last Monday of a month, and `claude --print` exits
           # 0 on the spend-cap error, so that week no-ops silently. The cap resets on the 1st, so this
           # workflow also fires on the 2nd as a catch-up. On the catch-up trigger ONLY, research just
-          # if the last real research run is stale (>5 days = the previous Monday was a null run);
-          # otherwise skip cleanly — no duplicate bets, no metrics row, no email.
+          # if the last real research run is stale; otherwise skip cleanly — no duplicate bets, no
+          # metrics row, no email.
+          # Threshold: a HEALTHY weekly cadence leaves the last run 1-7 days old (the 2nd of the
+          # month lands anywhere in the week after a Monday), so anything <=7 must skip. A genuine
+          # null run pushes the last REAL research run to the Monday before, i.e. 8-14 days old.
+          # 7 is therefore the only boundary that separates the two without a gap or an overlap.
+          # It was 5 until 2026-08-02, when the catch-up false-fired 6 days after a healthy Monday
+          # and burned a full extra research run one day before the regular cron.
           SCHEDULE='${{ github.event.schedule }}'
           if [ "$SCHEDULE" = "7 13 2 * *" ]; then
             LAST_RUN_DATE=$(grep -oE '^## Run [0-9]+ — [0-9]{4}-[0-9]{2}-[0-9]{2}' lessons.md \
               | tail -1 | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}$' || true)
             if [ -n "$LAST_RUN_DATE" ]; then
               AGE_DAYS=$(( ( $(date -u +%s) - $(date -u -d "$LAST_RUN_DATE" +%s) ) / 86400 ))
-              if [ "$AGE_DAYS" -le 5 ]; then
-                echo "Catch-up: last research run ($LAST_RUN_DATE) was ${AGE_DAYS}d ago (<=5) — last Monday ran fine, skipping."
+              if [ "$AGE_DAYS" -le 7 ]; then
+                echo "Catch-up: last research run ($LAST_RUN_DATE) was ${AGE_DAYS}d ago (<=7) — last Monday ran fine, skipping."
                 touch /tmp/agent-skip
                 exit 0
               fi
-              echo "Catch-up: last research run ($LAST_RUN_DATE) was ${AGE_DAYS}d ago (>5) — last Monday likely capped, researching now."
+              echo "Catch-up: last research run ($LAST_RUN_DATE) was ${AGE_DAYS}d ago (>7) — last Monday likely capped, researching now."
             fi
           fi
           # Evaluate resolved bets first (deterministic), so the agent sees fresh state.


### PR DESCRIPTION
## Qué

El cron catch-up del 2 de cada mes (`7 13 2 * *`) existe para recuperar un *silent null run*. Su guard sólo hacía SKIP cuando el último run real de investigación tenía **<=5 días**, pero una cadencia semanal sana deja ese run con **1-7 días** de antigüedad — el día 2 del mes cae en cualquier punto de la semana siguiente a un lunes.

## Por qué (disparó el 2026-08-02)

```
Catch-up: last research run (2026-07-27) was 6d ago (>5) — last Monday likely capped, researching now.
```

El lunes 27-jul había corrido **sano** (`## Run 9` en `lessons.md`, `AGENT_OK=1`). El catch-up lo leyó como null run e investigó igualmente: un run extra del LLM, una fila extra en `metrics.jsonl`, y `Run 10` aterrizando **un día antes** del cron regular del lunes — dos runs de investigación en 24h sobre un universo sin cambios.

Un null run de verdad empuja el último run real al lunes *anterior*, o sea **8-14 días**. Por tanto **7 es la única frontera** que separa los dos casos sin hueco ni solape.

## Verificación

Guard extraído del YAML y ejecutado contra fechas sintéticas en `lessons.md`:

| Edad | Resultado | Esperado |
|---|---|---|
| 1d / 5d / 6d / 7d | SKIP | cadencia sana |
| 8d / 9d / 14d / 15d | RESEARCH | null run real |
| sin cabecera `## Run` | RESEARCH | fail-safe preservado |
| 07-27 -> 08-02 (el caso real) | SKIP | antes RESEARCH (el falso positivo) |

Sin cambios de comportamiento en el cron de los lunes ni en `workflow_dispatch`: el guard sigue viviendo dentro del `if [ "$SCHEDULE" = "7 13 2 * *" ]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDzpWokcapiNC6FmhyC1jR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled research checks to recognize runs completed within the past 7 days as current.
  * Prevented unnecessary catch-up runs caused by the previous shorter time threshold.
  * Older or missing runs continue to trigger catch-up research.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->