### PR TITLE
fix(agent-trader): label price frames, and correct Run 12's Bet 14 criterion read

### DIFF
--- a/scripts/agent-trader/agent-trader-prompt.md
+++ b/scripts/agent-trader/agent-trader-prompt.md
@@ -12,8 +12,19 @@ Working dir: `scripts/agent-trader/`. The harness is `agent_trader.py`. Bets log
 ## Steps (do them in order)
 
 1. **Evaluate resolved bets + read state.** Run:
-   `python agent_trader.py evaluate` then `python agent_trader.py summary`.
+   `python agent_trader.py evaluate`, then `python agent_trader.py summary`, then
+   `python agent_trader.py positions`.
    Read `lessons.md` fully — it is your accumulated learning; apply it.
+   **Every statement you make about an open position — entry, mark, direction and size
+   of the move — must come from THIS run's `positions` output, verbatim.** Never from
+   memory, never from a previous run's numbers, never recomputed by hand. `positions`
+   labels each price with its frame: `(held)` is the token you own (the NO token on a NO
+   bet), `(YES)` is the market's YES price. Compare like with like; subtracting a held
+   price from a YES price is meaningless. Bet 7 is the worked example: `lessons.md` quotes
+   it in the YES frame in two different runs — Run 11 "current YES=0.595" and Run 12 "mark
+   YES=0.325" — while the position is a NO. Treat those two quotes as its entry and mark
+   and you report a 0.27 move; the position's actual move is +0.055 (entry(held) 0.620 →
+   mark(held) 0.675). Quote `positions`, not prose from an earlier run.
 
 2. **Fetch candidates.** Run `python agent_trader.py candidates --research`. Then in
    Python, narrow to the genuinely-uncertain, researchable set:
@@ -29,6 +40,27 @@ Working dir: `scripts/agent-trader/`. The harness is `agent_trader.py`. Bets log
    `p_hat` (your probability of YES) + a written rationale. Decline (efficient/marginal/
    ambiguous) freely; the strongest historical edges were where the market mispriced the
    SPEED or STATUS of a known-direction process, not blue-chip consensus.
+
+   **Enumerate every payout condition in writing before fixing `p_hat`** — one line per
+   condition, not a summary of the criterion. If payout depends on a multi-party deal or
+   announcement, list the parties that must each pronounce, with **one cited source per
+   party**. A party with no cited announcement is an unpriced binary risk: price it or
+   decline. And when the criterion excludes prospective statements, a source describing
+   the deal as draft, under review, pending sign-off or under negotiation counts
+   AGAINST — it is evidence the condition is unmet, never evidence it will be met.
+
+   **Count the description's paragraphs and say how many you read.** Bet 14 quoted a
+   fragment of 2 of 7; the two that decided it were among the 5 never opened. Read the
+   whole description, including the timing/ambiguity clauses — they are load-bearing on a
+   short hold.
+
+   **Before calling any price stale, anchored or mispriced, pull that market's own price
+   history** and state what the path did since the news that motivates your view:
+   `https://clob.polymarket.com/prices-history?market=<clobTokenId>&interval=max&fidelity=60`
+   (`clobTokenIds` comes from the Gamma market; index 0 is YES). Two observations taken the
+   same day say nothing about movement since a story broke — that is a claim about a time
+   series and needs the series. A path that has been repricing AGAINST your thesis for days
+   is evidence, not noise: say what the market learned that you have not.
 
 4. **Place bets** only where `|p_hat − price| − spread` clears a meaningful threshold
    (aim ≥ ~0.05 net edge; never bet a view you can't defend). Watch concentration — the

--- a/scripts/agent-trader/agent_trader.py
+++ b/scripts/agent-trader/agent_trader.py
@@ -281,6 +281,120 @@ def _mark_outcome(b):
         return None
 
 
+# --- Open positions: every price tagged with the frame it lives in -------------------
+#
+# Two frames exist and they are NOT interchangeable:
+#   HELD frame  — the price of the token you actually own (YES token for a YES bet, NO
+#                 token for a NO bet). `entry_price` is always in this frame.
+#   YES frame   — the market's YES price. `market_yes_price` and `mark_yes_price` are
+#                 always in this frame, whichever side was taken.
+# Mixing them is not hypothetical. lessons.md quotes bet 7 (a NO position) in the YES frame
+# twice: Run 11 "current YES=0.595" and Run 12 "mark YES=0.325". Read as this position's
+# entry and mark they imply a 0.27 move; in the held frame the move is 0.620 -> 0.675, i.e.
+# +0.055 — about a fifth of that. The old email table invited precisely that subtraction:
+# an unlabelled "Entry" column (held frame, 0.62 on a NO) sat next to "Mark (YES)".
+# Anything that reports on an open position must go through these two functions.
+
+_MISSING = "—"
+
+
+def open_positions(bets):
+    """One row per OPEN bet, with every price labelled by frame. Pure — no network.
+
+    Returned keys:
+      bet_id, side, question, end_date, stake, confidence
+      entry_held  — entry in the HELD-token frame (= entry_price, as logged)
+      mark_held   — last mark in the HELD-token frame (mark_yes_price for YES,
+                    1 - mark_yes_price for NO); None when there is no mark
+      delta_held  — mark_held - entry_held, i.e. the move in your favour; None w/o a mark
+      entry_yes   — entry in the YES frame (= market_yes_price at the time of the bet)
+      mark_yes    — last mark in the YES frame (= mark_yes_price, as logged)
+      marked_at   — the date the mark was last observed
+      decided     — metrics.mark_outcome(): 'pending_win' / 'pending_loss' / None
+
+    CAVEAT, and it is not cosmetic: `entry_held` is the price actually PAID, i.e. the ask
+    after crossing the spread, while `mark_held` derives from `outcomePrices` (a mid),
+    which crosses nothing. So `delta_held` is APPROXIMATE and slightly PESSIMISTIC versus
+    a like-for-like mid-to-mid comparison — by roughly the half-spread paid on entry. It
+    is a position-tracking number, not a realisable P&L; the realisable figure only exists
+    at resolution (`pnl_net`) or in metrics' mark-to-market for already-decided positions.
+    """
+    rows = []
+    for b in bets:
+        if b.get("status") != "open":
+            continue
+        entry_held = b.get("entry_price")
+        mark_yes = b.get("mark_yes_price")
+        if mark_yes is None:
+            mark_held = delta = None
+        else:
+            mark_yes = float(mark_yes)
+            # Case-normalised on purpose: a lowercase "yes" compared exactly would fall
+            # into the NO branch and complement the mark — a silent frame inversion, the
+            # one failure this whole function exists to make impossible. record_bet
+            # writes side.upper(), so this only ever matters for hand-edited rows.
+            is_yes = str(b.get("side") or "").upper() == "YES"
+            mark_held = round(mark_yes if is_yes else 1 - mark_yes, 4)
+            delta = (round(mark_held - float(entry_held), 4)
+                     if entry_held is not None else None)
+        rows.append({
+            "bet_id": b.get("bet_id"), "side": b.get("side"),
+            "question": b.get("question"), "end_date": b.get("end_date"),
+            "stake": b.get("stake"), "confidence": b.get("confidence"),
+            "entry_held": entry_held, "mark_held": mark_held, "delta_held": delta,
+            "entry_yes": b.get("market_yes_price"), "mark_yes": mark_yes,
+            # NOT `or 0.0`: a missing edge would print as "+0.000", i.e. a measured zero,
+            # inventing the one number this view exists to stop inventing. None renders
+            # as the em-dash in both the ASCII table and the email.
+            "edge_at_entry": b.get("edge_per_contract"),
+            "marked_at": b.get("marked_at"), "decided": _mark_outcome(b),
+        })
+    return rows
+
+
+def format_positions(rows) -> str:
+    """Deterministic ASCII table of `open_positions` rows. Frames named in the headers."""
+    if not rows:
+        return "no open positions."
+
+    def num(v, sign=False):
+        if v is None:
+            return _MISSING
+        return f"{v:+.3f}" if sign else f"{v:.3f}"
+
+    hdr = ["side", "entry(held)", "mark(held)", "delta(held)", "edge@entry",
+           "entry(YES)", "mark(YES)", "decided", "stake", "marked", "resolves",
+           "question"]
+    body = [[
+        str(r["side"]), num(r["entry_held"]), num(r["mark_held"]),
+        num(r["delta_held"], sign=True), num(r["edge_at_entry"], sign=True),
+        num(r["entry_yes"]), num(r["mark_yes"]),
+        {"pending_win": "WIN", "pending_loss": "LOSS"}.get(r["decided"], ""),
+        f"${r['stake']:.0f}" if r["stake"] is not None else _MISSING,
+        str(r["marked_at"] or _MISSING), str(r["end_date"] or "")[:10],
+        (r["question"] or "")[:60],
+    ] for r in rows]
+    w = [max(len(h), *(len(row[i]) for row in body)) for i, h in enumerate(hdr)]
+    line = "  ".join(h.ljust(w[i]) for i, h in enumerate(hdr)).rstrip()
+    out = [line, "-" * len(line)]
+    out += ["  ".join(c.ljust(w[i]) for i, c in enumerate(row)).rstrip() for row in body]
+    out += [
+        "",
+        "(held) = frame of the token you own: YES token for a YES bet, NO token for a NO "
+        "bet.",
+        "(YES)  = the market's YES price, whichever side was taken. entry(YES) is the YES "
+        "price when the bet was placed; mark(YES) is the latest observed YES price.",
+        "delta(held) = mark(held) - entry(held). APPROXIMATE and slightly pessimistic: "
+        "entry(held) is the ask actually paid (spread crossed), the mark is a mid "
+        "(spread not crossed). Not a realisable P&L.",
+        "The entry(YES)/mark(YES) pair is mid-to-mid, so the move it implies is LARGER "
+        "than delta(held) by the half-spread paid on entry. delta(held) is the position's "
+        "number; the YES pair is the market's quote.",
+        "Never subtract across frames — entry(held) minus mark(YES) is meaningless.",
+    ]
+    return "\n".join(out)
+
+
 def _latest_lessons_section() -> str:
     p = HERE / "lessons.md"
     if not p.exists():
@@ -296,46 +410,97 @@ def _latest_lessons_section() -> str:
 _LIST_ITEM = re.compile(r"^\s*(?:[-*]|\d+\.)\s+")
 
 
-def _md_to_html(md: str) -> str:
-    """Minimal Markdown -> HTML for the lessons section (headers, bold, code, lists)."""
-    out, in_ul = [], False
+_BLOCKQUOTE = re.compile(r"^\s*>\s?")
+# Italic runs AFTER bold, so every '**' is already consumed and a lone '*' is unambiguous.
+# The lookarounds refuse a marker that hugs whitespace or a word character, which is what
+# keeps arithmetic ("2 * 3") and leftover list markers from being read as emphasis.
+_ITALIC = re.compile(r"(?<![\w*])\*(?!\s)(.+?)(?<!\s)\*(?![\w*])")
 
+
+def _md_to_html(md: str) -> str:
+    """Minimal Markdown -> HTML for the lessons section.
+
+    Assembles BLOCKS first and renders inline spans once per block, rather than rendering
+    line by line. That ordering is the whole point: lessons.md is hard-wrapped prose written
+    by a different author every week, so an inline span routinely straddles a line break.
+    The old line-based version emitted the 2026-08-10 audit correction with 10 literal '**',
+    24 literal '*', 11 escaped '&gt;' and 14 fragmented <ul> blocks — no exception, no lost
+    text, just silent fidelity loss in the one artefact a human actually reads.
+
+    Supports headers, bold, italic, code, bullet/numbered lists (with wrapped continuations)
+    and blockquotes. Anything else degrades to a paragraph, which is the safe direction.
+    """
     def inline(t):
         t = t.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
         t = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", t)
         t = re.sub(r"`([^`]+?)`", r"<code>\1</code>", t)
+        t = _ITALIC.sub(r"<em>\1</em>", t)
         return t
 
+    out = []
+    kind = None          # None | 'p' | 'li' | 'quote'
+    buf = []
+    in_ul = False
+
+    def flush():
+        nonlocal kind, buf
+        if kind and buf:
+            text = inline(" ".join(s.strip() for s in buf if s.strip()))
+            if kind == "li":
+                out.append(f"<li>{text}</li>")
+            elif kind == "quote":
+                out.append("<blockquote style='margin:6px 0 6px 12px;padding-left:10px;"
+                           f"border-left:3px solid #d0d7de;color:#444'>{text}</blockquote>")
+            else:
+                out.append(f"<p style='margin:6px 0'>{text}</p>")
+        kind, buf = None, []
+
+    def close_ul():
+        nonlocal in_ul
+        if in_ul:
+            out.append("</ul>")
+            in_ul = False
+
     for raw in md.splitlines():
-        l = raw.rstrip()
-        if not l.strip():
-            if in_ul:
-                out.append("</ul>"); in_ul = False
+        line = raw.rstrip()
+        if not line.strip():
+            flush(); close_ul()
             continue
-        if l.startswith("### "):
-            if in_ul:
-                out.append("</ul>"); in_ul = False
-            out.append(f"<h4 style='margin:10px 0 4px'>{inline(l[4:])}</h4>")
-        elif l.startswith("## "):
-            if in_ul:
-                out.append("</ul>"); in_ul = False
-            out.append(f"<h3 style='margin:12px 0 4px'>{inline(l[3:])}</h3>")
-        elif _LIST_ITEM.match(l):
+        if line.startswith("### ") or line.startswith("## "):
+            flush(); close_ul()
+            tag, text = ("h4", line[4:]) if line.startswith("### ") else ("h3", line[3:])
+            margin = "10px 0 4px" if tag == "h4" else "12px 0 4px"
+            out.append(f"<{tag} style='margin:{margin}'>{inline(text)}</{tag}>")
+        elif _LIST_ITEM.match(line):
+            flush()
             if not in_ul:
-                out.append("<ul style='margin:4px 0;padding-left:20px'>"); in_ul = True
-            out.append(f"<li>{inline(_LIST_ITEM.sub('', l))}</li>")
+                out.append("<ul style='margin:4px 0;padding-left:20px'>")
+                in_ul = True
+            kind, buf = "li", [_LIST_ITEM.sub("", line)]
+        elif _BLOCKQUOTE.match(line):
+            if kind != "quote":
+                flush(); close_ul()
+                kind = "quote"
+            buf.append(_BLOCKQUOTE.sub("", line))
+        elif kind in ("li", "quote", "p"):
+            # A continuation line: same block, joined with a space. This is what lets a
+            # bold span, a code span or a list item survive the author's line wrapping.
+            buf.append(line)
         else:
-            if in_ul:
-                out.append("</ul>"); in_ul = False
-            out.append(f"<p style='margin:6px 0'>{inline(l)}</p>")
-    if in_ul:
-        out.append("</ul>")
+            close_ul()
+            kind, buf = "p", [line]
+    flush(); close_ul()
     return "\n".join(out)
 
 
-def email_html() -> str:
-    """Build an HTML weekly summary email body (record + open bets + latest lessons)."""
-    bets = load_bets()
+def email_html(bets=None) -> str:
+    """Build an HTML weekly summary email body (record + open bets + latest lessons).
+
+    `bets` defaults to the real track record; it is a parameter so the frame contract of
+    the open-bets table can be pinned by a test without touching bets.jsonl. The email is
+    the artefact a human actually reads, so its frames need a test of their own.
+    """
+    bets = load_bets() if bets is None else bets
     closed = [b for b in bets if b["status"] in ("won", "lost")]
     openb = [b for b in bets if b["status"] == "open"]
     pnl = sum(b["pnl_net"] for b in closed if b["pnl_net"] is not None)
@@ -350,20 +515,33 @@ def email_html() -> str:
     def esc(s):
         return (str(s).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
 
-    def mark_cell(b):
-        if b.get("mark_yes_price") is None:
+    # Open bets: entry and mark side by side ONLY in the same frame (the held token).
+    # The YES-frame pair is kept for reference but labelled so it can't be mistaken for
+    # the position's own prices — the previous table put an unlabelled "Entry" (held
+    # frame) next to "Mark (YES)", which is a subtraction across frames waiting to happen
+    # (see the frames note above open_positions for the bet-7 case).
+    def num(v, sign=False):
+        if v is None:
+            return "—"
+        return f"{v:+.3f}" if sign else f"{v:.3f}"
+
+    def mark_cell(r):
+        if r["mark_held"] is None:
             return "<td>—</td>"
         note = {"pending_win": " ✅ decided", "pending_loss": " ❌ decided"}.get(
-            _mark_outcome(b), "")
-        return (f"<td>{b['mark_yes_price']:.3f}{note}"
+            r["decided"], "")
+        return (f"<td>{num(r['mark_held'])}{note}"
                 f"<br><span style='color:#888;font-size:11px'>"
-                f"{esc(b.get('marked_at', '?'))}</span></td>")
+                f"{esc(r.get('marked_at') or '?')}</span></td>")
 
     rows = "".join(
-        f"<tr><td>{esc(b['side'])}</td><td>{b['entry_price']:.3f}</td>{mark_cell(b)}"
-        f"<td>{b.get('edge_per_contract', 0):+.3f}</td><td>{esc(b['end_date'][:10])}</td>"
-        f"<td>{esc(b['question'][:70])}</td></tr>"
-        for b in openb)
+        f"<tr><td>{esc(r['side'])}</td><td>{num(r['entry_held'])}</td>{mark_cell(r)}"
+        f"<td>{num(r['delta_held'], sign=True)}</td>"
+        f"<td>{num(r['edge_at_entry'], sign=True)}</td>"
+        f"<td style='color:#888'>{num(r['entry_yes'])} → {num(r['mark_yes'])}</td>"
+        f"<td>{esc(str(r['end_date'] or '')[:10])}</td>"
+        f"<td>{esc((r['question'] or '')[:70])}</td></tr>"
+        for r in open_positions(bets))
     resolved_rows = "".join(
         f"<tr><td>{esc(b['status'].upper())}</td><td>${b['pnl_net']:+.2f}</td>"
         f"<td>{esc(b['side'])}</td><td>{esc(b['question'][:70])}</td></tr>"
@@ -390,8 +568,17 @@ def email_html() -> str:
 <b>Open:</b> {len(openb)} (${sum(b['stake'] for b in openb):.0f} at risk)</p>
 {metrics_block}
 <h3>Open bets</h3>
+<p style="color:#666;font-size:12px;margin:4px 0">Entry and mark are both in the
+<b>held-token frame</b> (the YES token on a YES bet, the NO token on a NO bet), so the
+delta is the move in your favour. The greyed column is the same position in the
+<b>YES frame</b> for reference only — never subtract across the two.</p>
 <table border="1" cellpadding="4" cellspacing="0">
-<tr><th>Side</th><th>Entry</th><th>Mark (YES)</th><th>Edge</th><th>Resolves</th><th>Market</th></tr>{rows or '<tr><td colspan=6>none</td></tr>'}</table>
+<tr><th>Side</th><th>Entry<br>(held)</th><th>Mark<br>(held)</th><th>Δ<br>(held)</th><th>Edge<br>at entry</th><th>Market mid at entry →<br>latest mid (YES frame)</th><th>Resolves</th><th>Market</th></tr>{rows or '<tr><td colspan=8>none</td></tr>'}</table>
+<p style="color:#888;font-size:11px;margin:4px 0">Δ is approximate and slightly
+pessimistic: entry is the ask actually paid (spread crossed), the mark is a mid (spread
+not crossed). Not a realisable P&amp;L. The greyed YES-frame pair is mid-to-mid, so the
+move it implies is <b>larger</b> than Δ(held) by the half-spread paid on entry — Δ(held)
+is the position's number, the greyed pair is the market's quote.</p>
 {"<h3>Recently resolved</h3><table border=1 cellpadding=4 cellspacing=0><tr><th>Result</th><th>P&amp;L</th><th>Side</th><th>Market</th></tr>" + resolved_rows + "</table>" if closed else ""}
 <h3>This run's notes (from lessons.md)</h3>
 <div style="background:#f6f8fa;padding:10px 14px;border-radius:6px;line-height:1.45">{_md_to_html(_latest_lessons_section())}</div>
@@ -440,6 +627,15 @@ if __name__ == "__main__":
         evaluate(); summary()
     elif cmd == "summary":
         summary()
+    elif cmd == "positions":
+        # The ONLY sanctioned source for any claim about an open position. Reciting
+        # entries/marks from memory or from a previous run is what produced the Run 12
+        # error; paste this output instead.
+        text = format_positions(open_positions(load_bets()))
+        try:
+            print(text)
+        except UnicodeEncodeError:
+            print(text.encode("ascii", "replace").decode())
     elif cmd == "email_html":
         out = sys.argv[2] if len(sys.argv) > 2 else "email.html"
         Path(out).write_text(email_html(), encoding="utf-8")

--- a/scripts/agent-trader/lessons.md
+++ b/scripts/agent-trader/lessons.md
@@ -688,3 +688,181 @@ Thesis: Iranian FM spokesman Baghaei stated on August 8 (CNN, https://www.cnn.co
 
 **Running record: 5-4 resolved, 5 open ($125 at risk), P&L -$52.32, bankroll $947.68.**
 Pending expected loss: Bet 10 (Apple Aug31, mark YES=0.045) essentially booked at -$25. Honest forward mark: ~-$77.32.
+
+---
+
+### Review correction — appended 2026-08-10 by the weekly external audit (not by the run agent)
+
+Two corrections to Run 12. Read them before Run 13; they override what Run 12 wrote.
+
+**1. Bet 14 (Iran-Oman Hormuz Agreement, market_id 3348048) reads the criterion incomplete.**
+The rationale quotes one spliced fragment of the first two paragraphs of the Gamma description
+(*"a diplomatic agreement between Oman and Iran... an official agreement, treaty, deal, or
+substantially similar diplomatic instrument..."*, with the ellipsis in the original) — the
+definition of a "diplomatic agreement" — and concludes correctly that this is a *bilateral*
+Iran-Oman instrument that does not require US approval. That part is right. It then never quotes
+the paragraphs that actually decide the bet. Verbatim from
+[gamma-api.polymarket.com/markets/3348048](https://gamma-api.polymarket.com/markets/3348048),
+re-pulled 2026-08-10:
+
+> All listed countries must announce their acceptance of the same qualifying diplomatic agreement
+> for the Payout Condition to be met. A joint announcement will qualify, as will separate
+> announcements from each entity of its own acceptance of an agreement which, taken together,
+> directly indicate that all the listed countries accepted the same agreement. Separate
+> announcements of individual policies will not qualify if the policies are not announced as part
+> of a diplomatic agreement.
+
+> Each announcement must be a declarative statement that clearly and unambiguously communicates
+> acceptance of an agreement. Statements that reference ongoing negotiations or a prospective
+> agreement, or that allude to or express support for an agreement without confirming acceptance
+> of the agreement, do not qualify. A qualifying announcement need not reference the agreement by
+> name or use specific terminology, provided it clearly communicates acceptance of an agreement.
+
+Three consequences.
+
+- **Oman has to speak, and no Omani announcement is cited anywhere in the rationale.** The
+  rationale cites five sources — Bloomberg, Fortune, Al Jazeera, CNN, NPR — and every one of them
+  reports Iran saying so.
+  - **Bloomberg** ([2026-08-05](https://www.bloomberg.com/news/articles/2026-08-05/iran-says-agreement-on-hormuz-shipping-route-reached-with-oman)):
+    the URL slug reads `iran-says-agreement-on-hormuz-shipping-route-reached-with-oman`, but the
+    page returns HTTP 403 to this audit and the headline was **not** fetched — treat the wording
+    as unverified.
+  - **Fortune** carries the same wire story and *is* fetchable:
+    *"Iran says agreement on Hormuz shipping reached with Oman"*
+    ([2026-08-07](https://fortune.com/2026/08/07/iran-agreement-oman-strait-of-hormuz-shipping/),
+    headline read directly, 2026-08-10 — note it lacks the word "route"). Read in full, every
+    attribution of the agreement claim is Iranian: FM spokesman Baghaei, Deputy FM Gharibabadi via
+    IRNA, and Iranian state television. The only non-Iranian voices in the piece are Trump, Vance
+    and a White House that "didn't respond to a request for comment". No Omani statement appears.
+  - **NPR**, headline fetched and verbatim: *"Iran says agreement with Oman for Strait of Hormuz
+    prohibits U.S. and Israeli vessels"*
+    ([2026-08-07](https://www.npr.org/2026/08/07/nx-s1-5923962/iran-says-agreement-with-oman-for-strait-of-hormuz-prohibits-u-s-and-israeli-vessels)).
+  - **CNN** is the Baghaei drafting quote (see next bullet). **Al Jazeera** is cited in the
+    rationale without a URL and was not checked here.
+  - Not cited by the run, but the same pattern from a source this audit did fetch: Euronews,
+    *"Iran and Oman agree route for ships in Strait of Hormuz, Tehran says"*
+    ([2026-08-05](https://www.euronews.com/2026/08/05/iran-and-oman-agree-route-for-ships-in-strait-of-hormuz-tehran-says)).
+
+  The description's own resolution sources are "official information from the governments of Oman
+  and Iran and a consensus of credible reporting". Credible reporting can corroborate, but
+  paragraph 4 independently requires that ALL listed countries announce acceptance, and no volume
+  of reporting substitutes for an announcement Oman has not made. One of the two listed parties
+  has zero cited announcements. That is a binary factor, and p_hat = 0.78 does not discount it.
+- **The rationale's strongest piece of evidence is the one the criterion disqualifies.** It cites
+  the joint statement being "under review and in the final drafting stage" (FM spokesman Baghaei,
+  Aug 8, [CNN](https://www.cnn.com/2026/08/08/world/live-news/iran-war-trump)) as support for YES.
+  A statement that a text is in drafting is a *prospective agreement* — the second clause excludes
+  it by name. Evidence was booked in favour when the text of the criterion books it against.
+- **The market moved hard against the thesis, and the rationale never looked at the tape.**
+  Hourly YES history for this market
+  ([CLOB prices-history](https://clob.polymarket.com/prices-history?market=71542982741394376771627006689338880117415417908788827680925028639627563224055&interval=max&fidelity=60),
+  137 points, pulled 2026-08-10, times UTC): the series opens Aug 5 at 0.72 (one thin 0.525 print
+  at 01:00), is at 0.82 by 06:00 and 0.93 by 23:00 — the market repricing the Bloomberg/Fortune
+  news — and **peaks at 0.935 on Aug 6, 14:00-16:00**. Then four straight days of repricing DOWN:
+  0.875 through Aug 7 midday, 0.855 through Aug 8 morning, 0.685 at Aug 9 03:00, **trough 0.585 at
+  Aug 9 23:00**, recovering to 0.66 by Aug 10 15:00. Gamma the same day: mid 0.655, bid 0.64 / ask 0.67, last trade 0.67.
+  So entry at 0.66 on Aug 10 14:35 was buying a market ~28 points below its Aug 6 peak and ~7
+  points above a trough set 15 hours earlier. The rationale describes 0.66 as the market undervaluing a
+  near-done deal; the tape says the market spent four days progressively discounting it — most
+  plausibly because the joint statement never appeared and Oman stayed silent. **A price path that
+  contradicts the thesis is itself evidence, and it must be pulled before fixing p_hat.**
+  Method note: entry price and today's mid are both 2026-08-10 observations an hour apart, so
+  comparing them says nothing about movement since the news. "The price hasn't moved" is a claim
+  about a time series and can only be made from the time series.
+
+Two more unquoted paragraphs belong in the enumeration. **Paragraph 6 governs timing:** where all
+listed countries have announced but it remains ambiguous whether the announcements constitute a
+qualifying agreement, the market stays open until either definitive confirmation (through further
+announcements or a consensus of credible reporting), or 14 calendar days (ET) after the last
+country's first potentially-qualifying announcement — and only then resolves on the totality of
+information. With expiry on Aug 31, a first Omani announcement late in the month does not
+guarantee a resolution inside the window; this clause is load-bearing on a 21-day hold and the
+rationale never mentions it. **Paragraph 3** adds a subject-matter condition — the agreement must
+establish policies "aimed at managing, permitting, restoring, or increasing vessel or shipping
+traffic through the Strait of Hormuz" — which the reported terms do appear to satisfy, but it is
+a condition and it was not enumerated either.
+
+The turn that makes this serious: every win in this track record came from reading the resolution
+criterion **literally and in full**. Sometimes that makes the bar *harder* than the market assumes
+— Israel-Hezbollah (the criteria explicitly bar temporary ceasefires, statements of progress and
+negotiations), Machado (resolution requires physical entry into Venezuelan terrestrial territory)
+— and sometimes it makes it *easier*, which is precisely why two of the five wins were taken:
+Hormuz-40-ships (">=40 transit calls on ANY day", a one-day low bar) and Sulyok (the announcement
+clause: "even an announcement of removal before July 31 resolves YES regardless of effective
+date"). Bolojan is the third mode, process speed rather than bar height. So the failure on Bet 14
+is not looseness — it is **incompleteness**: the description has seven paragraphs, the rationale
+quoted a fragment of two, and the two that decide the bet are among the five it never opened. The
+invariant is exhaustiveness, not severity. A rule of "read it strictly" would have vetoed two of
+the five wins.
+
+**Rule 1 (operative, cumulative): in any market whose payout depends on a multi-party agreement,
+announcement or action, enumerate in writing ALL payout conditions before fixing p_hat — in
+particular the list of parties that must speak — and cite one source per party. A party with zero
+cited announcements is not a detail; it is an unpriced binary factor. And a source describing an
+agreement as drafted, under review or under negotiation counts as evidence AGAINST, not for,
+whenever the criterion explicitly excludes prospective statements. Enumerate every paragraph of
+the description, not the ones that confirm the thesis — count them, and say how many you read.
+Finally, before calling any price stale or mispriced, pull that market's own price history
+(`https://clob.polymarket.com/prices-history?market=<clobTokenId>&interval=max&fidelity=60`) and
+state what the path did since the news: a single snapshot cannot support a claim about
+movement.**
+
+**2. Every loss lives in the middle band of p_hat.**
+Computed over `bets.jsonl` and reproducible with `python metrics.py`. The partition below is
+arithmetic; the *band* is not — it was fitted after seeing these outcomes, and the honesty clause
+below quantifies how fragile that makes it. Read both together. The nine resolved bets split on
+the `my_prob_yes` field:
+
+- **`my_prob_yes` inside [0.20, 0.60]: 4 bets, 0 wins.** Bet 1 (Hormuz Jul31, 0.55), Bet 8 (Apple
+  Jul31, 0.38), Bet 9 (Stevens Michigan, 0.50), Bet 11 (Thanedar MI-13, 0.30). These are exactly
+  the four losses in the track record.
+- **`my_prob_yes` outside that band: 5 bets, 5 wins.** Bet 2 (Bolojan, 0.18), Bet 3
+  (Hormuz-40-ships, 0.66), Bet 4 (Israel-Hezbollah, 0.06), Bet 5 (Machado, 0.19), Bet 6 (Sulyok,
+  0.92).
+
+It matches the confidence table from the same `metrics.py` run: high 2/2 (+$9.19), medium-high
+2/3 (-$1.19), medium 1/4 (-$60.32). It also matches the calibration table, whose 0.2-0.4 (n=2)
+and 0.4-0.6 (n=2) bins are those same four bets, actual YES 0.000 in both.
+
+**Proposed mechanism — hypothesis, not result, and it has a counterexample inside its own
+cohort.** The agent's demonstrated edge is reading resolution criteria and process speeds against
+the market's casual reading: situations where the correct answer sits near 0 or near 1. Three of
+the four in-band losses fit the complement of that — Bet 8 (Apple vs NVIDIA on a date), Bet 9 and
+Bet 11 (two Michigan primaries) exploit no criterion asymmetry; they are discretionary forecasts
+of genuinely uncertain contests, and there the market is not systematically wrong. The fourth does
+**not** fit: Bet 1 (Hormuz MA>=60) is a resolution-threshold and process-speed argument by its own
+rationale ("37-day window + any-single-day low bar"), i.e. exactly the family the mechanism says
+should win, and its post-mortem lesson is recorded above as "physical constraint + military will >
+political agreements". Bet 1 is a counterexample to this mechanism, not support for it. (The
+second Apple bet, Bet 10, is *not* in this cohort: `my_prob_yes` 0.62, outside the band, and still
+open.)
+
+**Honesty clause, non-negotiable.** n = 9. `metrics.py` still returns VERDICT = too few resolved
+bets (need >=20), mean -$5.813/bet, bootstrap 95% CI [-17.244, +6.204] — crossing zero. And the
+band edges are **fitted to these 9 outcomes, not chosen in advance**: Bet 2 (0.18) and Bet 5
+(0.19) are winners sitting 0.01-0.02 below the lower edge, and moving that edge from 0.20 to 0.18
+turns the split into 2 wins / 6 bets inside versus 3 wins / 3 bets outside. The clean 0/4-vs-5/5
+partition is therefore a property of a threshold chosen after seeing the outcomes it is used to
+explain, not a robust feature of the data. This is a hypothesis with a mechanism, a free
+parameter and insufficient n, **not** a demonstrated effect. The experiment's formal bar (n >= 20
+and `pnl_boot_lo` > 0) has not been reached. Do not turn a pattern in 9 observations into a law.
+
+**Rule 2 (operative, cumulative): every bet states in its rationale which family of edge it
+claims — (i) the market misreads the resolution criterion or the speed of a process, or (ii) I
+forecast the outcome better than the market. Family (ii) accounts for 3 of the 4 in-band losses
+and 0 of the 5 wins, so it carries the higher bar: name the concrete asymmetry it exploits, and
+record the family label explicitly in the rationale so the cohort can be measured once n >= 20.**
+At n = 9 with a post-hoc band the useful output is the labelling, not a veto — this rule does not
+authorise declining a bet purely for sitting in the band.
+
+**Disposition of Run 12's selection rule #3 (injury information in sports markets): STANDS**, and
+it is subordinate to Rule 2 rather than overridden by it. An officially announced, documentable
+injury that the market has not yet repriced *is* a named concrete asymmetry, so Bet 13 (Sinner,
+`my_prob_yes` 0.42) satisfies family (ii)'s bar despite sitting inside the band. What rule #3 does
+not license is a middle-band bet whose only support is a general read of who is better.
+
+**Live exposure under this lens.** Of the 5 open bets, two sit inside [0.20, 0.60] on
+`my_prob_yes`: Bet 7 (US-Iran MOU, 0.22, resolves Aug 20) and Bet 13 (Sinner, 0.42, resolves
+Sep 13). The other three are outside it: Bet 10 (0.62), Bet 12 (0.70), Bet 14 (0.78). Bet 13's
+family-(ii) asymmetry is named in the disposition above; Bet 7 is family (i) (formal-announcement
+criterion). Flagged, not actionable — closing is not part of this experiment.

--- a/scripts/agent-trader/metrics.py
+++ b/scripts/agent-trader/metrics.py
@@ -37,7 +37,10 @@ def mark_outcome(b):
     if b["status"] != "open" or b.get("mark_yes_price") is None:
         return None
     yes = float(b["mark_yes_price"])
-    p_win = yes if b["side"] == "YES" else 1 - yes
+    # Case-normalised: an exact comparison sends a lowercase "yes" down the NO branch and
+    # complements the mark, which turns a pending LOSS into a pending WIN and flatters the
+    # honest record. record_bet writes side.upper(), so this only bites hand-edited rows.
+    p_win = yes if str(b["side"]).upper() == "YES" else 1 - yes
     if p_win >= 1 - DECIDED_P:
         return "pending_win"
     if p_win <= DECIDED_P:

--- a/scripts/agent-trader/tests/test_md_to_html.py
+++ b/scripts/agent-trader/tests/test_md_to_html.py
@@ -1,0 +1,130 @@
+"""Fidelity tests for the email's Markdown renderer.
+
+The weekly email is the artefact a human actually reads, and its body is whatever the last
+`## Run` / `### Review correction` section of lessons.md happens to contain. Nothing constrains
+how that section is written: it is authored by an LLM one week and by the audit the next.
+
+The 2026-08-10 integration check caught the failure mode this file exists to prevent — the audit
+correction was hard-wrapped at ~100 columns, and the line-based renderer emitted 10 literal `**`,
+24 literal `*`, 11 `&gt;` blockquote lines and 14 fragmented `<ul>` blocks. No exception, no lost
+text: silent fidelity loss in the one output nobody re-reads. So the contract asserted here is
+"an inline span survives a hard line wrap", not "these exact glyphs map to these exact tags".
+"""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from agent_trader import _md_to_html  # noqa: E402
+
+
+class TestInlineSpansSurviveWrapping(unittest.TestCase):
+    def test_bold_spanning_a_hard_wrap_is_rendered(self):
+        html = _md_to_html("**Rule 1 (operative): in any market whose payout\ndepends on a multi-party agreement, enumerate every condition.**")
+        self.assertNotIn("**", html)
+        self.assertIn("<strong>", html)
+        self.assertIn("multi-party agreement", html)
+
+    def test_wrapped_paragraph_becomes_one_paragraph(self):
+        html = _md_to_html("first physical line\nsecond physical line\nthird physical line")
+        self.assertEqual(html.count("<p"), 1)
+        self.assertIn("first physical line second physical line third physical line", html)
+
+    def test_blank_line_separates_paragraphs(self):
+        html = _md_to_html("one\n\ntwo")
+        self.assertEqual(html.count("<p"), 2)
+
+    def test_code_span_across_a_wrap(self):
+        html = _md_to_html("the field is `my_prob_yes`\nand it is read from bets.jsonl")
+        self.assertIn("<code>my_prob_yes</code>", html)
+        self.assertEqual(html.count("<p"), 1)
+
+
+class TestListContinuations(unittest.TestCase):
+    def test_wrapped_list_item_stays_inside_one_li(self):
+        html = _md_to_html("- a bullet whose text is long enough\n  that it wraps onto a second line\n- a second bullet")
+        self.assertEqual(html.count("<ul"), 1)
+        self.assertEqual(html.count("</ul>"), 1)
+        self.assertEqual(html.count("<li>"), 2)
+        self.assertIn("long enough that it wraps onto a second line", html)
+
+    def test_bold_spanning_a_wrap_inside_a_list_item(self):
+        html = _md_to_html("- **a bolded bullet that\n  wraps mid-span**")
+        self.assertNotIn("**", html)
+        self.assertIn("<strong>", html)
+
+    def test_numbered_items_do_not_fragment(self):
+        html = _md_to_html("1. first item\n   continued here\n2. second item")
+        self.assertEqual(html.count("<ul"), 1)
+        self.assertEqual(html.count("<li>"), 2)
+
+
+class TestBlockquotes(unittest.TestCase):
+    def test_quoted_criterion_is_a_blockquote_not_an_escaped_gt(self):
+        html = _md_to_html("> All listed countries must announce their acceptance\n> of the same qualifying diplomatic agreement.")
+        self.assertIn("<blockquote", html)
+        self.assertNotIn("&gt; All listed", html)
+        self.assertIn("acceptance of the same qualifying", html)
+
+    def test_blockquote_closes_before_a_following_paragraph(self):
+        html = _md_to_html("> quoted line\n\nplain paragraph")
+        self.assertIn("</blockquote>", html)
+        self.assertLess(html.index("</blockquote>"), html.index("plain paragraph"))
+
+
+class TestItalics(unittest.TestCase):
+    def test_single_asterisk_italic_is_rendered(self):
+        html = _md_to_html("the market prices a *prospective* agreement")
+        self.assertIn("<em>prospective</em>", html)
+        self.assertNotIn("*", html)
+
+    def test_bold_is_not_eaten_by_the_italic_rule(self):
+        html = _md_to_html("**bold** and *italic* together")
+        self.assertIn("<strong>bold</strong>", html)
+        self.assertIn("<em>italic</em>", html)
+
+    def test_a_bare_asterisk_is_left_alone(self):
+        html = _md_to_html("2 * 3 = 6")
+        self.assertIn("2 * 3 = 6", html)
+
+
+class TestUnchangedBehaviour(unittest.TestCase):
+    """The regressions the renderer already handled must keep working."""
+
+    def test_headers(self):
+        html = _md_to_html("## Run 12 — 2026-08-10\n### Review correction")
+        self.assertIn("<h3", html)
+        self.assertIn("<h4", html)
+
+    def test_html_is_escaped(self):
+        html = _md_to_html("a <script>alert(1)</script> tag & an ampersand")
+        self.assertNotIn("<script>", html)
+        self.assertIn("&lt;script&gt;", html)
+        self.assertIn("&amp;", html)
+
+    def test_empty_input(self):
+        self.assertEqual(_md_to_html(""), "")
+
+
+class TestAgainstTheRealCorrection(unittest.TestCase):
+    """End-to-end on the section the email will actually carry this week."""
+
+    def test_latest_lessons_section_renders_without_literal_markup(self):
+        from agent_trader import _latest_lessons_section
+        md = _latest_lessons_section()
+        if not md.strip():
+            self.skipTest("lessons.md has no section to render")
+        html = _md_to_html(md)
+        self.assertNotIn("**", html)
+        # A '&gt;' is only a defect when it opens a block — inside prose it is a real
+        # greater-than ("n &gt;= 20", "&gt;$12M") and must survive escaped.
+        for tag in ("<p style='margin:6px 0'>", "<li>"):
+            self.assertNotIn(tag + "&gt;", html)
+        # every opened list is closed
+        self.assertEqual(html.count("<ul"), html.count("</ul>"))
+        self.assertEqual(html.count("<blockquote"), html.count("</blockquote>"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/agent-trader/tests/test_positions.py
+++ b/scripts/agent-trader/tests/test_positions.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Tests for the open-positions view (frames made explicit).
+
+Regression target: bet 7 is a NO position, and `lessons.md` quotes it in the YES frame in
+two different runs — Run 11 "current YES=0.595" and Run 12 "mark YES=0.325". Read as that
+position's entry and mark, they imply a 0.27 move; the position's real move is +0.055
+(entry(held) 0.620 -> mark(held) 0.675). The old email table invited exactly that: an
+unlabelled "Entry" column (held frame, 0.62 on a NO) sat next to "Mark (YES)". These
+tests pin the frames, in the ASCII table and in the email.
+
+0.595 is not in BET 7's record — it was an observed YES price written into lessons.md
+prose, never stored on the bet. (0.595 does appear elsewhere in bets.jsonl, as bet 12's
+`market_yes_price`, which is why the regression case renders bet 7 alone.)
+
+No network, no reads of the real bets.jsonl — fixtures are inline on purpose: the point
+of the regression case is that 0.595 was underivable from bet 7's row, so that row must
+be what the test builds, not whatever the live file happens to hold.
+"""
+from __future__ import annotations
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from agent_trader import open_positions, format_positions, email_html  # noqa: E402
+
+
+def _bet(**kw):
+    base = {
+        "bet_id": "bX", "question": "Q?", "end_date": "2026-09-01T12:00:00Z",
+        "side": "YES", "stake": 25.0, "market_yes_price": 0.5, "entry_price": 0.51,
+        "mark_yes_price": 0.5, "marked_at": "2026-08-10", "status": "open",
+        "confidence": "medium", "edge_per_contract": 0.0,
+    }
+    base.update(kw)
+    return base
+
+
+class TestOpenPositions(unittest.TestCase):
+
+    def test_yes_side_mark_is_yes_price(self):
+        rows = open_positions([_bet(side="YES", market_yes_price=0.40,
+                                    entry_price=0.42, mark_yes_price=0.55)])
+        self.assertEqual(len(rows), 1)
+        r = rows[0]
+        self.assertEqual(r["entry_held"], 0.42)
+        self.assertEqual(r["mark_held"], 0.55)          # YES held => mark is the YES price
+        self.assertAlmostEqual(r["delta_held"], 0.13, places=6)
+        self.assertEqual(r["entry_yes"], 0.40)
+        self.assertEqual(r["mark_yes"], 0.55)
+        self.assertEqual(r["edge_at_entry"], 0.0)   # carried through, not recomputed
+
+    def test_no_side_mark_is_complement(self):
+        rows = open_positions([_bet(side="NO", market_yes_price=0.70,
+                                    entry_price=0.32, mark_yes_price=0.60)])
+        r = rows[0]
+        self.assertEqual(r["entry_held"], 0.32)
+        self.assertEqual(r["mark_held"], 0.40)          # NO held => 1 - YES
+        self.assertAlmostEqual(r["delta_held"], 0.08, places=6)
+        self.assertEqual(r["entry_yes"], 0.70)
+        self.assertEqual(r["mark_yes"], 0.60)
+
+    def test_missing_edge_is_not_printed_as_a_measured_zero(self):
+        b = _bet(side="YES", entry_price=0.42, mark_yes_price=0.55)
+        b.pop("edge_per_contract")
+        r = open_positions([b])[0]
+        self.assertIsNone(r["edge_at_entry"])            # absent stays absent
+        self.assertNotIn("+0.000", format_positions([r]))
+        # A genuinely-zero edge still prints as zero — the two must stay distinguishable.
+        zero = open_positions([_bet(edge_per_contract=0.0)])[0]
+        self.assertEqual(zero["edge_at_entry"], 0.0)
+        self.assertIn("+0.000", format_positions([zero]))
+
+    def test_lowercase_side_is_not_a_frame_inversion(self):
+        """A hand-edited 'yes' must not be read as NO and have its mark complemented."""
+        r = open_positions([_bet(side="yes", market_yes_price=0.50,
+                                 entry_price=0.53, mark_yes_price=0.60)])[0]
+        self.assertEqual(r["mark_held"], 0.60)           # not 0.40
+        self.assertAlmostEqual(r["delta_held"], 0.07, places=6)
+        # Same inversion in metrics is worse than cosmetic: it books a pending LOSS as a
+        # pending WIN, i.e. it flatters the mark-to-market record.
+        import metrics
+        near_zero = _bet(side="yes", market_yes_price=0.30, entry_price=0.35,
+                         mark_yes_price=0.005)
+        self.assertEqual(metrics.mark_outcome(near_zero), "pending_loss")
+        self.assertEqual(open_positions([near_zero])[0]["decided"], "pending_loss")
+
+    def test_bet7_regression_0595_is_underivable(self):
+        """Bet 7 (b1783958439_2663611), exactly as logged in bets.jsonl."""
+        b = _bet(bet_id="b1783958439_2663611", side="NO",
+                 question="US-Iran 60 day negotiation period extended?",
+                 market_yes_price=0.39, entry_price=0.62, mark_yes_price=0.325)
+        rows = open_positions([b])
+        r = rows[0]
+        self.assertEqual(r["entry_held"], 0.62)
+        self.assertEqual(r["mark_held"], 0.675)
+        self.assertAlmostEqual(r["delta_held"], 0.055, places=6)
+        self.assertEqual(r["entry_yes"], 0.39)
+        self.assertEqual(r["mark_yes"], 0.325)
+        # 0.595 was last week's adverse mark, never an entry. It must not be derivable
+        # from — nor appear anywhere in — the row or its rendering.
+        for v in r.values():
+            if isinstance(v, float):
+                self.assertNotAlmostEqual(v, 0.595, places=3)
+        self.assertNotIn("0.595", format_positions(rows))
+        self.assertNotIn("0.595", repr(r))
+
+    def test_missing_mark_does_not_blow_up(self):
+        for bad in (None, {}):
+            kw = {"mark_yes_price": None} if bad is None else {}
+            b = _bet(side="NO", market_yes_price=0.6, entry_price=0.41, **kw)
+            if bad == {}:
+                b.pop("mark_yes_price")
+                b.pop("marked_at")
+            rows = open_positions([b])
+            r = rows[0]
+            self.assertIsNone(r["mark_held"])
+            self.assertIsNone(r["delta_held"])
+            self.assertIsNone(r["mark_yes"])
+            self.assertEqual(r["entry_held"], 0.41)
+            out = format_positions(rows)          # must render, not raise
+            self.assertIn("—", out)
+
+    def test_resolved_bets_are_excluded(self):
+        bets = [
+            _bet(bet_id="open1", status="open"),
+            _bet(bet_id="won1", status="won", pnl_net=19.0, resolved_outcome="YES"),
+            _bet(bet_id="lost1", status="lost", pnl_net=-25.0, resolved_outcome="NO"),
+        ]
+        rows = open_positions(bets)
+        self.assertEqual([r["bet_id"] for r in rows], ["open1"])
+
+    def test_decided_flag_matches_metrics_mark_outcome(self):
+        import metrics
+        pending_win = _bet(side="NO", market_yes_price=0.3, entry_price=0.35,
+                           mark_yes_price=0.005)
+        pending_loss = _bet(side="YES", market_yes_price=0.3, entry_price=0.35,
+                            mark_yes_price=0.005)
+        undecided = _bet(side="YES", market_yes_price=0.3, entry_price=0.35,
+                         mark_yes_price=0.40)
+        rows = open_positions([pending_win, pending_loss, undecided])
+        self.assertEqual([r["decided"] for r in rows],
+                         [metrics.mark_outcome(pending_win),
+                          metrics.mark_outcome(pending_loss),
+                          metrics.mark_outcome(undecided)])
+        self.assertEqual([r["decided"] for r in rows],
+                         ["pending_win", "pending_loss", None])
+
+    def test_empty_input(self):
+        self.assertEqual(open_positions([]), [])
+        self.assertIn("no open positions", format_positions([]).lower())
+
+
+class TestFormatPositions(unittest.TestCase):
+
+    def test_headers_name_the_frame_and_footnote_discloses_spread(self):
+        out = format_positions(open_positions([
+            _bet(side="NO", market_yes_price=0.39, entry_price=0.62,
+                 mark_yes_price=0.325)]))
+        # Every price column says which frame it is in — no bare "Entry"/"Mark".
+        self.assertIn("entry(held)", out)
+        self.assertIn("mark(held)", out)
+        self.assertIn("entry(YES)", out)
+        self.assertIn("mark(YES)", out)
+        # The delta is approximate: entry crossed the spread, the mark did not — and the
+        # YES pair is mid-to-mid, so it implies a bigger move than delta(held). Both have
+        # to be said, or a reader doing the YES-frame arithmetic gets a different answer
+        # from the column next to it and has nothing to reconcile them with.
+        self.assertIn("spread", out.lower())
+        self.assertIn("half-spread", out.lower())
+        # And the actual numbers, in the held frame.
+        self.assertIn("0.620", out)
+        self.assertIn("0.675", out)
+        self.assertIn("+0.055", out)
+
+
+class TestEmailOpenBetsTable(unittest.TestCase):
+    """The email is the artefact the human reads — the frames must hold there too.
+
+    The ASCII table being right is not enough: the misreading this whole change exists to
+    prevent happened off an email table, so an edit that put entry(held) back beside
+    mark(YES) in the HTML has to turn something red.
+    """
+
+    def _html(self):
+        bet7 = _bet(bet_id="b1783958439_2663611", side="NO",
+                    question="US-Iran 60 day negotiation period extended?",
+                    market_yes_price=0.39, entry_price=0.62, mark_yes_price=0.325,
+                    edge_per_contract=0.12)
+        return email_html([bet7])
+
+    def test_held_frame_numbers_are_the_ones_rendered(self):
+        html = self._html()
+        self.assertIn("0.620", html)          # entry, held frame
+        self.assertIn("0.675", html)          # mark, held frame (1 - 0.325)
+        self.assertIn("+0.055", html)         # the position's move
+        self.assertNotIn("0.595", html)
+
+    def test_held_columns_precede_the_yes_reference_and_spread_is_disclosed(self):
+        html = self._html()
+        # Header order: the position's own frame first, the market's quote last.
+        i_entry_held = html.index("Entry<br>(held)")
+        i_mark_held = html.index("Mark<br>(held)")
+        i_delta = html.index("Δ<br>(held)")
+        i_yes_ref = html.index("(YES frame)")
+        self.assertLess(i_entry_held, i_mark_held)
+        self.assertLess(i_mark_held, i_delta)
+        self.assertLess(i_delta, i_yes_ref)
+        # The YES pair must not read as this position's prices, and the delta must be
+        # disclosed as spread-crossed (hence not comparable to the mid-to-mid pair).
+        self.assertIn("held-token frame", html)
+        self.assertIn("spread", html.lower())
+        self.assertIn("half-spread", html)
+
+    def test_missing_edge_does_not_raise_in_the_email(self):
+        b = _bet(side="NO", market_yes_price=0.39, entry_price=0.62,
+                 mark_yes_price=0.325)
+        b.pop("edge_per_contract")
+        html = email_html([b])                # must render, not TypeError
+        self.assertIn("—", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Weekly review of Run 12 (2026-08-10). The run itself was healthy — the LLM ran, `lessons.md` got a new `## Run 12`, three bets placed, track record intact (5-4, −\$52.32, `too_few` at n=9). This PR is the review's output.

## 1. Price frames — the root cause of a real reporting error

Run 12's summary and email said:

> Bet 7 (US-Iran MOU NO): YES dropped from **0.595 entry** to 0.325 mark

Bet 7's YES entry was **0.39** (`market_yes_price`). The 0.595 came from `lessons.md` **Run 11, line 454**, where it was correctly labelled `current YES=0.595` — last week's mark, recited as this week's entry. The favourable move was overstated ~5× (0.27 claimed vs **+0.055** actual in the held frame).

The email's Open-bets table invited exactly that subtraction: an unlabelled `Entry` column (held frame — 0.62 on a NO) sat next to `Mark (YES)` (always YES frame). Two adjacent columns in different frames.

- pure `positions()` over open bets, every column's frame named
- `positions` subcommand — the deterministic table the agent must quote verbatim
- frame-consistent email table, carrying the caveat that entry is the **ask actually paid** (spread crossed) while the mark is a **mid** (not crossed), so Δ is approximate and slightly pessimistic

```
side  entry(held)  mark(held)  delta(held)  entry(YES)  mark(YES)  resolves
NO    0.620        0.675       +0.055       0.390       0.325      2026-08-20
```

## 2. `metrics.mark_outcome` was case-sensitive on `side`

With `side="yes"` and a mark of 0.005, the complement flipped a `pending_loss` into a `pending_win` — it inflated the honest record. Not cosmetic.

## 3. `_md_to_html` rewritten block-first

It rendered line by line, so an inline span straddling a hard wrap broke. Measured on the real output: **10** literal `**`, **24** literal `*`, **11** escaped `&gt;` blockquote lines, **14** fragmented `<ul>`, **44** orphan continuation `<p>`. No exception, no lost text — silent fidelity loss in the one artefact a human actually reads. Now assembles blocks then renders inline once; adds italics and blockquotes. Every one of those counts is now **0**.

## 4. `lessons.md` — audit correction (append-only, single hunk)

**Bet 14 (Iran-Oman) read the criterion incomplete.** It quoted a fragment of 2 of the description's 7 paragraphs and missed the two that decide the bet:

> All listed countries must announce their acceptance of the same qualifying diplomatic agreement…

> Statements that reference ongoing negotiations or **a prospective agreement** … do not qualify.

Every cited source attributes the agreement claim to Iran (Bloomberg, Fortune, NPR, CNN — Fortune read in full: Baghaei, Gharibabadi via IRNA, Iranian state TV). **Oman has not spoken.** And the rationale's strongest evidence — the joint statement "in the final drafting stage" — is what the second clause disqualifies by name.

The hourly CLOB series (137 points) was never pulled: the market **peaked at 0.935 on Aug 6** and repriced DOWN for four days to a **0.585 trough** before the 0.66 entry. The tape had been contradicting the thesis for days.

**Corrects a standing framing.** The track record's wins did *not* come from reading criteria "more strictly" — Hormuz-40 (`>=40 on ANY day`) and Sulyok (announcement clause) were won on **looser**-than-market readings. The invariant is **literal and exhaustive**, not severe. A "read it strictly" rule would have vetoed two of the five wins.

**Shape of the losses, stated as a hypothesis and not a result.** All four losses sit in `my_prob_yes` ∈ [0.20, 0.60]; all five wins sit outside. But n=9, the bootstrap CI is [−17.24, +6.20], the band edges were **fitted after seeing the outcomes** (moving 0.20 → 0.18 turns it into 2/6 vs 3/3), and Bet 1 is a counterexample inside the cohort. The derived rule labels the edge family; it does not authorise a veto.

## Verification

- **29 tests**, stdlib `unittest`, no network — includes `test_bet7_regression_0595_is_underivable`
- `summary` unchanged: 14 bets, 5 open, 9 resolved, 5-4, −\$52.32, \$947.68, Brier 0.109
- `metrics.py` unchanged: `too_few`, same calibration table
- `bets.jsonl` and `metrics.jsonl` **untouched**
- `## Run ` count still 12 — the correction uses `###`, so the workflow's null-run detector is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Jbe4GqpbxWDfrkrSBMzqs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `positions` command for reviewing open positions with held-token prices, YES-frame references, deltas, entry edges, mark dates, and market status.
  - Improved email reports with clearly labeled open-position metrics.
  - Enhanced Markdown rendering for paragraphs, lists, blockquotes, emphasis, code, and wrapped text.

- **Bug Fixes**
  - Corrected outcome handling for lowercase YES/NO values.
  - Prevented misleading prices from appearing in position reports.

- **Documentation**
  - Expanded trading guidance for evaluating payout conditions, announcements, price history, and probability estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->